### PR TITLE
Add persons/add/ and persons/{id}/edit

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -102,6 +102,9 @@ class Person(models.Model):
             email = ' <{0}>'.format(self.email)
         return '{0}{1}'.format(self.fullname(), email)
 
+    def get_absolute_url(self):
+        return reverse('person_details', args=[str(self.id)])
+
 #------------------------------------------------------------
 
 class Project(models.Model):

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -29,4 +29,5 @@
 {% else %}
     <p>No persons.</p>
 {% endif %}
+<p class="add-new"><a href="{% url 'person_add' %}">Add a new person</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -20,4 +20,6 @@
   <tr><td>twitter:</td><td>{{ person.twitter }}</td></tr>
   <tr><td>url:</td><td>{{ person.url }}</td></tr>
 </table>
+
+<p class="edit-object"><a href="{% url 'person_edit' person.id %}">Edit this person</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/person_form.html
+++ b/workshops/templates/workshops/person_form.html
@@ -1,0 +1,23 @@
+{% extends "workshops/_page.html" %}
+
+{% load breadcrumbs %}
+{% block breadcrumbs %}
+    {% breadcrumb_url 'Index' 'index'  %}
+    {% breadcrumb_url 'All persons' 'all_persons' %}
+    {% if object %}
+        {% url 'person_details' object.domain as object_url %}
+        {% breadcrumb object.domain object_url %}
+        {% breadcrumb_active 'Edit person'  %}
+    {% else %}
+        {% breadcrumb_active 'New person'  %}
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+<form action="" method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Submit" />
+</form>
+
+{% endblock %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url
 from .views import AirportCreate, AirportUpdate, \
+                   PersonCreate, PersonUpdate, \
                    SiteCreate, SiteUpdate, \
                    TaskCreate, TaskUpdate, \
                    CohortCreate, CohortUpdate, \
@@ -22,6 +23,8 @@ urlpatterns = [
 
     url(r'^persons/?$', views.all_persons, name='all_persons'),
     url(r'^person/(?P<person_id>[\w\.-]+)/?$', views.person_details, name='person_details'),
+    url(r'^person/(?P<person_id>[\w\.-]+)/edit$', PersonUpdate.as_view(), name='person_edit'),
+    url(r'^persons/add/$', PersonCreate.as_view(), name='person_add'),
 
     url(r'^events/?$', views.all_events, name='all_events'),
     url(r'^event/(?P<event_slug>[\w\.-]+)/?$', views.event_details, name='event_details'),

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -125,6 +125,18 @@ def person_details(request, person_id):
                'person' : person}
     return render(request, 'workshops/person.html', context)
 
+
+class PersonCreate(CreateView):
+    model = Person
+    fields = '__all__'
+
+
+class PersonUpdate(UpdateView):
+    model = Person
+    fields = '__all__'
+    pk_url_kwarg = 'person_id'
+
+
 #------------------------------------------------------------
 
 def all_events(request):


### PR DESCRIPTION
Following the pattern set by 0957f12d ([Create and edit sites using
django generic views, 2014-12-09](https://github.com/swcarpentry/amy/commit/0957f12dfb830013b190d7e3a1395fdfea6d1108)).

The [pk_url_kwarg field](https://docs.djangoproject.com/en/1.7/ref/class-based-views/mixins-single-object/#django.views.generic.detail.SingleObjectMixin.pk_url_kwarg) avoids:

  AttributeError at /workshops/person/7458/edit

  Generic detail view PersonUpdate must be called with either an
    object pk or a slug.

The '**all**' value for fields automatically uses all the forms
fields.  The [Django docs point out](https://docs.djangoproject.com/en/1.7/topics/forms/modelforms/#selecting-the-fields-to-use) that this could be a security
problem if you add a secret field to a model and forget that it will
be visible and editable by anyone with permissions for that form,
but I don't expect we'll be needing secret Person information and it's
good to stay DRY.

Fixes #26.
