### PR TITLE
Trainer badge in badge column on all persons / event details / workshop staff pages

### DIFF
--- a/amy/static/css/amy.css
+++ b/amy/static/css/amy.css
@@ -37,6 +37,9 @@ label.col-form-label {
     font-weight: bold;
 }
 
+table .badges-column {
+    width: 13%;
+}
 table .additional-links {
     width: 70px;
 }

--- a/amy/templates/workshops/all_persons.html
+++ b/amy/templates/workshops/all_persons.html
@@ -12,14 +12,15 @@
 {% if all_persons %}
     <table class="table table-striped">
       <tr>
-        <th width="25">Instr. badges</th>
+        <th class="badges-column">Some badges <i class="fas fa-question-circle" data-toggle="tooltip"
+            title="Only Instructor or Trainer badges shown."></i></th>
         <th>Name</th>
         <th>Email</th>
         <th class="additional-links"></th>
       </tr>
     {% for person in all_persons %}
       <tr>
-        <td class="text-center">{% for badge in person.instructor_badges %}
+        <td>{% for badge in person.important_badges %}
           {% bootstrap_tag badge.name|cut:"-instructor"|upper %}
         {% empty %}&mdash;{% endfor %}</td>
         <td><a href="{% url 'person_details' person.id %}">{{ person.full_name }}</a></td>

--- a/amy/templates/workshops/event.html
+++ b/amy/templates/workshops/event.html
@@ -110,7 +110,8 @@
 <table id="event-tasks" class="table table-striped table-bordered">
   <thead>
     <tr>
-      <th width="150">Instr. badges</th>
+      <th class="badges-column">Some badges <i class="fas fa-question-circle" data-toggle="tooltip"
+          title="Only Instructor or Trainer badges shown."></i></th>
       <th>Person</th>
       <th>URL</th>
       <th>Role</th>
@@ -122,7 +123,9 @@
   <tbody>
   {% for t in tasks %}
   <tr>
-    <td>{% for badge in t.person.instructor_badges %}{% bootstrap_tag badge.name|cut:"-instructor"|upper %}{% empty %}&mdash;{% endfor %}</td>
+    <td>{% for badge in t.person.important_badges %}
+      {% bootstrap_tag badge.name|cut:"-instructor"|upper %}
+    {% empty %}&mdash;{% endfor %}</td>
     <td><a href="{{ t.person.get_absolute_url }}">{{ t.person.full_name }}</a>{% if t.person.email and t.person.may_contact %} &lt;{{ t.person.email|urlize }}&gt;{% endif %}</td>
     <td>{{ t.url|default:"&mdash;"|urlize_newtab }}</td>
     <td>{{ t.role.name }}</td>

--- a/amy/templates/workshops/workshop_staff.html
+++ b/amy/templates/workshops/workshop_staff.html
@@ -15,7 +15,8 @@
     <table class="table table-striped">
       <tr>
         <th><input type="checkbox" value="Select all" select-all-checkbox /></th>
-        <th>Instr. badges</th>
+        <th class="badges-column">Some badges <i class="fas fa-question-circle" data-toggle="tooltip"
+            title="Only Instructor or Trainer badges shown."></i></th>
         <th>Has Trainer badge</th>
         <th>Person</th>
         <th>Taught</th>
@@ -28,9 +29,9 @@
       {% for p in persons %}
       <tr>
         <td><input type="checkbox" email="{{ p.email }}" respond-to-select-all-checkbox /></td>
-        <td>{% for badge in p.instructor_badges %}
+        <td>{% for badge in p.important_badges %}
           {% bootstrap_tag badge.name|cut:"-instructor"|upper %}
-        {% endfor %}</td>
+          {% empty %}&mdash;{% endfor %}</td>
         <td>{{ p.is_trainer|yesno }}</td>
         <td><a href="{{ p.get_absolute_url }}">{{ p.full_name }}</a>{% if p.email and p.may_contact %} &lt;{{ p.email|urlize }}&gt;{% endif %}</td>
         <td>{{ p.num_taught }}</td>

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -1413,6 +1413,7 @@ class Badge(models.Model):
 
     # just for easier access outside `models.py`
     INSTRUCTOR_BADGES = BadgeQuerySet.INSTRUCTOR_BADGES
+    IMPORTANT_BADGES = INSTRUCTOR_BADGES + ('trainer', )
 
     name       = models.CharField(max_length=STR_MED, unique=True)
     title      = models.CharField(max_length=STR_MED)

--- a/amy/workshops/tests/test_workshop_staff_searching.py
+++ b/amy/workshops/tests/test_workshop_staff_searching.py
@@ -368,7 +368,7 @@ class TestWorkshopStaffCSV(TestBase):
         rv = self.client.get(self.url)
         first_row = rv.content.decode('utf-8').splitlines()[0]
         first_row_expected = (
-            "Name,Email,Instructor badges,Has Trainer badge,Taught times,"
+            "Name,Email,Some badges,Has Trainer badge,Taught times,"
             "Is trainee,Airport,Country,Lessons,Affiliation"
         )
 
@@ -382,9 +382,9 @@ class TestWorkshopStaffCSV(TestBase):
         for row, expected in zip(reader, results):
             self.assertEqual(row['Name'], expected.full_name)
             self.assertEqual(row['Email'] or None, expected.email)
-            self.assertEqual(row['Instructor badges'],
+            self.assertEqual(row['Some badges'],
                              " ".join(map(lambda x: x.name,
-                                          expected.instructor_badges)))
+                                          expected.important_badges)))
             self.assertEqual(row['Has Trainer badge'],
                              'yes' if expected.is_trainer else 'no')
             self.assertEqual(row['Taught times'], str(expected.num_taught))

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -203,9 +203,9 @@ class AllPersons(OnlyForAdminsMixin, AMYListView):
     queryset = Person.objects.prefetch_related(
         Prefetch(
             'badges',
-            to_attr='instructor_badges',
-            queryset=Badge.objects.instructor_badges()
-        )
+            to_attr='important_badges',
+            queryset=Badge.objects.filter(name__in=Badge.IMPORTANT_BADGES),
+        ),
     )
     title = 'All Persons'
 
@@ -836,16 +836,17 @@ def event_details(request, slug):
     except Event.DoesNotExist:
         raise Http404('Event matching query does not exist.')
 
-    person_instructor_badges = Prefetch(
+    person_important_badges = Prefetch(
         'person__badges',
-        to_attr='instructor_badges',
-        queryset=Badge.objects.instructor_badges()
+        to_attr='important_badges',
+        queryset=Badge.objects.filter(name__in=Badge.IMPORTANT_BADGES)
     )
+
     tasks = (
         Task.objects
             .filter(event__id=event.id)
             .select_related('event', 'person', 'role')
-            .prefetch_related(person_instructor_badges)
+            .prefetch_related(person_important_badges)
             .order_by('role__name')
     )
 
@@ -1409,11 +1410,11 @@ def _workshop_staff_query(lat=None, lng=None):
     TTT = Tag.objects.get(name='TTT')
     stalled = Tag.objects.get(name='stalled')
     learner = Role.objects.get(name='learner')
-    instructor_badges = Badge.objects.instructor_badges()
+    important_badges = Badge.objects.filter(name__in=Badge.IMPORTANT_BADGES)
 
     trainee_tasks = Task.objects.filter(event__tags=TTT, role=learner) \
                                 .exclude(event__tags=stalled) \
-                                .exclude(person__badges__in=instructor_badges)
+                                .exclude(person__badges__in=important_badges)
 
     # we need to count number of specific roles users had
     # and if they are SWC/DC/LC instructors
@@ -1446,8 +1447,8 @@ def _workshop_staff_query(lat=None, lng=None):
             'lessons',
             Prefetch(
                 'badges',
-                to_attr='instructor_badges',
-                queryset=Badge.objects.instructor_badges()
+                to_attr='important_badges',
+                queryset=Badge.objects.filter(name__in=Badge.IMPORTANT_BADGES)
             ),
         )
         .order_by('family', 'personal')
@@ -1523,7 +1524,7 @@ def workshop_staff_csv(request):
     people = f.qs
 
     # first row of the CSV output
-    header_row = ('Name', 'Email', 'Instructor badges', 'Has Trainer badge',
+    header_row = ('Name', 'Email', 'Some badges', 'Has Trainer badge',
                   'Taught times', 'Is trainee', 'Airport', 'Country',
                   'Lessons', 'Affiliation')
 
@@ -1539,7 +1540,7 @@ def workshop_staff_csv(request):
             person.full_name,
             person.email,
             " ".join([
-                badge.name for badge in person.instructor_badges
+                badge.name for badge in person.important_badges
             ]),
             "yes" if person.is_trainer else "no",
             person.num_taught,


### PR DESCRIPTION
Three templates:
* all persons
* event details
* workshop staff searching

were changed. The column that showed instructor badges in all three templates was replaced with unified column showing instructor badges and a trainer badge.

This fixes #1549.