### PR TITLE
add link to submit self org wkshp

### DIFF
--- a/amy/templates/dashboard/trainee_dashboard.html
+++ b/amy/templates/dashboard/trainee_dashboard.html
@@ -78,7 +78,7 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
         <p>If you think that you're missing a badge, please email us at <a href="mailto:team@carpentries.org">team@carpentries.org</a></p>
     </td></tr>
     <tr><th>Your workshop activity:<br>
-        <small>If you have run a self-organised workshop that is missing from this list,<br> please fill out our <a href="/forms/self-organized">self organised workshop form</a> and we will update our records.</small></th><td>
+        <small>If you have run a self-organised workshop that is missing from this list,<br> please fill out our <a href="{% url 'selforganised_submission' %}">self organised workshop form</a> and we will update our records.</small></th><td>
         {% if workshops %}
         <table class="table">
           <tr>

--- a/amy/templates/dashboard/trainee_dashboard.html
+++ b/amy/templates/dashboard/trainee_dashboard.html
@@ -77,7 +77,8 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
         {% endif %}
         <p>If you think that you're missing a badge, please email us at <a href="mailto:team@carpentries.org">team@carpentries.org</a></p>
     </td></tr>
-    <tr><th>Your workshop activity:</th><td>
+    <tr><th>Your workshop activity:<br>
+        <small>If you have run a self-organised workshop that is missing from this list,<br> please fill out our <a href="/forms/self-organized">self organised workshop form</a> and we will update our records.</small></th><td>
         {% if workshops %}
         <table class="table">
           <tr>


### PR DESCRIPTION
Based on suggestion from @Talishask  , this PR adds a link to the trainee dashboard view so they can submit a self organised workshop directly from that view if they see something missing.  Here's a snapshot of what it will look like:

![image](https://user-images.githubusercontent.com/829690/73018344-781f0b80-3def-11ea-847b-859042f6f02a.png)



