### PR TITLE
Upgrade some dependencies due to deprecation warnings in old versions

### DIFF
--- a/amy/api/urls.py
+++ b/amy/api/urls.py
@@ -10,17 +10,17 @@ app_name = 'api'
 
 # routers generate URLs for methods like `.list` or `.retrieve`
 router = routers.SimpleRouter()
-router.register('reports', views.ReportsViewSet, base_name='reports')
+router.register('reports', views.ReportsViewSet, basename='reports')
 router.register('persons', views.PersonViewSet)
 awards_router = routers.NestedSimpleRouter(router, 'persons', lookup='person')
-awards_router.register('awards', views.AwardViewSet, base_name='person-awards')
+awards_router.register('awards', views.AwardViewSet, basename='person-awards')
 person_task_router = routers.NestedSimpleRouter(router, 'persons',
                                                 lookup='person')
 person_task_router.register('tasks', views.PersonTaskViewSet,
-                            base_name='person-tasks')
+                            basename='person-tasks')
 router.register('events', views.EventViewSet)
 tasks_router = routers.NestedSimpleRouter(router, 'events', lookup='event')
-tasks_router.register('tasks', views.TaskViewSet, base_name='event-tasks')
+tasks_router.register('tasks', views.TaskViewSet, basename='event-tasks')
 router.register('organizations', views.OrganizationViewSet)
 router.register('airports', views.AirportViewSet)
 

--- a/amy/workshops/util.py
+++ b/amy/workshops/util.py
@@ -645,7 +645,7 @@ def find_metadata_on_event_homepage(content):
     have workshop-related data."""
     try:
         first, header, last = content.split('---')
-        metadata = yaml.load(header.strip())
+        metadata = yaml.load(header.strip(), Loader=yaml.SafeLoader)
 
         # get metadata to the form returned by `find_metadata_on_event_website`
         # because YAML tries to interpret values from index's header

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ django-crispy-forms==1.7.2
 # replaces django-autocomplete-light
 django-select2==7.1.1
 django-countries==5.3.2
-django-filter==2.0.0
+django-filter==2.2.0
 django-reversion==2.0.13
 django-reversion-compare==0.8.4
 diff-match-patch==20121119
-djangorestframework==3.8.2
+djangorestframework==3.9.4
 djangorestframework-csv==2.1.0
 djangorestframework-yaml==1.0.3
 drf-nested-routers==0.91
@@ -18,15 +18,15 @@ django-recaptcha==1.4.0
 Faker==0.9.1
 django-compressor==2.3
 PyGithub==1.43.2
-social-auth-core==1.7.0
-social-auth-app-django==2.1.0
+social-auth-core==3.2.0
+social-auth-app-django==3.1.0
 django-webtest==1.9.3
 django-debug-toolbar==1.10.1
-django-extensions==2.1.3
+django-extensions==2.2.5
 django-anymail==3.0
 django-environ==0.4.5
 argon2-cffi==18.3.0
 django-contrib-comments==1.9.0
 django-markdownx==2.0.28
-Markdown==3.0.1
+Markdown==3.1.1
 Pillow==6.2.0


### PR DESCRIPTION
Upgraded dependencies:
* django-filter 2.0.0 -> 2.2.0
* djangorestframework 3.8.2 -> 3.9.4
* social-auth-code 1.7.0 -> 3.2.0
* social-auth-app-django 2.1.0 -> 3.1.0
* django-extensions 2.1.3 -> 2.2.5
* Markdown 3.0.1 -> 3.1.1

This commit also contains important security change in PyYAML loader.
PyYAML was recently upgraded from 3.x to 5.1.

See more info at https://msg.pyyaml.org/load
