### PR TITLE
workshops: Replace 'persons' with 'people'

### DIFF
--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -1,6 +1,6 @@
 {% extends "workshops/_page.html" %}
 {% block content %}
-{% if all_persons %}
+{% if all_people %}
     <table class="table table-striped">
         <tr>
 	    <th>personal</th>
@@ -9,7 +9,7 @@
 	    <th>email</th>
 	    <th></th>
 	</tr>
-    {% for person in all_persons %}
+    {% for person in all_people %}
         <tr>
 	    <td>{{ person.personal }}</td>
 	    <td>{{ person.middle }}</td>
@@ -20,7 +20,7 @@
     {% endfor %}
     </table>
 {% else %}
-    <p>No persons.</p>
+    <p>No people.</p>
 {% endif %}
 <p>... <a href="{% url 'index' %}">index</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -4,7 +4,7 @@
   <li><a href="{% url 'all_sites' %}">sites</a></li>
   <li><a href="{% url 'all_airports' %}">airports</a></li>
   <li><a href="{% url 'all_events' %}">events</a></li>
-  <li><a href="{% url 'all_persons' %}">persons</a></li>
+  <li><a href="{% url 'all_people' %}">people</a></li>
   <li><a href="{% url 'all_tasks' %}">tasks</a></li>
   <li><a href="{% url 'all_cohorts' %}">cohorts</a></li>
 </ul>

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -12,6 +12,6 @@
   <tr><td>twitter:</td><td>{{ person.twitter }}</td></tr>
   <tr><td>url:</td><td>{{ person.url }}</td></tr>
 </table>
-<p>... <a href="{% url 'all_persons' %}">all persons</a></p>
+<p>... <a href="{% url 'all_people' %}">all people</a></p>
 <p>... <a href="{% url 'index' %}">index</a></p>
 {% endblock %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
     url(r'^airport/(?P<airport_iata>[\w\.-]+)/edit$', AirportUpdate.as_view(), name='airport_edit'),
     url(r'^airports/add/$', AirportCreate.as_view(), name='airport_add'),
 
-    url(r'^persons/?$', views.all_persons, name='all_persons'),
+    url(r'^people/?$', views.all_people, name='all_people'),
     url(r'^person/(?P<person_id>[\w\.-]+)/?$', views.person_details, name='person_details'),
 
     url(r'^events/?$', views.all_events, name='all_events'),

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -75,12 +75,12 @@ class AirportUpdate(UpdateView):
 
 #------------------------------------------------------------
 
-def all_persons(request):
-    '''List all persons.'''
-    all_persons = Person.objects.order_by('family', 'personal')
+def all_people(request):
+    '''List all people.'''
+    all_people = Person.objects.order_by('family', 'personal')
     context = {'title' : 'All Persons',
-               'all_persons' : all_persons}
-    return render(request, 'workshops/all_persons.html', context)
+               'all_people' : all_people}
+    return render(request, 'workshops/all_people.html', context)
 
 def person_details(request, person_id):
     '''List details of a particular person.'''


### PR DESCRIPTION
"persons" [is archaic / legalistic](http://english.stackexchange.com/questions/46294/correct-usage-of-persons-vs-people).  Replaced with:

```
$ find workshops -type f -execdir sed -i 's/persons/people/g' {} \;
```
