### PR TITLE
Send form copy to Training Request applicant

### DIFF
--- a/amy/extforms/tests/test_training_request_form.py
+++ b/amy/extforms/tests/test_training_request_form.py
@@ -64,6 +64,7 @@ class TestTrainingRequestForm(TestBase):
         self.assertEqual(msg.to, [email])
         self.assertEqual(msg.subject,
                          TrainingRequestCreate.autoresponder_subject)
+        self.assertIn('A copy of your request', msg.body)
         # with open('email.eml', 'wb') as f:
         #     f.write(msg.message().as_bytes())
 

--- a/amy/templates/includes/trainingrequest_details.html
+++ b/amy/templates/includes/trainingrequest_details.html
@@ -1,0 +1,153 @@
+{% load state %}
+{% load utils %}
+<table class="table table-striped">
+  <tbody>
+    <tr><th>Submission date:</th>
+        <td>{{ object.created_at }}</td></tr>
+{% if admin %}
+    <tr><th>State:</th>
+        <td><span class="{% state_label object %}">{{ object.get_state_display }}</span></td></tr>
+    <tr><th>Matched person:</th>
+        <td>
+          {% if object.person %}
+            <a href="{% url 'person_details' object.person.pk %}">
+              {{ object.person.full_name }}</a>
+            {% if object.person.email %}&lt;{{ object.person.email|urlize }}&gt;{% endif %}
+          {% else %}&mdash;{% endif %}
+        </td></tr>
+    <tr><th>Application score:</th>
+        <td>Automatic: {{ object.score_auto }} pts. <br>
+            Manual: {% if object.score_manual is not None %}{{ object.score_manual }} pts.{% else %}not scored{% endif %} <br>
+            <b>Total: {{ object.score_total }} pts.</b></td></tr>
+    <tr><th>Manual score notes:</th>
+        <td>{% if object.score_notes %}<pre>{{ object.score_notes }}</pre>{% else %}&mdash;{% endif %}</td></tr>
+{% endif %}
+    <tr><th>Application Type:</th>
+        <td>{{ object.get_review_process_display|default:"&mdash;" }}</td></tr>
+    <tr><th>Registration Code:</th>
+        <td>{{ object.group_name|default:"&mdash;" }}</td></tr>
+    <tr><th>Personal name:</th>
+        <td>{{ object.personal }}</td></tr>
+    <tr><th>Middle name:</th>
+        <td>{{ object.middle }}</td></tr>
+    <tr><th>Family name:</th>
+        <td>{{ object.family}}</td></tr>
+    <tr><th>Email:</th>
+        <td>{{ object.email|urlize }}</td></tr>
+    <tr><th>Github:</th>
+        <td>{{ object.github|default:"&mdash;" }}</td></tr>
+    <tr><th>Occupation:</th>
+        <td>{{ object.get_occupation_display }} {{ object.occupation_other }}</td></tr>
+    <tr><th>Affiliation:</th>
+        <td>{{ object.affiliation }}</td></tr>
+    <tr><th>Location:</th>
+        <td>{{ object.location}}</td></tr>
+    <tr><th>Country:</th>
+        <td>{{ object.get_country_display }}</td></tr>
+    <tr><th>This is a small, remote, or under-resourced institution:</th>
+        <td>{{ object.underresourced|yesno }}</td></tr>
+    <tr><th>Areas of expertise:</th>
+        <td>
+            {% if object.domains.all %}
+            <ul>
+            {% for domain in object.domains.all %}
+                <li>{{ domain }}</li>
+            {% endfor %}
+            </ul>
+            {% else %}
+            No areas of expertise.
+            {% endif %}
+        </td></tr>
+    <tr><th>Other areas of expertise:</th>
+        <td>{{ object.domains_other|default:"&mdash;" }}</td></tr>
+    <tr><th>I self-identify as a member of a group that is under-represented in research and/or computing:</th>
+        <td>{{ object.get_underrepresented_display }}</td></tr>
+    <tr><th>If you are comfortable doing so, please share more details. Your response is optional, and these details will not impact your application's ranking.</th>
+        <td>
+            {% if object.underrepresented_details %}
+            {{ object.underrepresented_details }}
+            {% else %}
+            &mdash;
+            {% endif %}
+        </td></tr>
+    <tr><th> I have been an active contributor to other volunteer or non-profit groups with significant teaching or training components.</th>
+        <td>{{ object.nonprofit_teaching_experience|default:"&mdash;" }}</td></tr>
+    <tr><th>In which of the following ways have you been involved with The Carpentries:</th>
+        <td>
+            {% if object.previous_involvement.all %}
+            <ul>
+            {% for involvement in object.previous_involvement.all %}
+                <li>{{ involvement }}</li>
+            {% endfor %}
+            </ul>
+            {% else %}
+            No previous involvement.
+            {% endif %}
+        </td></tr>
+    </tr>
+    <tr><th>Previous formal training as a teacher or instructor:</th>
+        <td>
+            {{ object.get_previous_training_display }}
+            {% if object.previous_training_other %}
+            {{ object.previous_training_other }}
+            {% endif %}
+        </td></tr>
+    <tr><th>Description of your previous training in teaching:</th>
+        <td>
+            {% if object.previous_training_explanation %}
+            <pre>{{ object.previous_training_explanation }}</pre>
+            {% else %}
+            &mdash;
+            {% endif %}
+        </td></tr>
+    <tr><th>Previous experience in teaching:</th>
+        <td>
+            {{ object.get_previous_experience_display }}
+            {% if object.previous_experience_other %}
+            {{ object.previous_experience_other }}
+            {% endif %}
+        </td></tr>
+    <tr><th>Description of your previous experience in teaching:</th>
+        <td>
+            {% if object.previous_experience_explanation %}
+            <pre>{{ object.previous_experience_explanation }}</pre>
+            {% else %}
+            &mdash;
+            {% endif %}
+        </td></tr>
+    <tr><th>How frequently do you work with the tools that The Carpentries teach, such as R, Python, MATLAB, Perl, SQL, Git, OpenRefine, and the Unix Shell?</th>
+        <td>{{ object.get_programming_language_usage_frequency_display }}</td></tr>
+    <tr><th>How often would you expect to teach Carpentry Workshops after this training?</th>
+        <td>
+            {{ object.get_teaching_frequency_expectation_display }}
+            {% if object.teaching_frequency_expectation_other %}
+            {{ object.teaching_frequency_expectation_other}}
+            {% endif %}
+        </td></tr>
+    <tr><th>How frequently would you be able to travel to teach such classes?:</th>
+        <td>
+            {{ object.get_max_travelling_frequency_display }}
+            {% if object.max_travelling_frequency_other %}
+            {{ object.max_travelling_frequency_other }}
+            {% endif %}
+        </td></tr>
+    <tr><th>Why do you want to attend this training course?:</th>
+        <td><pre>{{ object.reason }}</pre></td></tr>
+    <tr><th>Additional notes:</th>
+        <td>
+            {% if object.user_notes %}
+            <pre>{{ object.user_notes }}</pre>
+            {% else %}
+            &mdash;
+            {% endif %}
+        </td></tr>
+    <tr><th>Data privacy agreement:</th>
+        <td>{{ object.data_privacy_agreement|yesno }}</td></tr>
+    <tr><th>Code of Conduct agreement:</th>
+        <td>{{ object.code_of_conduct_agreement|yesno }}</td></tr>
+    <tr><th>Training completion within three months agreement:</th>
+        <td>{{ object.training_completion_agreement|yesno }}</td></tr>
+    <tr><th>Teach a workshop within 12 months agreement:</th>
+        <td>{{ object.workshop_teaching_agreement|yesno }}</td></tr>
+  </tbody>
+</table>

--- a/amy/templates/mailing/training_request.html
+++ b/amy/templates/mailing/training_request.html
@@ -8,3 +8,9 @@ with one of our institutional partners (listed at
 ), we will do our best to prioritize your
 application; if you or your institution would like to discuss partnership, we
 would welcome an opportunity to speak with you.</p>
+
+<hr>
+
+<p>A copy of your request is included below for your reference.</p>
+
+{% include "includes/trainingrequest_details.html" with admin=False object=object %}

--- a/amy/templates/mailing/training_request.txt
+++ b/amy/templates/mailing/training_request.txt
@@ -5,3 +5,64 @@ with one of our institutional partners (listed at
 https://carpentries.org/members/), we will do our best to prioritize your
 application; if you or your institution would like to discuss partnership, we
 would welcome an opportunity to speak with you.
+
+
+
+--------------------------------------------
+
+A copy of your request is included below for your reference.
+
+ubmission date: {{ object.created_at }}
+Application Type: {{ object.get_review_process_display|default:"---" }}
+Registration Code: {{ object.group_name|default:"&mdash;" }}
+Person: {{object.personal}} {{object.middle}} {{object.family}} &lt;{{object.email}}&gt;
+Github: {{ object.github|default:"---" }}
+Occupation: {{ object.get_occupation_display }} {{ object.occupation_other }}
+Affiliation: {{ object.affiliation }}
+Location: {{ object.location}}
+Country: {{ object.country.name }}
+Underresourced institution: {{ object.underresourced|yesno }}
+Areas of expertise: {% for domain in object.domains.all %}{{ domain }}{% if not forloop.last %}, {%endif%}{%endfor%}
+Other areas of expertise: {{ object.domains_other|default:"---" }}
+I self-identify as a member of a group that is under-represented in research and/or computing: {{ object.get_underrepresented_display }}
+If you are comfortable doing so, please share more details. Your response is optional, and these details will not impact your application's ranking: {{ object.underrepresented_details|default:"---" }}
+I have been an active contributor to other volunteer or non-profit groups with significant teaching or training components: {{ object.nonprofit_teaching_experience|default:"---" }}
+Previous involvement with The Carpentries: {% for involvement in object.previous_involvement.all %}{{ involvement }}{% if not forloop.last %}, {%endif%}{%endfor%}
+Previous formal training as a teacher or instructor: {{ object.get_previous_training_display|default:"---" }}
+Other previous formal training as a teacher or instructor: {{ object.previous_training_other|default:"---" }}
+Description of your previous training in teaching:
+    {% if object.previous_training_explanation %}
+    {{ object.previous_training_explanation }}
+    {% else %}
+    ---
+    {% endif %}
+Previous experience in teaching: {{ object.get_previous_experience_display|default:"---" }}
+Other previous experience in teaching: {{ object.previous_experience_other|default:"---" }}
+Description of your previous experience in teaching:
+    {% if object.previous_experience_explanation %}
+    {{ object.previous_experience_explanation }}
+    {% else %}
+    ---
+    {% endif %}
+How frequently do you work with the tools that The Carpentries teach, such as R, Python, MATLAB, Perl, SQL, Git, OpenRefine, and the Unix Shell: {{ object.get_programming_language_usage_frequency_display }}
+How often would you expect to teach Carpentry Workshops after this training: {{ object.get_teaching_frequency_expectation_display|default:"---" }}
+    other: {{ object.teaching_frequency_expectation_other|default:"---" }}
+How frequently would you be able to travel to teach such classes? {{ object.get_max_travelling_frequency_display }}
+    other: {{ object.max_travelling_frequency_other|default:"---" }}
+Why do you want to attend this training course:
+    {% if object.reason %}
+    {{ object.reason }}
+    {% else %}
+    ---
+    {% endif %}
+Additional notes:
+    {% if object.user_notes %}
+    {{ object.user_notes }}
+    {% else %}
+    ---
+    {% endif %}
+
+Data privacy agreement: {{ object.data_privacy_agreement|yesno }}
+Code of Conduct agreement: {{ object.code_of_conduct_agreement|yesno }}
+Training completion within three months agreement: {{ object.training_completion_agreement|yesno }}
+Teach a workshop within 12 months agreement: {{ object.workshop_teaching_agreement|yesno }}

--- a/amy/templates/requests/trainingrequest.html
+++ b/amy/templates/requests/trainingrequest.html
@@ -26,87 +26,8 @@
 <div class="edit-object">
   <a href="{% url 'trainingrequest_edit' req.id %}" class="btn btn-primary">Edit</a>
 </div>
-<table class="table table-striped">
-  <tr><th>State:</th>
-      <td><span class="{% state_label req %}">
-            {{ req.get_state_display }}
-          </span>
-      </td></tr>
-  <tr><th>Matched person:</th>
-      <td>
-        {% if req.person %}
-          <a href="{% url 'person_details' req.person.pk %}">
-            {{ req.person.full_name }}</a>
-          {% if req.person.email %}&lt;{{ req.person.email|urlize }}&gt;{% endif %}
-        {% else %}&mdash;{% endif %}
-      </td></tr>
-  <tr><th>Created at:</th>
-      <td>{{ req.created_at }}</td></tr>
-  <tr><th>Application score:</th>
-      <td>Automatic: {{ req.score_auto }} pts. <br>
-          Manual: {% if req.score_manual is not None %}{{ req.score_manual }} pts.{% else %}not scored{% endif %} <br>
-          <b>Total: {{ req.score_total }} pts.</b></td></tr>
-  <tr><th>Manual score notes:</th>
-      <td>{% if req.score_notes %}<pre>{{ req.score_notes }}</pre>{% else %}&mdash;{% endif %}</td></tr>
-  <tr><th>Registration Code:</th>
-      <td>{{ req.group_name }}</td></tr>
-  <tr><th>Personal name:</th>
-      <td>{{ req.personal }}</td></tr>
-  <tr><th>Middle name:</th>
-      <td>{{ req.middle }}</td></tr>
-  <tr><th>Family name:</th>
-      <td>{{ req.family}}</td></tr>
-  <tr><th>Email:</th>
-      <td>{{ req.email|urlize }}</td></tr>
-  <tr><th>Github:</th>
-      <td>{{ req.github|default:"&mdash;" }}</td></tr>
-  <tr><th>Occupation:</th>
-      <td>{{ req.get_occupation_display }} {{ req.occupation_other }}</td></tr>
-  <tr><th>Affiliation:</th>
-      <td>{{ req.affiliation }}</td></tr>
-  <tr><th>Location:</th>
-      <td>{{ req.location}}</td></tr>
-  <tr><th>Country:</th>
-      <td>{{ req.get_country_display }}</td></tr>
-  <tr><th>Domains:</th>
-      <td><ul>
-          {% for domain in req.domains.all %}
-            <li>{{ domain }}</li>
-          {% empty %}
-            <li>No knowledge domain.</li>
-          {% endfor %}
-          </ul></td></tr>
-  <tr><th>Other areas of expertise:</th>
-      <td>{{ req.domains_other|default:"&mdash;" }}</td></tr>
-  <tr><th>Under-represented:</th>
-      <td>{{ req.get_underrepresented_display }}.{% if req.underrepresented_details %} Reason: {{ req.underrepresented_details }}{% endif %}</td></tr>
-  <tr><th>Previous involvement:</th>
-      <td><ul>
-          {% for involvement in req.previous_involvement.all %}
-            <li>{{ involvement }}</li>
-          {% empty %}
-            <li>No previous involvement.</li>
-          {% endfor %}
-          </ul></td></tr>
-  <tr><th>Previous training in teaching:</th>
-      <td>{{ req.get_previous_training_display }} {{ req.previous_training_other }}</td></tr>
-  <tr><th>Explanation of previous training in teaching:</th>
-      <td>{% if req.previous_training_explanation %}<pre>{{ req.previous_training_explanation }}</pre>{% else %}&mdash;{% endif %}</td></tr>
-  <tr><th>Previous experience in teaching:</th>
-      <td>{{ req.get_previous_experience_display }} {{ req.previous_experience_other }}</td></tr>
-  <tr><th>Explanation of previous experience in teaching:</th>
-      <td>{% if req.previous_experience_explanation %}<pre>{{ req.previous_experience_explanation }}</pre>{% else %}&mdash;{% endif %}</td></tr>
-  <tr><th>Programming language usage frequency:</th>
-      <td>{{ req.get_programming_language_usage_frequency_display }}</td></tr>
-  <tr><th>Why do you want to attend this training course?:</th>
-      <td><pre>{{ req.reason }}</pre></td></tr>
-  <tr><th>Teaching frequency expectation:</th>
-      <td>{{ req.get_teaching_frequency_expectation_display }} {{ req.teaching_frequency_expectation_other}}</td></tr>
-  <tr><th>Max travelling frequency:</th>
-      <td>{{ req.get_max_travelling_frequency_display }} {{ req.max_travelling_frequency_other }}</td></tr>
-  <tr><th>Additional comments by submitter:</th>
-      <td>{% if req.comment %}<pre>{{ req.comment }}</pre>{% else %}&mdash;{% endif %}</td></tr>
-</table>
+
+{% include "includes/trainingrequest_details.html" with admin=True object=req %}
 
 {% include "includes/comments.html" with object=req %}
 

--- a/amy/workshops/management/commands/fake_database.py
+++ b/amy/workshops/management/commands/fake_database.py
@@ -246,6 +246,7 @@ class Command(BaseCommand):
             state = 'a'
             person = person_or_None
 
+        registration_code = self.faker.city() if randbool(0.1) else ''
         occupation = choice(TrainingRequest._meta.get_field('occupation')
                                            .choices)[0]
         training_completion_agreement = randbool(0.5)
@@ -255,7 +256,8 @@ class Command(BaseCommand):
         req = TrainingRequest.objects.create(
             state=state,
             person=person_or_None,
-            group_name=self.faker.city() if randbool(0.1) else '',
+            review_process='preapproved' if registration_code else 'open',
+            group_name=registration_code,
             personal=person.personal,
             middle='',
             family=person.family,


### PR DESCRIPTION
This fixes #1422 by adding a table with data entered by a sender.

This is very similar to how other 3 workshop request forms work:
* a general-purpose table details template is available
* it's used for admin display (it changes slightly)
* it's also used for HTML email content
* finally a manually trimmered version is used for bare (text) email.
