### PR TITLE
Django-Compressor performance upgrade

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -301,13 +301,15 @@ STATICFILES_FINDERS = [
 # https://django-compressor.readthedocs.io/en/stable/settings/
 COMPRESS_ENABLED = not CONTINUOUS_INTEGRATION
 
-COMPRESS_CSS_FILTERS = [
-    'compressor.filters.css_default.CssAbsoluteFilter',
-    'compressor.filters.cssmin.rCSSMinFilter',
-]
-COMPRESS_JS_FILTERS = [
-    'compressor.filters.jsmin.JSMinFilter',
-]
+COMPRESS_FILTERS = {
+    'css': [
+        'compressor.filters.css_default.CssAbsoluteFilter',
+        'compressor.filters.cssmin.rCSSMinFilter',
+    ],
+    'js': [
+        'compressor.filters.jsmin.JSMinFilter',
+    ]
+}
 
 # MEDIA
 # -----------------------------------------------------------------------------

--- a/config/settings.py
+++ b/config/settings.py
@@ -258,6 +258,12 @@ CACHES = {
     'select2': {
         'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
         'LOCATION': 'cache_select2',
+    },
+    'compressor': {
+        # TODO: in future, either switch to offline compression or
+        #       install Memcached
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        # 'LOCATION': 'templates-media',  # required if >1 LocMemCache used
     }
 }
 
@@ -310,6 +316,14 @@ COMPRESS_FILTERS = {
         'compressor.filters.jsmin.JSMinFilter',
     ]
 }
+
+# DB-backend cache is very slow when we're using SQLite. Therefore it is
+# advised to use a different cache, like MemCached. By default, AMY sets
+# LocMemCache for Django-Compressor. It has some drawbacks, biggest one
+# this cache being available only for one process. Therefore, for more
+# processes Django-Compressor will start regenerating the cache.
+# TODO: switch to Redis / Memcached once they're in place.
+COMPRESS_CACHE_BACKEND = 'compressor'
 
 # MEDIA
 # -----------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ djangorestframework-yaml==1.0.3
 drf-nested-routers==0.91
 django-recaptcha==1.4.0
 Faker==0.9.1
-django-compressor==2.2
+django-compressor==2.3
 PyGithub==1.43.2
 social-auth-core==1.7.0
 social-auth-app-django==2.1.0


### PR DESCRIPTION
Fixes #1598.

Due to cache settings change, Django-Compressor started using DB-based cache. Since the default database, SQLite, is pretty terrible, that change resulted in very poor performance.

This PR switches cache backend used by Django-Compressor back to `LocMemCache`, which despite its shortcomings should result in good performance.