### PR TITLE
Update from URL when `slug` is missing

### DIFF
--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -423,28 +423,40 @@ def selforganisedsubmission_accept_event(request, submission_id):
 
     else:
         # non-POST request
-        form = FormClass()
+        url = wr.workshop_url.strip()
+        data = {
+            'url': url,
+            'curricula': list(wr.workshop_types.all()),
+            'host': wr.host_organization() or wr.institution,
+            'administrator': Organization.objects.get(domain='self-organized'),
+        }
+        if mix_match:
+            data['tags'] = [Tag.objects.get(name='Circuits')]
 
         try:
-            url = wr.workshop_url.strip()
             metadata = fetch_workshop_metadata(url)
-            data = parse_workshop_metadata(metadata)
-            data.update({
-                'url': url,
-                'curricula': list(wr.workshop_types.all()),
-                'host': wr.host_organization() or wr.institution,
-                'administrator':
-                    Organization.objects.get(domain='self-organized'),
-            })
+            parsed_data = parse_workshop_metadata(metadata)
+        except (AttributeError, HTTPError, RequestException, WrongWorkshopURL):
+            # ignore errors, but show warning instead
+            messages.warning(request, "Cannot automatically fill the form "
+                                      "from provided workshop URL.")
+        else:
+            # keep working only if no exception occurred
+            try:
+                lang = parsed_data['language'].lower()
+                parsed_data['language'] = Language.objects.get(subtag=lang)
+            except (KeyError, ValueError, Language.DoesNotExist):
+                # ignore non-existing
+                messages.warning(request,
+                                 "Cannot automatically fill language.")
+                # it's easier to remove bad value than to leave
+                # 500 Server Error when the form is rendered
+                if 'language' in parsed_data:
+                    del parsed_data['language']
 
-            if mix_match:
-                data.update({
-                    'tags': [Tag.objects.get(name='Circuits')],
-                })
-
-            if 'language' in data:
-                lang = data['language'].lower()
-                data['language'] = Language.objects.get(subtag=lang)
+            # even if for some reason language doesn't exist, we can push
+            # an update
+            data.update(parsed_data)
 
             if 'instructors' in data or 'helpers' in data:
                 instructors = data.get('instructors') or ['none']
@@ -452,13 +464,8 @@ def selforganisedsubmission_accept_event(request, submission_id):
                 data['comment'] = "Instructors: {}\n\nHelpers: {}" \
                     .format(','.join(instructors), ','.join(helpers))
 
-            form = FormClass(initial=data)
-
-        except (AttributeError, KeyError, ValueError, HTTPError,
-                RequestException, WrongWorkshopURL, Language.DoesNotExist):
-            # ignore errors
-            messages.warning(request, "Cannot automatically fill the form "
-                                      "from provided workshop URL.")
+        # there's some data that we can push as initial for the form
+        form = FormClass(initial=data)
 
     context = {
         'object': wr,

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -90,8 +90,8 @@ from workshops.util import (
     merge_objects,
     failed_to_delete,
     InternalError,
-    fetch_event_metadata,
-    parse_metadata_from_event_website,
+    fetch_workshop_metadata,
+    parse_workshop_metadata,
     WrongWorkshopURL,
 )
 
@@ -427,8 +427,8 @@ def selforganisedsubmission_accept_event(request, submission_id):
 
         try:
             url = wr.workshop_url.strip()
-            metadata = fetch_event_metadata(url)
-            data = parse_metadata_from_event_website(metadata)
+            metadata = fetch_workshop_metadata(url)
+            data = parse_workshop_metadata(metadata)
             data.update({
                 'url': url,
                 'curricula': list(wr.workshop_types.all()),

--- a/amy/workshops/management/commands/check_for_workshop_websites_updates.py
+++ b/amy/workshops/management/commands/check_for_workshop_websites_updates.py
@@ -13,8 +13,8 @@ from rest_framework.utils.encoders import JSONEncoder
 
 from workshops.models import Event
 from workshops.util import (
-    fetch_event_metadata,
-    parse_metadata_from_event_website,
+    fetch_workshop_metadata,
+    parse_workshop_metadata,
     WrongWorkshopURL,
 )
 
@@ -124,14 +124,14 @@ class Command(BaseCommand):
 
     def get_event_metadata(self, event_url):
         """Get metadata from event (location, instructors, helpers, etc.)."""
-        metadata = fetch_event_metadata(event_url)
+        metadata = fetch_workshop_metadata(event_url)
         # normalize the metadata
-        metadata = parse_metadata_from_event_website(metadata)
+        metadata = parse_workshop_metadata(metadata)
         return metadata
 
     def empty_metadata(self):
         """Prepare basic, empty metadata."""
-        return parse_metadata_from_event_website({})
+        return parse_workshop_metadata({})
 
     def serialize(self, obj):
         """Serialize object to be put in the database."""

--- a/amy/workshops/tests/test_util.py
+++ b/amy/workshops/tests/test_util.py
@@ -173,6 +173,66 @@ Other content.
 
         self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
+    def test_finding_metadata_empty_tags(self):
+        content = """
+            <html><head>
+            <meta name="slug" content="" />
+            <meta name="startdate" content="" />
+            <meta name="enddate" content="" />
+            <meta name="country" content="" />
+            <meta name="venue" content="" />
+            <meta name="address" content="" />
+            <meta name="latlng" content="" />
+            <meta name="language" content="" />
+            <meta name="invalid" content="" />
+            <meta name="instructor" content="" />
+            <meta name="helper" content="" />
+            <meta name="contact" content="" />
+            <meta name="eventbrite" content="" />
+            <meta name="charset" content="" />
+            </head>
+            <body>
+            <h1>test</h1>
+            </body></html>
+        """
+        expected = {
+            'slug': '',
+            'startdate': '',
+            'enddate': '',
+            'country': '',
+            'venue': '',
+            'address': '',
+            'latlng': '',
+            'language': '',
+            'instructor': '',
+            'helper': '',
+            'contact': '',
+            'eventbrite': '',
+        }
+        self.assertEqual(expected, find_workshop_HTML_metadata(content))
+
+    def test_finding_metadata_missing_tags(self):
+        content = """
+            <html><head>
+            <meta name="slug" content="" />
+            <meta name="charset" content="utf-8" />
+            </head>
+            <body>
+            <h1>test</h1>
+            </body></html>
+        """
+        expected = {
+            'slug': '',
+        }
+        self.assertEqual(expected, find_workshop_HTML_metadata(content))
+
+    def test_finding_metadata_empty_page(self):
+        content1 = "<html><head></head><body></body></html>"
+        content2 = ""
+        expected = {}
+        self.assertEqual(expected, find_workshop_HTML_metadata(content1))
+        self.assertEqual(expected, find_workshop_HTML_metadata(content2))
+
     def test_parsing_empty_metadata(self):
         empty_dict = {}
         expected = {

--- a/amy/workshops/tests/test_util.py
+++ b/amy/workshops/tests/test_util.py
@@ -226,6 +226,21 @@ Other content.
         }
         self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
+    def test_finding_metadata_single_line(self):
+        content = (
+            '<html><head>'
+            '<meta name="slug" content="" />'
+            '<meta name="charset" content="utf-8" />'
+            '</head>'
+            '<body>'
+            '<h1>test</h1>'
+            '</body></html>'
+        )
+        expected = {
+            'slug': '',
+        }
+        self.assertEqual(expected, find_workshop_HTML_metadata(content))
+
     def test_finding_metadata_empty_page(self):
         content1 = "<html><head></head><body></body></html>"
         content2 = ""

--- a/amy/workshops/tests/test_util.py
+++ b/amy/workshops/tests/test_util.py
@@ -21,12 +21,12 @@ from workshops.models import (
     Language,
 )
 from workshops.util import (
-    fetch_event_metadata,
+    fetch_workshop_metadata,
     generate_url_to_event_index,
-    find_metadata_on_event_homepage,
-    find_metadata_on_event_website,
-    parse_metadata_from_event_website,
-    validate_metadata_from_event_website,
+    find_workshop_YAML_metadata,
+    find_workshop_HTML_metadata,
+    parse_workshop_metadata,
+    validate_workshop_metadata,
     get_members,
     default_membership_cutoff,
     assignment_selection,
@@ -87,29 +87,29 @@ Other content.
 
     @requests_mock.Mocker()
     def test_fetching_event_metadata_html(self, mock):
-        "Ensure 'fetch_event_metadata' works correctly with HTML metadata provided."
+        "Ensure 'fetch_workshop_metadata' works correctly with HTML metadata provided."
         website_url = 'https://pbanaszkiewicz.github.io/workshop'
         repo_url = ('https://raw.githubusercontent.com/pbanaszkiewicz/'
                     'workshop/gh-pages/index.html')
         mock.get(website_url, text=self.html_content, status_code=200)
         mock.get(repo_url, text='', status_code=200)
-        metadata = fetch_event_metadata(website_url)
+        metadata = fetch_workshop_metadata(website_url)
         self.assertEqual(metadata['slug'], '2015-07-13-test')
 
     @requests_mock.Mocker()
     def test_fetching_event_metadata_yaml(self, mock):
-        "Ensure 'fetch_event_metadata' works correctly with YAML metadata provided."
+        "Ensure 'fetch_workshop_metadata' works correctly with YAML metadata provided."
         website_url = 'https://pbanaszkiewicz.github.io/workshop'
         repo_url = ('https://raw.githubusercontent.com/pbanaszkiewicz/'
                     'workshop/gh-pages/index.html')
         mock.get(website_url, text='', status_code=200)
         mock.get(repo_url, text=self.yaml_content, status_code=200)
-        metadata = fetch_event_metadata(website_url)
+        metadata = fetch_workshop_metadata(website_url)
         self.assertEqual(metadata['slug'], 'workshop')
 
     @requests_mock.Mocker()
     def test_fetching_event_metadata_timeout(self, mock):
-        "Ensure 'fetch_event_metadata' reacts to timeout."
+        "Ensure 'fetch_workshop_metadata' reacts to timeout."
         website_url = 'https://pbanaszkiewicz.github.io/workshop'
         repo_url = ('https://raw.githubusercontent.com/pbanaszkiewicz/'
                     'workshop/gh-pages/index.html')
@@ -118,7 +118,7 @@ Other content.
             exc=requests.exceptions.ConnectTimeout,
         )
         with self.assertRaises(requests.exceptions.ConnectTimeout):
-            metadata = fetch_event_metadata(website_url)
+            metadata = fetch_workshop_metadata(website_url)
 
     def test_generating_url_to_index(self):
         tests = [
@@ -152,7 +152,7 @@ Other content.
             'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
             'eventbrite': '10000000',
         }
-        self.assertEqual(expected, find_metadata_on_event_homepage(content))
+        self.assertEqual(expected, find_workshop_YAML_metadata(content))
 
     def test_finding_metadata_on_website(self):
         content = self.html_content
@@ -171,7 +171,7 @@ Other content.
             'eventbrite': '10000000',
         }
 
-        self.assertEqual(expected, find_metadata_on_event_website(content))
+        self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
     def test_parsing_empty_metadata(self):
         empty_dict = {}
@@ -190,7 +190,7 @@ Other content.
             'helpers': [],
             'contact': '',
         }
-        self.assertEqual(expected, parse_metadata_from_event_website(empty_dict))
+        self.assertEqual(expected, parse_workshop_metadata(empty_dict))
 
     def test_parsing_correct_metadata(self):
         metadata = {
@@ -222,7 +222,7 @@ Other content.
             'helpers': ['Peter Parker', 'Tony Stark', 'Natasha Romanova'],
             'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
         }
-        self.assertEqual(expected, parse_metadata_from_event_website(metadata))
+        self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_country_language(self):
         """Ensure we always get a 2-char string or nothing."""
@@ -252,7 +252,7 @@ Other content.
                 metadata = dict(country=country, language=language)
                 expected['country'] = country_exp
                 expected['language'] = language_exp
-                self.assertEqual(expected, parse_metadata_from_event_website(metadata))
+                self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_dates(self):
         """Test if non-dates don't get parsed."""
@@ -281,7 +281,7 @@ Other content.
                 metadata = dict(startdate=startdate, enddate=enddate)
                 expected['start'] = start
                 expected['end'] = end
-                self.assertEqual(expected, parse_metadata_from_event_website(metadata))
+                self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_list_of_names(self):
         """Ensure we always get a list."""
@@ -315,7 +315,7 @@ Other content.
                 metadata = dict(instructor=instructor, helper=helper)
                 expected['instructors'] = instructors
                 expected['helpers'] = helpers
-                self.assertEqual(expected, parse_metadata_from_event_website(metadata))
+                self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_latitude_longitude(self):
         tests = [
@@ -345,7 +345,7 @@ Other content.
                 metadata = dict(latlng=latlng)
                 expected['latitude'] = latitude
                 expected['longitude'] = longitude
-                self.assertEqual(expected, parse_metadata_from_event_website(metadata))
+                self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_eventbrite_id(self):
         tests = [
@@ -372,7 +372,7 @@ Other content.
             with self.subTest(eventbrite_id=eventbrite_id):
                 metadata = dict(eventbrite=eventbrite_id)
                 expected['reg_key'] = reg_key
-                self.assertEqual(expected, parse_metadata_from_event_website(metadata))
+                self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_validating_invalid_metadata(self):
         metadata = {
@@ -389,14 +389,14 @@ Other content.
             'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
             'eventbrite': 'bigmoney',
         }
-        errors, warnings = validate_metadata_from_event_website(metadata)
+        errors, warnings = validate_workshop_metadata(metadata)
         assert len(errors) == 7
         assert not warnings
         assert all([error.startswith('Invalid value') for error in errors])
 
     def test_validating_missing_metadata(self):
         metadata = {}
-        errors, warnings = validate_metadata_from_event_website(metadata)
+        errors, warnings = validate_workshop_metadata(metadata)
         assert len(errors) == 9  # There are nine required fields
         assert len(warnings) == 3  # There are three optional fields
         assert all([issue.startswith('Missing')
@@ -419,7 +419,7 @@ Other content.
         }
         expected_errors = ['slug', 'startdate', 'country', 'latlng',
                            'instructor', 'helper', 'contact']
-        errors, warnings = validate_metadata_from_event_website(metadata)
+        errors, warnings = validate_workshop_metadata(metadata)
         assert not warnings
         for error, key in zip(errors, expected_errors):
             self.assertIn(key, error)
@@ -439,7 +439,7 @@ Other content.
             'helper': 'FIXME',
             'contact': 'FIXME',
         }
-        errors, warnings = validate_metadata_from_event_website(metadata)
+        errors, warnings = validate_workshop_metadata(metadata)
         assert len(errors) == 12
         assert not warnings
         assert all([
@@ -462,7 +462,7 @@ Other content.
             'helper': 'Peter Parker, Tony Stark, Natasha Romanova',
             'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
         }
-        errors, warnings = validate_metadata_from_event_website(metadata)
+        errors, warnings = validate_workshop_metadata(metadata)
         assert not warnings
         assert not errors
 
@@ -495,7 +495,7 @@ Other content.
                 metadata = dict(instructor=instructor, helper=helper)
                 expected['instructors'] = instructors
                 expected['helpers'] = helpers
-                self.assertEqual(expected, parse_metadata_from_event_website(metadata))
+                self.assertEqual(expected, parse_workshop_metadata(metadata))
 
 
 class TestAlternativeLatitudeLongitude(TestBase):
@@ -539,28 +539,28 @@ Other content.
         expected = {
             'latlng': '36.998977, -109.045173',
         }
-        self.assertEqual(expected, find_metadata_on_event_homepage(content))
+        self.assertEqual(expected, find_workshop_YAML_metadata(content))
 
         content = self.yaml_content_new
         expected = {
             'lat': '36.998977',
             'lng': '-109.045173',
         }
-        self.assertEqual(expected, find_metadata_on_event_homepage(content))
+        self.assertEqual(expected, find_workshop_YAML_metadata(content))
 
     def test_finding_metadata_on_website(self):
         content = self.html_content_old
         expected = {
             'latlng': '36.998977, -109.045173',
         }
-        self.assertEqual(expected, find_metadata_on_event_website(content))
+        self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
         content = self.html_content_new
         expected = {
             'lat': '36.998977',
             'lng': '-109.045173',
         }
-        self.assertEqual(expected, find_metadata_on_event_website(content))
+        self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
     def test_parsing_old_latlng(self):
         metadata = {
@@ -592,7 +592,7 @@ Other content.
             'helpers': ['Peter Parker', 'Tony Stark', 'Natasha Romanova'],
             'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
         }
-        self.assertEqual(expected, parse_metadata_from_event_website(metadata))
+        self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_new_latlng(self):
         metadata = {
@@ -625,7 +625,7 @@ Other content.
             'helpers': ['Peter Parker', 'Tony Stark', 'Natasha Romanova'],
             'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
         }
-        self.assertEqual(expected, parse_metadata_from_event_website(metadata))
+        self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_validating_old_latlng(self):
         """"""
@@ -643,7 +643,7 @@ Other content.
             'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
             'latlng': '36.998977, -109.045173',
         }
-        errors, warnings = validate_metadata_from_event_website(metadata)
+        errors, warnings = validate_workshop_metadata(metadata)
         self.assertEqual(errors, [])
         self.assertEqual(warnings, [])
 
@@ -664,7 +664,7 @@ Other content.
             'lat': '36.998977',
             'lng': '-109.045173',
         }
-        errors, warnings = validate_metadata_from_event_website(metadata)
+        errors, warnings = validate_workshop_metadata(metadata)
         self.assertEqual(errors, [])
         self.assertEqual(warnings, [])
 

--- a/amy/workshops/util.py
+++ b/amy/workshops/util.py
@@ -628,7 +628,7 @@ def fetch_workshop_metadata(event_url, timeout=5):
     # find metadata
     metadata = find_workshop_HTML_metadata(content)
 
-    if 'slug' not in metadata:
+    if not metadata:
         # there are no HTML metadata, so let's try the old method
         index_url, repository = generate_url_to_event_index(event_url)
 
@@ -701,11 +701,14 @@ def find_workshop_HTML_metadata(content):
     """Given website content, find and take <meta> metadata that have
     workshop-related data."""
 
-    R = r'<meta name="(?P<name>[\w-]+)" content="(?P<content>.+)" />$'
-    regexp = re.compile(R, re.M)
+    R = r'<meta\s+name="(?P<name>\w+?)"\s+content="(?P<content>.*?)"\s*?/?>'
+    regexp = re.compile(R, re.MULTILINE)
 
-    return {name: content for name, content in regexp.findall(content)
-            if name in ALLOWED_METADATA_NAMES}
+    return {
+        name: content
+        for name, content in regexp.findall(content)
+        if name in ALLOWED_METADATA_NAMES
+    }
 
 
 def parse_workshop_metadata(metadata):

--- a/amy/workshops/util.py
+++ b/amy/workshops/util.py
@@ -702,7 +702,7 @@ def find_workshop_HTML_metadata(content):
     workshop-related data."""
 
     R = r'<meta\s+name="(?P<name>\w+?)"\s+content="(?P<content>.*?)"\s*?/?>'
-    regexp = re.compile(R, re.MULTILINE)
+    regexp = re.compile(R)
 
     return {
         name: content

--- a/amy/workshops/util.py
+++ b/amy/workshops/util.py
@@ -617,16 +617,16 @@ def get_pagination_items(request, all_objects):
     return result
 
 
-def fetch_event_metadata(event_url, timeout=5):
-    """Handle metadata from any event site (works with rendered <meta> metadata and
-    YAML metadata in `index.html`)."""
+def fetch_workshop_metadata(event_url, timeout=5):
+    """Handle metadata from any event site (works with rendered <meta> tags
+    metadata or YAML metadata in `index.html`)."""
     # fetch page
     response = requests.get(event_url, timeout=timeout)
     response.raise_for_status()  # assert it's 200 OK
     content = response.text
 
     # find metadata
-    metadata = find_metadata_on_event_website(content)
+    metadata = find_workshop_HTML_metadata(content)
 
     if 'slug' not in metadata:
         # there are no HTML metadata, so let's try the old method
@@ -638,7 +638,7 @@ def fetch_event_metadata(event_url, timeout=5):
         if response.status_code == 200:
             # don't throw errors for pages we fall back to
             content = response.text
-            metadata = find_metadata_on_event_homepage(content)
+            metadata = find_workshop_YAML_metadata(content)
 
             # add 'slug' metadata if missing
             if 'slug' not in metadata:
@@ -671,14 +671,14 @@ def generate_url_to_event_index(website_url):
     raise WrongWorkshopURL()
 
 
-def find_metadata_on_event_homepage(content):
+def find_workshop_YAML_metadata(content):
     """Given workshop's raw `index.html`, find and take YAML metadata that
     have workshop-related data."""
     try:
         first, header, last = content.split('---')
         metadata = yaml.load(header.strip(), Loader=yaml.SafeLoader)
 
-        # get metadata to the form returned by `find_metadata_on_event_website`
+        # get metadata to the form returned by `find_workshop_HTML_metadata`
         # because YAML tries to interpret values from index's header
         filtered_metadata = {key: value for key, value in metadata.items()
                              if key in ALLOWED_METADATA_NAMES}
@@ -697,7 +697,7 @@ def find_metadata_on_event_homepage(content):
         return dict()
 
 
-def find_metadata_on_event_website(content):
+def find_workshop_HTML_metadata(content):
     """Given website content, find and take <meta> metadata that have
     workshop-related data."""
 
@@ -708,7 +708,7 @@ def find_metadata_on_event_website(content):
             if name in ALLOWED_METADATA_NAMES}
 
 
-def parse_metadata_from_event_website(metadata):
+def parse_workshop_metadata(metadata):
     """Simple preprocessing of the metadata from event website."""
     # no compatibility with old-style names
     country = metadata.get('country', '').upper()[0:2]
@@ -785,7 +785,7 @@ def parse_metadata_from_event_website(metadata):
     }
 
 
-def validate_metadata_from_event_website(metadata):
+def validate_workshop_metadata(metadata):
     errors = []
     warnings = []
 

--- a/amy/workshops/util.py
+++ b/amy/workshops/util.py
@@ -649,13 +649,13 @@ def fetch_workshop_metadata(event_url, timeout=5):
 
 
 class WrongWorkshopURL(ValueError):
-    """Raised when we fall back to reading metadata from event's YAML front matter,
-    which requires a link to GitHub raw hosted file, but we can't get that link
-    because provided URL doesn't match Event.WEBSITE_REGEX
+    """Raised when we fall back to reading metadata from event's YAML front
+    matter, which requires a link to GitHub raw hosted file, but we can't get
+    that link because provided URL doesn't match Event.WEBSITE_REGEX
     (see `generate_url_to_event_index` below)."""
 
     def __str__(self):
-        return 'Event\'s URL doesn\'t match Github website or repo format.'
+        return "Event's URL doesn't match Github website or repo format."
 
 
 def generate_url_to_event_index(website_url):

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -115,9 +115,9 @@ from workshops.util import (
     create_uploaded_persons_tasks,
     InternalError,
     WrongWorkshopURL,
-    fetch_event_metadata,
-    parse_metadata_from_event_website,
-    validate_metadata_from_event_website,
+    fetch_workshop_metadata,
+    parse_workshop_metadata,
+    validate_workshop_metadata,
     assignment_selection,
     get_pagination_items,
     failed_to_delete,
@@ -905,10 +905,10 @@ def validate_event(request, slug):
     warning_messages = []
 
     try:
-        metadata = fetch_event_metadata(page_url)
+        metadata = fetch_workshop_metadata(page_url)
         # validate metadata
         error_messages, warning_messages = \
-            validate_metadata_from_event_website(metadata)
+            validate_workshop_metadata(metadata)
 
     except WrongWorkshopURL as e:
         error_messages.append(str(e))
@@ -1086,9 +1086,9 @@ def event_import(request):
     url = request.GET.get('url', '').strip()
 
     try:
-        metadata = fetch_event_metadata(url)
+        metadata = fetch_workshop_metadata(url)
         # normalize the metadata
-        metadata = parse_metadata_from_event_website(metadata)
+        metadata = parse_workshop_metadata(metadata)
         return JsonResponse(metadata)
 
     except requests.exceptions.HTTPError as e:
@@ -1240,14 +1240,14 @@ def event_review_metadata_changes(request, slug):
         raise Http404('No event found matching the query.')
 
     try:
-        metadata = fetch_event_metadata(event.website_url)
+        metadata = fetch_workshop_metadata(event.website_url)
     except requests.exceptions.RequestException:
         messages.error(request, "There was an error while fetching event's "
                                 "website. Make sure the event has website URL "
                                 "provided, and that it's reachable.")
         return redirect(event.get_absolute_url())
 
-    metadata = parse_metadata_from_event_website(metadata)
+    metadata = parse_workshop_metadata(metadata)
 
     # save serialized metadata in session so in case of acceptance we don't
     # reload them


### PR DESCRIPTION
This PR responds to numerous issues raised over functionality of "import from URL" / "update from URL":

- #1572 
- #1610
- #1625 

The solution is to basically ignore the fact that `slug` is missing from websites (mostly because they're hosted outside GitHub). Instead, only when not a single tag is to be found in HTML, then the algorithm switches to YAML version, and if again nothing is found - an error is generated.

This slight change allow to import from URL from websites such as:
* https://pages.nist.gov/2020-05-29-nist/ (used in tests below)
* https://www.hpc.tntech.edu/workshop-2020-03-16/

You can access source code (CTRL+U in Firefox for Windows) and see that these website have a bunch of `<meta>` tags, but the one named `slug` is missing content.

Using first page as an example, I was able to import from URL when creating a new event (1) and when accepting a self-organised submission (2):

**1:**
![Screenshot_2020-03-29 AMY New event](https://user-images.githubusercontent.com/72821/77849520-7a755b80-71cc-11ea-8622-eca4f1810a9f.png)

**2:**
![Screenshot_2020-03-29 AMY](https://user-images.githubusercontent.com/72821/77849522-7ea17900-71cc-11ea-868a-1ab4d51dfa85.png)


Please note how in both cases the slug field, when empty, was highlighted red.

Closes #1572. Closes #1610. Closes #1625.