### PR TITLE
Update link for Teaching Demos etherpad

### DIFF
--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -148,7 +148,7 @@
     {% endif %}
     <tr>
       <td colspan="2">{% if not user.passed_swc_demo or not user.passed_dc_demo or not user.passed_lc_demo %}
-          <p>You can register for Demo Session on <a href="https://pad.carpentries.org/teaching-demos-recovered">this Etherpad</a>.</p>
+          <p>You can register for Demo Session on <a href="https://pad.carpentries.org/teaching-demos">this Etherpad</a>.</p>
         {% endif %}</td>
     </tr>
 


### PR DESCRIPTION
On the Training Progress page, the link to the Teaching Demos etherpad seems to be broken.
Update to working link.