### PR TITLE
fix email address for sysadmin

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -397,7 +397,7 @@ ADMIN_NOTIFICATION_CRITERIA_DEFAULT = 'team@carpentries.org'
 ADMIN_URL = env('AMY_ADMIN_URL', default='admin/')
 # https://docs.djangoproject.com/en/dev/ref/settings/#admins
 ADMINS = [
-    ('Sysadmins ML', 'sysadmin@lists.carpentries.org'),
+    ('Sysadmins ML', 'sysadmin@carpentries.org'),
 ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#managers
 MANAGERS = ADMINS


### PR DESCRIPTION
looking at the logs of Mailgun I noticed that notifications to this address bounce because it doesn't exist. `sysadmin@carpentries.org` does exist though but I'm not 100% sure we want to go there because I'm not sure the kind of emails that end up being sent to this address.