### PR TITLE
change GH link swcarpentry > carpentries

### DIFF
--- a/amy/templates/base.html
+++ b/amy/templates/base.html
@@ -67,8 +67,8 @@
       <div class="row">
         <footer class="col-sm-12 text-center text-muted border-top pt-3">
           <p>
-            Powered by <a href="https://github.com/swcarpentry/amy">AMY</a>
-            version {{ workshops_version }}{% if workshops_git_hash %} (<a href="https://github.com/swcarpentry/amy/commit/{{ workshops_git_hash }}">{{ workshops_git_short_hash }}</a> {{ workshops_git_date }}{% if workshops_git_dirty %} dirty{% endif %}){% endif %}.
+            Powered by <a href="https://github.com/carpentries/amy">AMY</a>
+            version {{ workshops_version }}{% if workshops_git_hash %} (<a href="https://github.com/carpentries/amy/commit/{{ workshops_git_hash }}">{{ workshops_git_short_hash }}</a> {{ workshops_git_date }}{% if workshops_git_dirty %} dirty{% endif %}){% endif %}.
             View <a href="https://docs.carpentries.org/topic_folders/policies/privacy.html">our data privacy policy</a>.
           </p>
           <p>


### PR DESCRIPTION
There may be other places that we also need to update the GH  name.