### PR TITLE
Non-transactional DB error when matching Training Request with existing Person

### DIFF
--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -15,6 +15,7 @@ from django.core.exceptions import (
 )
 from django.db import (
     IntegrityError,
+    transaction,
 )
 from django.db.models import (
     Prefetch,
@@ -609,6 +610,7 @@ def all_trainingrequests(request):
     return render(request, 'requests/all_trainingrequests.html', context)
 
 
+@transaction.atomic
 def _match_training_request_to_person(request, training_request, create=False,
                                       person=None):
     if create:
@@ -663,10 +665,10 @@ def _match_training_request_to_person(request, training_request, create=False,
         return True
     except IntegrityError:
         # email or github not unique
-        messages.error(request, "It was impossible to update related person's "
-                                "data. Probably email address or GitHub "
-                                "handle used in the training request are not "
-                                " unique amongst person entries.")
+        messages.warning(request, "It was impossible to update related "
+                                  "person's data. Probably email address or "
+                                  "Github handle used in the training request "
+                                  "are not unique amongst person entries.")
         return False
 
 


### PR DESCRIPTION
During matching Training Request with existing person in database,
this person's details are updated from the Request.

It may happen that there's a conflict in our DB. For example,
a duplicate person with the same email as in the Training Request.

In this case the rewriting of person's data will trigger
IntegrityError, and before this commit it wasn't in a transaction
and could result in 500 Server Error.