### PR TITLE
Regression fix: Instructors Over Time, badge not iterable

### DIFF
--- a/amy/api/filters.py
+++ b/amy/api/filters.py
@@ -88,7 +88,6 @@ class InstructorsOverTimeFilter(AMYFilterSet):
     badges = filters.ModelMultipleChoiceFilter(
         queryset=Badge.objects.instructor_badges(),
         label='Badges',
-        lookup_expr='in',
     )
     country = filters.MultipleChoiceFilter(
         choices=list(Countries()),


### PR DESCRIPTION
Due to wrong lookup type in `InstructorsOverTimeFilter`, an error
was present in API that prevented admins from looking up instructor
numbers with specific badges.
