### PR TITLE
Add missing pagination on All Workshop Inquiries and Self-Organised Submissions

### DIFF
--- a/amy/templates/requests/all_selforganisedsubmissions.html
+++ b/amy/templates/requests/all_selforganisedsubmissions.html
@@ -59,8 +59,8 @@
     </tr>
     {% endfor %}
   </table>
-  {% pagination requests %}
+  {% pagination submissions %}
   {% else %}
-  <p>No workshop requests matching the filter.</p>
+  <p>No self-organised submissions matching the filter.</p>
   {% endif %}
 {% endblock %}

--- a/amy/templates/requests/all_workshopinquiries.html
+++ b/amy/templates/requests/all_workshopinquiries.html
@@ -61,8 +61,8 @@
     </tr>
     {% endfor %}
   </table>
-  {% pagination requests %}
+  {% pagination inquiries %}
   {% else %}
-  <p>No workshop requests matching the filter.</p>
+  <p>No workshop inquiries matching the filter.</p>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
This fixes #1536 by adding missing pagination on these pages.
The pagination template tag used wrong variable name, therefore was
unable to render.