### PR TITLE
Add 'review_process' to CSV download of Training Requests data

### DIFF
--- a/amy/api/renderers.py
+++ b/amy/api/renderers.py
@@ -15,6 +15,7 @@ class TrainingRequestCSVColumns:
         'person_id': 'Matched Trainee ID',
         'awards': 'Badges',
         'training_tasks': 'Training Tasks',
+        'review_process': 'Application Type',
         'group_name': 'Registration Code',
         'personal': 'Personal',
         'middle': 'Middle',

--- a/amy/api/serializers.py
+++ b/amy/api/serializers.py
@@ -265,8 +265,9 @@ class TrainingRequestSerializer(serializers.ModelSerializer):
     class Meta:
         model = TrainingRequest
         fields = (
-            'created_at', 'last_updated_at',
-            'state', 'group_name', 'personal', 'middle', 'family', 'email',
+            'created_at', 'last_updated_at', 'state',
+            'review_process', 'group_name',
+            'personal', 'middle', 'family', 'email',
             'github', 'occupation', 'occupation_other', 'affiliation',
             'location', 'country', 'underresourced', 'underrepresented',
             'underrepresented_details',
@@ -327,7 +328,8 @@ class TrainingRequestWithPersonSerializer(TrainingRequestSerializer):
         fields = (
             'created_at', 'last_updated_at', 'state',
             'person', 'person_id', 'awards', 'training_tasks',
-            'group_name', 'personal', 'middle', 'family',
+            'review_process', 'group_name',
+            'personal', 'middle', 'family',
             'email', 'github', 'underrepresented', 'underrepresented_details',
             'occupation', 'occupation_other', 'affiliation',
             'location', 'country', 'underresourced',
@@ -355,6 +357,7 @@ class TrainingRequestForManualScoringSerializer(TrainingRequestSerializer):
             'request_id',
             'score_manual',
             'score_notes',
+            'review_process',
             'group_name',
             'personal',
             'middle',

--- a/amy/api/tests/test_export.py
+++ b/amy/api/tests/test_export.py
@@ -593,6 +593,7 @@ class TestExportingPersonData(BaseExportingTest):
             state='p',  # pending
 
             person=self.user,
+            review_process='preapproved',
             group_name='Mosquitos',
             personal='User',
             middle='',
@@ -855,6 +856,7 @@ class TestExportingPersonData(BaseExportingTest):
                 'last_updated_at':
                     data['training_requests'][0]['last_updated_at'],
                 'state': 'Pending',
+                'review_process': 'preapproved',
                 'group_name': 'Mosquitos',
                 'personal': 'User',
                 'middle': '',

--- a/amy/api/tests/test_trainingrequests.py
+++ b/amy/api/tests/test_trainingrequests.py
@@ -49,6 +49,7 @@ class TestListingTrainingRequests(APITestBase):
         self.tr1 = TrainingRequest(
             state='p',
             person=None,
+            review_process='preapproved',
             group_name='GummiBears',
             personal='Zummi',
             middle='',
@@ -95,6 +96,7 @@ class TestListingTrainingRequests(APITestBase):
         self.tr2 = TrainingRequest(
             state='a',
             person=self.admin,
+            review_process='preapproved',
             group_name='GummiBears',
             personal='Grammi',
             middle='',
@@ -176,6 +178,7 @@ class TestListingTrainingRequests(APITestBase):
                 'person_id': None,
                 'awards': '',
                 'training_tasks': '',
+                'review_process': 'preapproved',
                 'group_name': 'GummiBears',
                 'personal': 'Zummi',
                 'middle': '',
@@ -231,6 +234,7 @@ class TestListingTrainingRequests(APITestBase):
                 'awards': 'swc-instructor 2018-07-12, '
                           'dc-instructor 2018-07-12',
                 'training_tasks': '2018-07-12-TTT-event',
+                'review_process': 'preapproved',
                 'group_name': 'GummiBears',
                 'personal': 'Grammi',
                 'middle': '',
@@ -297,7 +301,8 @@ class TestListingTrainingRequests(APITestBase):
         firstline = content.splitlines()[0]
         expected_firstline = (
             'Created at,Last updated at,State,Matched Trainee,'
-            'Matched Trainee ID,Badges,Training Tasks,Registration Code,'
+            'Matched Trainee ID,Badges,Training Tasks,'
+            'Application Type,Registration Code,'
             'Personal,Middle,Family,Email,GitHub username,Underrepresented,'
             'Underrepresented (reason),Occupation,Occupation (other),'
             'Affiliation,Location,Country,Underresourced institution,'


### PR DESCRIPTION
This fixes #1540. The CSV serializers were extended with one additional
column (`review_process` - Application Type). Tests were adjusted.