### PR TITLE
Redis: use persistent storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   redis_cache:
+    command: redis-server --appendonly yes
     image: redis:latest
     ports:
       - "6379:6379"


### PR DESCRIPTION
This solves the recent problem with no permissions for redis
to write to the `/data` on its container.
