### PR TITLE
Change text for self org msg

### DIFF
--- a/amy/templates/forms/selforganised_submission.html
+++ b/amy/templates/forms/selforganised_submission.html
@@ -10,7 +10,7 @@
 
 <p class="lead">
     Please fill out this form if you are already connected with our certified  
-    Instructors to register a self-organised workshop. We use
+    Instructors to register a <a href="https://carpentries.org/workshops/#workshop-organising">self-organised workshop</a>. We use
     the URL of your workshop website to collect information, so please set that
     up using our
     <a href="https://github.com/carpentries/workshop-template">workshop template</a>

--- a/amy/templates/forms/selforganised_submission.html
+++ b/amy/templates/forms/selforganised_submission.html
@@ -9,8 +9,8 @@
 {% block content %}
 
 <p class="lead">
-    Please fill out this form if you are a Carpentries Instructor or affiliated
-    with a Member Organisation to register a self-organised workshop. We use
+    Please fill out this form if you are already connected with our certified  
+    Instructors to register a self-organised workshop. We use
     the URL of your workshop website to collect information, so please set that
     up using our
     <a href="https://github.com/carpentries/workshop-template">workshop template</a>
@@ -19,8 +19,8 @@
     can still submit it through this form.
 </p>
 <p class="lead">
-    If you are not affiliated with a Member Organisation or are a Certified
-    Carpentries Instructor, please use our
+    If you are not already connected with our certified  
+    Instructors please use our
     <a href="{% url 'workshop_request' %}">request a workshop</a> form or
     <a href="{% url 'workshop_inquiry' %}">request more information about a workshop</a>.
 </p>

--- a/amy/templates/forms/workshop_landing.html
+++ b/amy/templates/forms/workshop_landing.html
@@ -28,7 +28,6 @@
       </div>
       <div class="col-lg text-center my-3">
         <a href="{% url 'selforganised_submission' %}" class="btn btn-lg btn-primary">Register a self-organised workshop</a><br>
-        <small>For Member Organisations and Instructors</small>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Text about self organised workshops made it sound like only a certified instructor or a member site could submit this form.  This clarifies the language to note you must be connected with a certified Instructor who will teach, but anyone can actually fill out the form. 