### PR TITLE
Main page title

### DIFF
--- a/workshops/views.py
+++ b/workshops/views.py
@@ -20,7 +20,7 @@ ITEMS_PER_PAGE = 25
 def index(request):
     '''Home page.'''
     upcoming_events = Event.objects.upcoming_events()
-    context = {'title' : None,
+    context = {'title' : "Main Page",
                'upcoming_events' : upcoming_events}
     return render(request, 'workshops/index.html', context)
 


### PR DESCRIPTION
The main page had a `<title>` of "Amy: None". Now it's "Amy: Main Page".

The issue is that now the main page has two shouting headings:
![screenshot from 2014-12-21 19 26 58](https://cloud.githubusercontent.com/assets/72821/5519193/cb32b8e2-8947-11e4-9774-5e4436a6f186.png)

I think the main issue is not the introduction of a `<h1>` header on the main page. I think the issue is that we don't have a good heading structure. Look at Bootstrap page:
![screenshot from 2014-12-21 19 34 23](https://cloud.githubusercontent.com/assets/72821/5519207/be9114ca-8948-11e4-91ec-3a44f5486b85.png)

On Bootstrap page they start with navigation bar, then they introduce actual content (starting with `<h1>` header). In Amy we have "page title" (as a header), then navigation bar (as breadcrumbs), then content.

Any thought on changing that order? I'll open up an issue for that.
