### PR TITLE
workshops/views.py: Specify sort key explicitly in match()

### DIFF
--- a/workshops/views.py
+++ b/workshops/views.py
@@ -259,7 +259,12 @@ def match(request):
                    float(form.cleaned_data['longitude']))
             persons = [(earth_distance(loc, (p.airport.latitude, p.airport.longitude)), p)
                        for p in persons]
-            persons.sort()
+            persons.sort(
+                key=lambda distance_person: (
+                    distance_person[0],
+                    distance_person[1].family,
+                    distance_person[1].personal,
+                    distance_person[1].middle))
             persons = [x[1] for x in persons[:10]]
 
         else:


### PR DESCRIPTION
Avoid:

```
Traceback:
  File "/.../django/core/handlers/base.py" in get_response
    111. response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/wking/src/swc/amy/workshops/views.py" in match
    262. persons.sort()
Exception Type: TypeError at /workshops/match
Exception Value: unorderable types: Person() < Person()
```

In Python 3.4.
