### PR TITLE
Format person a little better if email is not set

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -61,8 +61,8 @@ class Person(models.Model):
             middle = ' {0}'.format(self.middle)
         email = ''
         if self.email is not None:
-            email = ' {0}'.format(self.email)
-        return '{0}{1} {2} <{3}>'.format(self.personal, middle, self.family, email)
+            email = ' <{0}>'.format(self.email)
+        return '{0}{1} {2}{3}'.format(self.personal, middle, self.family, email)
 
 #------------------------------------------------------------
 


### PR DESCRIPTION
Just noticed the string representation of a person comes out as "First_name Last_name <None>" if their email address is not set. I changed it to "First_name Last_name <>", but I could also remove the angle brackets entirely if you prefer.
