### PR TITLE
Tests for notes in Site and Event models

### DIFF
--- a/workshops/test/test_event.py
+++ b/workshops/test/test_event.py
@@ -208,7 +208,6 @@ class TestEventNotes(TestCase):
     """Make sure notes once written are saved forever!"""
 
     def setUp(self):
-        """Prepare testing events"""
         # a test site is required for all new events
         self.test_site = Site.objects.create(domain='example.com',
                                              fullname='Test Site')

--- a/workshops/test/test_site.py
+++ b/workshops/test/test_site.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+from ..models import Site
+
+
+class TestSiteNotes(TestCase):
+    """Make sure notes once written are saved forever!"""
+
+    def test_site_without_notes(self):
+        "Make sure sites without notes don't have NULLed field ``notes``"
+        s = Site(domain="example.org",
+                 fullname="Sample Example",
+                 country="US")
+
+        # test for field's default value (the field is not NULL)
+        self.assertEqual(s.notes, "")  # therefore the field is not NULL
+
+    def test_site_with_notes(self):
+        "Make sure event with notes are correctly stored"
+
+        notes = "This site is untrusted."
+
+        s = Site(domain="example.org",
+                 fullname="Sample Example",
+                 country="US",
+                 notes=notes)
+
+        # make sure that notes have been saved
+        self.assertEqual(s.notes, notes)


### PR DESCRIPTION
This is PR for #76. I added two test cases, one for Site and one for Event models.

Each test case consists of two methods checking for default value of the `notes` field (in case of lack of notes and when there are some).

Feedback requested.
