### PR TITLE
Fix empty manual_attendance bug

### DIFF
--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -575,6 +575,11 @@ class EventForm(forms.ModelForm):
 
         return curricula
 
+    def clean_manual_attendance(self):
+        """Regression: #1608 - fix 500 server error when field is cleared."""
+        manual_attendance = self.cleaned_data['manual_attendance'] or 0
+        return manual_attendance
+
     def save(self, *args, **kwargs):
         res = super().save(*args, **kwargs)
 

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -567,6 +567,24 @@ class TestEventViews(TestBase):
         f = EventForm(data)
         self.assertTrue(f.is_valid())
 
+    def test_empty_manual_attendance(self):
+        """Ensure we don't get 500 server error when field is left with empty
+        value.
+
+        This is a regression test for
+        https://github.com/swcarpentry/amy/issues/1608."""
+
+        data = {
+            'slug': '2016-06-30-test-event',
+            'host': self.test_host.id,
+            'tags': [self.test_tag.id],
+            'manual_attendance': '',
+        }
+        f = EventForm(data)
+        self.assertTrue(f.is_valid())
+        event = f.save()
+        self.assertEqual(event.manual_attendance, 0)
+
     def test_number_of_attendees_increasing(self):
         """Ensure event.attendance gets bigger after adding new learners."""
         event = Event.objects.get(slug='test_event_0')


### PR DESCRIPTION
This fixes #1608 bug: if empty `manual_attendance` is supplied,
it defaults to zero instead of None, which was causing DB error.
