### PR TITLE
Fix Github OAuth2 warning

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -158,7 +158,10 @@ MIGRATION_MODULES = {
 # -----------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#authentication-backends
 AUTHENTICATION_BACKENDS = [
-    'social_core.backends.github.GithubOAuth2',
+    # temporary fix until upstream catches up
+    # https://github.com/python-social-auth/social-core/pull/428
+    # 'social_core.backends.github.GithubOAuth2',
+    'workshops.github_auth.GithubOAuth2HeaderFix',
     'django.contrib.auth.backends.ModelBackend',
 ]
 SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['github']


### PR DESCRIPTION
Github [deprecated](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters)
API login through query args (now it should use HTTP basic auth).

This commit provides a simple solution that overrides headers sent to
GH servers in a GH OAuth2 social-login backend.

Unfortunately upstream remains unresponsive to PRs that fix this
urging matter, so I decided to follow custom-backend approach.
