### PR TITLE
Use `logging` module instead of prints in migrater script

### DIFF
--- a/migrater.py
+++ b/migrater.py
@@ -6,6 +6,10 @@ import sqlite3
 # stick to string name of the logger because it's better than "__main__"
 # (what __name__ defaults to)
 logger = logging.getLogger("amy-migrater")
+
+# verbosity: show all messages with severity of at least INFO
+logger.setLevel(logging.INFO)
+
 FAKE = True
 
 


### PR DESCRIPTION
I replaced `fail` function printing out to `stderr` with `logger.debug`
(from Python standard library).

Additionally I introduced `info` function that indicates migration
progress.  It simply logs out "Successfully migrated 'TABLE' table",
so that user knows the script is running error-free.

Ref #89 
