### PR TITLE
Enable responsiveness on login page

### DIFF
--- a/amy/templates/account/base.html
+++ b/amy/templates/account/base.html
@@ -3,4 +3,4 @@
 
 {% block logo %}<div class="mx-auto text-center"><a href="https://github.com/carpentries/amy"><img class="p-4" src="{% static 'amy-logo.png' %}" alt="AMY Logo" /></a></div>{% endblock %}
 
-{% block maincolumn %}col-6 mx-auto pt-4{% endblock maincolumn %}
+{% block maincolumn %}col-xl-6 col-lg-9 col-sm-10 col-12 mx-auto pt-4{% endblock maincolumn %}

--- a/amy/templates/account/login.html
+++ b/amy/templates/account/login.html
@@ -7,7 +7,7 @@
     {% endif %}
 
     <div class="row">
-      <div class="col-5">
+      <div class="col-12 col-md-5">
         <h4>For The Carpentries Administrators</h4>
         <form method="post" action="{% url 'login' %}">
           {% csrf_token %}
@@ -25,11 +25,11 @@
         <small><a href="{% url 'password_reset' %}">Forgotten your password?</a></small>
       </div>
 
-      <div class="col">
+      <div class="col-12 col-md">
         <p class="text-center"><strong>OR</strong></p>
       </div>
 
-      <div class="col-5">
+      <div class="col-12 col-md-5">
         <h4>For The Carpentries Instructors</h4>
         <p><a class="btn btn-primary w-100" href="/login/github/"><i class="fab fa-github"></i> Log in with your GitHub account</a></p>
         <p>Having trouble logging in? Contact us at <a href="mailto:team@carpentries.org">team@carpentries.org</a>.</p>


### PR DESCRIPTION
This fixes #1522.

The changes:
* more break points in accounts/base.html (for extra large `xl` we set
  page width to 6 columns, for large `lg`: 9 columns, for small `sm`:
  10 columns, for extra small [no prefix]: 12 columns)
* different columns in login page (left column: login form, center column:
  word "OR", right column: login with GitHub) and they have different
  widths depending on display size (on extra small [no prefix] all
  columns have 12col width, which is the widest, and on medium or
  higher `md`: 5 cols, the rest, 5 cols).
