### PR TITLE
AMY dashboard: Demo Session Etherpad Link

### DIFF
--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -148,7 +148,7 @@
     {% endif %}
     <tr>
       <td colspan="2">{% if not user.passed_swc_demo or not user.passed_dc_demo or not user.passed_lc_demo %}
-          <p>You can register for Demo Session on <a href="https://pad.carpentries.org/teaching-demos-recovered">this Etherpad</a>.</p>
+          <p>You can register for Demo Session on <a href="https://pad.carpentries.org/teaching-demos">this Etherpad</a>.</p>
         {% endif %}</td>
     </tr>
 


### PR DESCRIPTION
The link to teaching demo pad needs correction at the bottom of https://amy.carpentries.org/dashboard/trainee/training_progress/
under "4. Demo Session".

It is in the "You can register for ."

For the hyperlink of "this Etherpad",
Proposed link:
https://pad.carpentries.org/teaching-demos
Current link:
https://pad.carpentries.org/teaching-demos-recovered