### PR TITLE
Enable cache

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -247,6 +247,20 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# CACHE
+# -----------------------------------------------------------------------------
+# https://docs.djangoproject.com/en/2.2/topics/cache/#database-caching
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'cache_default',
+    },
+    'select2': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'cache_select2',
+    }
+}
+
 # MIDDLEWARE
 # -----------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#middleware
@@ -521,3 +535,4 @@ COMMENTS_APP = 'extcomments'
 SELECT2_JS = ''  # don't load JS on it's own - we're loading it in `base.html`
 SELECT2_CSS = ''  # the same for CSS
 SELECT2_I18N = 'select2/js/i18n'
+SELECT2_CACHE_BACKEND = 'select2'


### PR DESCRIPTION
This potentially fixes #1538 (I'm still waiting for user test results).

The potential cause for this error was no cache table (no cache at all
was set up), so the Django-select2 AutoResponseView was unable to find
a correct widget by `field_id` GET parameter.

https://github.com/applegrew/django-select2/blob/master/django_select2/views.py#L82