### PR TITLE
Fix assignment link in SelfOrgSubmission and WorkshopInquiry

### DIFF
--- a/amy/templates/requests/selforganisedsubmission.html
+++ b/amy/templates/requests/selforganisedsubmission.html
@@ -6,7 +6,7 @@
 
 <div class="row">
   <div class="col-md-6 offset-md-6 text-right">
-    {% include "includes/assigned_to.html" with object=object user=user assign_url='workshoprequest_assign' %}
+    {% include "includes/assigned_to.html" with object=object user=user assign_url='selforganisedsubmission_assign' %}
   </div>
 </div>
 

--- a/amy/templates/requests/workshopinquiry.html
+++ b/amy/templates/requests/workshopinquiry.html
@@ -6,7 +6,7 @@
 
 <div class="row">
   <div class="col-md-6 offset-md-6 text-right">
-    {% include "includes/assigned_to.html" with object=object user=user assign_url='workshoprequest_assign' %}
+    {% include "includes/assigned_to.html" with object=object user=user assign_url='workshopinquiry_assign' %}
   </div>
 </div>
 


### PR DESCRIPTION
This fixes #1550 by changing the wrong links to proper ones:
* `selforganisedsubmission_assign` for Self-Organised Submission
* `workshopinquiry_assign` for Workshop Inquiry.