### PR TITLE
EventForm: build expected tags in clean_curricula differently

### DIFF
--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -557,10 +557,12 @@ class EventForm(forms.ModelForm):
         tags = self.cleaned_data['tags']
 
         try:
-            expected_tags = [
-                c.slug.split("-")[0].upper() for c in curricula
-                if c.active and not c.unknown
-            ]
+            expected_tags = []
+            for c in curricula:
+                if c.active and c.carpentry:
+                    expected_tags.append(c.carpentry)
+                elif c.active and c.mix_match:
+                    expected_tags.append('Circuits')
         except (ValueError, TypeError):
             expected_tags = []
 

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -737,6 +737,34 @@ class TestEventViews(TestBase):
         form = EventForm(data)
         self.assertNotIn('curricula', form.errors)
 
+    def test_curricula_circuits_tag(self):
+        """Ensure validation of `curricula` and `tags` fields."""
+        # missing tags
+        data = {
+            'slug': '2018-10-28-curriculum',
+            'host': self.org_alpha.pk,
+            # there has to be some tag
+            'tags': [Tag.objects.get(name='DC').pk],
+            'curricula': [
+                Curriculum.objects.get(slug='swc-python').pk,
+                Curriculum.objects.get(mix_match=True).pk,
+            ],
+        }
+        form = EventForm(data)
+        # we're missing SWC and Circuits
+        self.assertIn('curricula', form.errors)
+
+        # try adding SWC tag
+        data['tags'].append(Tag.objects.get(name='SWC').pk)
+        form = EventForm(data)
+        self.assertIn('curricula', form.errors)
+        # now we're missing only circuits
+
+        # try adding Circuits tag
+        data['tags'].append(Tag.objects.get(name='Circuits').pk)
+        form = EventForm(data)
+        self.assertNotIn('curricula', form.errors)
+
 
 class TestEventMerging(TestBase):
     def setUp(self):


### PR DESCRIPTION
Previously we were using name of the curriculum (split by "-"). Now we
can use curriculum.carpentry value, which corresponds to Tag name,
unless it's mix&match -> then tag name is "Circuits". And this is what
the method now does.

A new test case was added to ensure this mechanism is working correctly
with Mix&Match curriculum.

This fixes #1554.