### PR TITLE
Training Request form: Add missing email context

### DIFF
--- a/amy/extforms/views.py
+++ b/amy/extforms/views.py
@@ -46,6 +46,9 @@ class TrainingRequestCreate(
     autoresponder_body_template_html = 'mailing/training_request.html'
     autoresponder_form_field = 'email'
 
+    def autoresponder_email_context(self, form):
+        return dict(object=self.object)
+
     def get_success_message(self, *args, **kwargs):
         """Don't display a success message."""
         return ''


### PR DESCRIPTION
This is required to generate proper context to the autoresponder email template.