### PR TITLE
workshops/templatetags/breadcrumbs.py: Wrap map in a list

### DIFF
--- a/workshops/templatetags/breadcrumbs.py
+++ b/workshops/templatetags/breadcrumbs.py
@@ -71,7 +71,7 @@ class BreadcrumbNode(Node):
         """
         First var is title, second var is url context variable
         """
-        self.vars = map(Variable, vars)
+        self.vars = list(map(Variable, vars))
 
     def render(self, context):
         title = self.vars[0].var


### PR DESCRIPTION
In BreadcrumbNode.**init**, self.var was being setup with 'map(...)'.
In Python 3 that returns an iterable, and iterables don't support
indexing, so you'd get:

  Traceback:
  File "/.../django/core/handlers/base.py" in get_response
    137.                 response = response.render()
  File "/.../django/template/response.py" in render
    103.             self.content = self.rendered_content
  File "/.../django/template/response.py" in rendered_content
    80.         content = template.render(context)
  File "/.../django/template/base.py" in render
    148.             return self._render(context)
  File "/.../django/template/base.py" in _render
    142.         return self.nodelist.render(context)
  File "/.../django/template/base.py" in render
    844.                 bit = self.render_node(node, context)
  File "/.../django/template/debug.py" in render_node
    80.             return node.render(context)
  File "/.../django/template/loader_tags.py" in render
    126.         return compiled_parent._render(context)
  File "/.../django/template/base.py" in _render
    142.         return self.nodelist.render(context)
  File "/.../django/template/base.py" in render
    844.                 bit = self.render_node(node, context)
  File "/.../django/template/debug.py" in render_node
    80.             return node.render(context)
  File "/.../django/template/loader_tags.py" in render
    65.                 result = block.nodelist.render(context)
  File "/.../django/template/base.py" in render
    844.                 bit = self.render_node(node, context)
  File "/.../django/template/debug.py" in render_node
    80.             return node.render(context)
  File "/.../django/template/defaulttags.py" in render
    312.                 return nodelist.render(context)
  File "/.../django/template/base.py" in render
    844.                 bit = self.render_node(node, context)
  File "/.../django/template/debug.py" in render_node
    80.             return node.render(context)
  File "/.../amy/workshops/templatetags/breadcrumbs.py" in render
    77.         title = self.vars[0].var

  Exception Type: TypeError at /workshops/site/asu.edu/edit
  Exception Value: 'map' object is not subscriptable

This commit uses 'list(map(...))' to convert the iterable into an
indexable list.
