### PR TITLE
PostWorkshopAction in "accept and create event" views

### DIFF
--- a/amy/extrequests/base_views.py
+++ b/amy/extrequests/base_views.py
@@ -1,0 +1,71 @@
+from django.core.exceptions import ImproperlyConfigured
+
+from workshops.base_views import AMYCreateView
+
+
+class AMYCreateAndFetchObjectView(AMYCreateView):
+    """AMY-based CreateView extended with fetching a different object based on
+    URL parameter."""
+
+    model_other = None
+    queryset_other = None
+    context_other_object_name = 'other_object'
+    pk_url_kwarg = 'pk'
+    slug_field = 'slug'
+    slug_url_kwarg = 'slug'
+    query_pk_and_slug = False
+
+    def __init__(self, *args, **kwargs):
+        """Initialize some internal vars."""
+        self.other_object = None
+        super().__init__(*args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        """Load other object upon GET request. Save the request."""
+        if self.other_object is None:
+            self.other_object = self.get_other_object()
+
+        self.request = request
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        """Load other object upon POST request. Save the request."""
+        if self.other_object is None:
+            self.other_object = self.get_other_object()
+
+        self.request = request
+        return super().post(request, *args, **kwargs)
+
+    def get_other_object(self, queryset=None):
+        """Similar to `get_object`, but uses other queryset."""
+        queryset = self.get_other_queryset()
+        return super().get_object(queryset=queryset)
+
+    def get_other_queryset(self):
+        """Similar to `get_queryset`, but uses other queryset/model."""
+        if self.queryset_other is None:
+            if self.other_model:
+                return self.model_other._default_manager.all()
+            else:
+                cls = self.__class__.__name__
+                raise ImproperlyConfigured(
+                    f"{cls} is missing a QuerySet. Define {cls}.model_other, "
+                    f"{cls}.queryset_other, or override "
+                    f"{cls}.get_other_queryset()."
+                )
+        return self.queryset_other.all()
+
+    def get_form_kwargs(self):
+        """Remove `instance` from form's parameters.
+
+        This is necessary because having `pk_url_kwarg` / `slug_url_kwarg`
+        makes this form into edit form."""
+        kwargs = super().get_form_kwargs()
+        if 'instance' in kwargs:
+            del kwargs['instance']
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        """Add other object to the template context."""
+        kwargs[self.context_other_object_name] = self.other_object
+        return super().get_context_data(**kwargs)

--- a/amy/extrequests/tests/test_selforganised_submissions.py
+++ b/amy/extrequests/tests/test_selforganised_submissions.py
@@ -9,6 +9,7 @@ from autoemails.tests.base import FakeRedisTestCaseMixin
 from extrequests.forms import SelfOrganisedSubmissionBaseForm
 from extrequests.models import SelfOrganisedSubmission
 import extrequests.views
+from workshops.forms import EventCreateForm
 from workshops.models import (
     Task,
     Role,
@@ -321,7 +322,6 @@ class TestSelfOrganisedSubmissionViews(TestBase):
             'slug': '2018-10-28-test-event',
             'host': Organization.objects.first().pk,
             'tags': [1],
-            'invoice_status': 'unknown',
         }
         rv = self.client.post(
             reverse('selforganisedsubmission_accept_event',
@@ -332,32 +332,7 @@ class TestSelfOrganisedSubmissionViews(TestBase):
                                .selforganisedsubmission
         self.assertEqual(request, self.sos1)
 
-    def test_lessons_shown_in_event_create_form(self):
-        """Ensure Mix&Match triggers "lessons" field on EventCreateForm."""
-        # self.sos1 has Mix&Match workshop type, so it should display "lessons"
-        # field in Event form
-        url = reverse('selforganisedsubmission_accept_event',
-                      args=[self.sos1.pk])
-        rv = self.client.get(url)
-        self.assertEqual(rv.status_code, 200)
-        self.assertIn(Curriculum.objects.get(mix_match=True),
-                      self.sos1.workshop_types.all())
-        self.assertIn("lessons", rv.context["form"].fields.keys())
-
-        # self.sos2 doesn't have Mix&Match workshop type, so it can't show
-        # "lessons" field in Event form
-        # but for tests we need a different status for that submission
-        self.sos2.state = "p"
-        self.sos2.save()
-        url = reverse('selforganisedsubmission_accept_event',
-                      args=[self.sos2.pk])
-        rv = self.client.get(url)
-        self.assertEqual(rv.status_code, 200)
-        self.assertNotIn(Curriculum.objects.get(mix_match=True),
-                         self.sos2.workshop_types.all())
-        self.assertNotIn("lessons", rv.context["form"].fields.keys())
-
-    def test_discarded_request_accepted_with_event(self):
+    def test_discarded_request_not_accepted_with_event(self):
         rv = self.client.get(reverse('selforganisedsubmission_accept_event',
                                      args=[self.sos2.pk]))
         self.assertEqual(rv.status_code, 404)
@@ -414,11 +389,75 @@ class TestSelfOrganisedSubmissionViews(TestBase):
         invalid = settings.TEMPLATES[0]['OPTIONS']['string_if_invalid']
         self.assertNotIn(invalid, rv.content.decode('utf-8'))
 
+
+class TestAcceptingSelfOrgSubmission(TestBase):
+    def setUp(self):
+        super().setUp()
+        self._setUpRoles()
+        self._setUpUsersAndLogin()
+
+        self.sos1 = SelfOrganisedSubmission.objects.create(
+            state="p", personal="Harry", family="Potter",
+            email="harry@hogwarts.edu",
+            institution=self.org_alpha,
+            institution_other_name="Hogwarts",
+            workshop_url='http://nonexistent-url/',
+            workshop_format='',
+            workshop_format_other='',
+            workshop_types_other_explain='',
+            language=Language.objects.get(name='English'),
+        )
+        self.sos1.workshop_types.set(Curriculum.objects.filter(mix_match=True))
+
+        self.url = reverse('selforganisedsubmission_accept_event',
+                           args=[self.sos1.pk])
+
+        self.sos2 = SelfOrganisedSubmission.objects.create(
+            state="d", personal="Harry", family="Potter",
+            email="harry@potter.com",
+            institution_other_name="Hogwarts",
+            workshop_url='',
+            workshop_format='',
+            workshop_format_other='',
+            workshop_types_other_explain='',
+            language=Language.objects.get(name='English'),
+        )
+        self.sos2.workshop_types.set(
+            Curriculum.objects.filter(mix_match=False, unknown=False,
+                                      other=False)[:1]
+        )
+        self.url2 = reverse('selforganisedsubmission_accept_event',
+                            args=[self.sos2.pk])
+
+    def test_page_context(self):
+        """Ensure proper objects render in the page."""
+        rv = self.client.get(self.url)
+        self.assertIn('form', rv.context)
+        self.assertIn('object', rv.context)  # this is our request
+        form = rv.context['form']
+        sos = rv.context['object']
+        self.assertEqual(sos, self.sos1)
+        self.assertTrue(isinstance(form, EventCreateForm))
+
+    def test_state_changed(self):
+        """Ensure request's state is changed after accepting."""
+        self.assertTrue(self.sos1.state == 'p')
+        data = {
+            'slug': '2018-10-28-test-event',
+            'host': Organization.objects.first().pk,
+            'tags': [1],
+        }
+        rv = self.client.post(self.url, data)
+        self.assertEqual(rv.status_code, 302)
+        self.sos1.refresh_from_db()
+        self.assertTrue(self.sos1.state == 'a')
+
     def test_host_task_created(self):
         """Ensure a host task is created when a person submitting already is in
         our database."""
 
-        # Harry matched as a submitted for self.sos1, and he has no tasks so far
+        # Harry matched as a submitted for self.sos1, and he has no tasks
+        # so far
         self.assertEqual(self.sos1.host(), self.harry)
         self.assertFalse(self.harry.task_set.all())
 
@@ -428,16 +467,34 @@ class TestSelfOrganisedSubmissionViews(TestBase):
             'host': Organization.objects.first().pk,
             'tags': [1],
         }
-        rv = self.client.post(
-            reverse('selforganisedsubmission_accept_event',
-                    args=[self.sos1.pk]),
-            data)
+        rv = self.client.post(self.url, data)
         self.assertEqual(rv.status_code, 302)
         event = Event.objects.get(slug='2019-08-18-test-event')
 
         # check if Harry gained a task
         Task.objects.get(person=self.harry, event=event,
                          role=Role.objects.get(name="host"))
+
+    def test_lessons_shown_in_event_create_form(self):
+        """Ensure Mix&Match triggers "lessons" field on EventCreateForm."""
+        # self.sos1 has Mix&Match workshop type, so it should display "lessons"
+        # field in Event form
+        rv = self.client.get(self.url)
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn(Curriculum.objects.get(mix_match=True),
+                      self.sos1.workshop_types.all())
+        self.assertIn("lessons", rv.context["form"].fields.keys())
+
+        # self.sos2 doesn't have Mix&Match workshop type, so it can't show
+        # "lessons" field in Event form
+        # but for tests we need a different status for that submission
+        self.sos2.state = "p"
+        self.sos2.save()
+        rv = self.client.get(self.url2)
+        self.assertEqual(rv.status_code, 200)
+        self.assertNotIn(Curriculum.objects.get(mix_match=True),
+                         self.sos2.workshop_types.all())
+        self.assertNotIn("lessons", rv.context["form"].fields.keys())
 
 
 class TestAcceptingSelfOrgSubmPrefilledform(TestBase):

--- a/amy/extrequests/tests/test_workshop_inquiries.py
+++ b/amy/extrequests/tests/test_workshop_inquiries.py
@@ -1,12 +1,16 @@
-import datetime
+from datetime import date, timedelta
 
 from django.conf import settings
 from django.urls import reverse
 
+from autoemails.models import Trigger, EmailTemplate, RQJob
+from autoemails.tests.base import FakeRedisTestCaseMixin
 from extrequests.forms import WorkshopInquiryRequestBaseForm
 from extrequests.models import WorkshopInquiryRequest, DataVariant
+import extrequests.views
 from workshops.forms import EventCreateForm
 from workshops.models import (
+    Tag,
     Task,
     Role,
     Event,
@@ -270,7 +274,7 @@ class TestWorkshopInquiryBaseForm(FormTestHelper, TestBase):
 
         # 2: either one present will work
         data = {
-            'preferred_dates': '{:%Y-%m-%d}'.format(datetime.date.today()),
+            'preferred_dates': '{:%Y-%m-%d}'.format(date.today()),
             'other_preferred_dates': '',
         }
         form = WorkshopInquiryRequestBaseForm(data)
@@ -296,7 +300,7 @@ class TestWorkshopInquiryBaseForm(FormTestHelper, TestBase):
 
         # 4: preferred date wrong format
         data = {
-            'preferred_dates': '{:%d-%m-%Y}'.format(datetime.date.today()),
+            'preferred_dates': '{:%d-%m-%Y}'.format(date.today()),
             'other_preferred_dates': '',
         }
         form = WorkshopInquiryRequestBaseForm(data)
@@ -571,3 +575,107 @@ class TestAcceptingWorkshopInquiry(TestBase):
         # check if Harry gained a task
         Task.objects.get(person=self.harry, event=event,
                          role=Role.objects.get(name="host"))
+
+
+class TestAcceptWorkshopInquiryAddsEmailAction(FakeRedisTestCaseMixin,
+                                               TestBase):
+    def setUp(self):
+        super().setUp()
+        self._setUpRoles()
+        self._setUpUsersAndLogin()
+        # we're missing some tags
+        Tag.objects.bulk_create([
+            Tag(name='SWC'),
+            Tag(name='DC'),
+            Tag(name='LC'),
+            Tag(name='TTT'),
+            Tag(name='automated-email'),
+        ])
+
+        self.wi1 = WorkshopInquiryRequest.objects.create(
+            state="p", personal="Harry", family="Potter",
+            email="harry@hogwarts.edu",
+            institution_other_name="Hogwarts",
+            institution_other_URL='hogwarts.uk',
+            location="Scotland", country="GB",
+            routine_data_other="",
+            domains_other="",
+            audience_description="Students of Hogwarts",
+            preferred_dates=None, other_preferred_dates="soon",
+            language=Language.objects.get(name='English'),
+            number_attendees='10-40',
+            administrative_fee='nonprofit',
+            travel_expences_management='booked',
+            travel_expences_management_other='',
+            travel_expences_agreement=True,
+            institution_restrictions='no_restrictions',
+            institution_restrictions_other='',
+            public_event='invite',
+            carpentries_info_source_other='',
+            user_notes='n/c',
+        )
+
+        template1 = EmailTemplate.objects.create(
+            slug='sample-template1',
+            subject='Welcome to {{ site.name }}',
+            to_header='recipient@address.com',
+            from_header='test@address.com',
+            cc_header='copy@example.org',
+            bcc_header='bcc@example.org',
+            reply_to_header='{{ reply_to }}',
+            body_template="Sample text.",
+        )
+        self.trigger1 = Trigger.objects.create(
+            action='week-after-workshop-completion',
+            template=template1,
+        )
+
+        self.url = reverse('workshopinquiry_accept_event',
+                           args=[self.wi1.pk])
+
+        # save scheduler and connection data
+        self._saved_scheduler = extrequests.views.scheduler
+        self._saved_redis_connection = extrequests.views.redis_connection
+        # overwrite them
+        extrequests.views.scheduler = self.scheduler
+        extrequests.views.redis_connection = self.connection
+
+    def tearDown(self):
+        super().tearDown()
+        extrequests.views.scheduler = self._saved_scheduler
+        extrequests.views.redis_connection = self._saved_redis_connection
+
+    def test_jobs_created(self):
+        data = {
+            'slug': 'xxxx-xx-xx-test-event',
+            'host': Organization.objects.first().pk,
+            'administrator': Organization.objects
+                                         .get(domain='self-organized').pk,
+            'start': date.today() + timedelta(days=7),
+            'end': date.today() + timedelta(days=8),
+            'tags': Tag.objects.filter(name__in=['automated-email', 'LC'])
+                       .values_list('pk', flat=True),
+        }
+
+        # no jobs scheduled
+        rqjobs_pre = RQJob.objects.all()
+        self.assertQuerysetEqual(rqjobs_pre, [])
+
+        # send data in
+        rv = self.client.post(self.url, data, follow=True)
+        self.assertEqual(rv.status_code, 200)
+        event = Event.objects.get(slug='xxxx-xx-xx-test-event')
+        request = event.workshopinquiryrequest
+        self.assertEqual(request, self.wi1)
+
+        # 1 job created
+        rqjobs_post = RQJob.objects.all()
+        self.assertEqual(len(rqjobs_post), 1)
+
+        # ensure the job ids are mentioned in the page output
+        content = rv.content.decode('utf-8')
+        for job in rqjobs_post:
+            self.assertIn(job.job_id, content)
+
+        # ensure the job is for PostWorkshopAction
+        rqjobs_post[0].trigger = self.trigger1

--- a/amy/extrequests/urls.py
+++ b/amy/extrequests/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
     path('workshop_request/<int:request_id>/', include([
         path('', views.WorkshopRequestDetails.as_view(), name='workshoprequest_details'),
         path('set_state/<slug:state>/', views.WorkshopRequestSetState.as_view(), name='workshoprequest_set_state'),
-        path('accept_event/', views.workshoprequest_accept_event, name='workshoprequest_accept_event'),
+        path('accept_event/', views.WorkshopRequestAcceptEvent.as_view(), name='workshoprequest_accept_event'),
         path('edit/', views.WorkshopRequestChange.as_view(), name='workshoprequest_edit'),
         path('assign/', views.WorkshopRequestAssign.as_view(), name='workshoprequest_assign'),
         path('assign/<int:person_id>/', views.WorkshopRequestAssign.as_view(), name='workshoprequest_assign'),
@@ -30,7 +30,7 @@ urlpatterns = [
     path('workshop_inquiry/<int:inquiry_id>/', include([
         path('', views.WorkshopInquiryDetails.as_view(), name='workshopinquiry_details'),
         path('set_state/<slug:state>/', views.WorkshopInquirySetState.as_view(), name='workshopinquiry_set_state'),
-        path('accept_event/', views.workshopinquiry_accept_event, name='workshopinquiry_accept_event'),
+        path('accept_event/', views.WorkshopInquiryAcceptEvent.as_view(), name='workshopinquiry_accept_event'),
         path('edit/', views.WorkshopInquiryChange.as_view(), name='workshopinquiry_edit'),
         path('assign/', views.WorkshopInquiryAssign.as_view(), name='workshopinquiry_assign'),
         path('assign/<int:person_id>/', views.WorkshopInquiryAssign.as_view(), name='workshopinquiry_assign'),
@@ -41,7 +41,7 @@ urlpatterns = [
     path('selforganised_submission/<int:submission_id>/', include([
         path('', views.SelfOrganisedSubmissionDetails.as_view(), name='selforganisedsubmission_details'),
         path('set_state/<slug:state>/', views.SelfOrganisedSubmissionSetState.as_view(), name='selforganisedsubmission_set_state'),
-        path('accept_event/', views.selforganisedsubmission_accept_event, name='selforganisedsubmission_accept_event'),
+        path('accept_event/', views.SelfOrganisedSubmissionAcceptEvent.as_view(), name='selforganisedsubmission_accept_event'),
         path('edit/', views.SelfOrganisedSubmissionChange.as_view(), name='selforganisedsubmission_edit'),
         path('assign/', views.SelfOrganisedSubmissionAssign.as_view(), name='selforganisedsubmission_assign'),
         path('assign/<int:person_id>/', views.SelfOrganisedSubmissionAssign.as_view(), name='selforganisedsubmission_assign'),

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -27,7 +27,10 @@ from django_countries import countries
 import django_rq
 from requests.exceptions import HTTPError, RequestException
 
-from autoemails.actions import SelfOrganisedRequestAction
+from autoemails.actions import (
+    SelfOrganisedRequestAction,
+    PostWorkshopAction,
+)
 from autoemails.base_views import ActionManageMixin
 from autoemails.models import Trigger
 from extrequests.base_views import AMYCreateAndFetchObjectView
@@ -188,6 +191,20 @@ class WorkshopRequestAcceptEvent(OnlyForAdminsMixin, PermissionRequiredMixin,
             Task.objects.create(event=event, person=person,
                                 role=Role.objects.get(name="host"))
 
+        if PostWorkshopAction.check(event):
+            objs = dict(event=event, request=wr)
+            jobs, rqjobs = ActionManageMixin.add(
+                action_class=PostWorkshopAction,
+                logger=logger,
+                scheduler=scheduler,
+                triggers=Trigger.objects.filter(
+                    active=True, action="week-after-workshop-completion",
+                ),
+                context_objects=objs,
+                object_=event,
+                request=self.request,
+            )
+
         wr.state = 'a'
         wr.event = event
         wr.save()
@@ -289,6 +306,20 @@ class WorkshopInquiryAcceptEvent(OnlyForAdminsMixin, PermissionRequiredMixin,
         if person:
             Task.objects.create(event=event, person=person,
                                 role=Role.objects.get(name="host"))
+
+        if PostWorkshopAction.check(event):
+            objs = dict(event=event, request=wr)
+            jobs, rqjobs = ActionManageMixin.add(
+                action_class=PostWorkshopAction,
+                logger=logger,
+                scheduler=scheduler,
+                triggers=Trigger.objects.filter(
+                    active=True, action="week-after-workshop-completion",
+                ),
+                context_objects=objs,
+                object_=event,
+                request=self.request,
+            )
 
         wr.state = 'a'
         wr.event = event
@@ -469,6 +500,20 @@ class SelfOrganisedSubmissionAcceptEvent(OnlyForAdminsMixin,
                 scheduler=scheduler,
                 triggers=Trigger.objects.filter(
                     active=True, action="self-organised-request-form"
+                ),
+                context_objects=objs,
+                object_=event,
+                request=self.request,
+            )
+
+        if PostWorkshopAction.check(event):
+            objs = dict(event=event, request=wr)
+            jobs, rqjobs = ActionManageMixin.add(
+                action_class=PostWorkshopAction,
+                logger=logger,
+                scheduler=scheduler,
+                triggers=Trigger.objects.filter(
+                    active=True, action="week-after-workshop-completion",
                 ),
                 context_objects=objs,
                 object_=event,

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -10,9 +10,7 @@ from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.mixins import (
     PermissionRequiredMixin,
 )
-from django.core.exceptions import (
-    ObjectDoesNotExist,
-)
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import (
     IntegrityError,
     transaction,
@@ -22,6 +20,7 @@ from django.db.models import (
     Q,
     ProtectedError,
 )
+from django.http import Http404
 from django.shortcuts import redirect, render, get_object_or_404
 from django.urls import reverse
 from django_countries import countries
@@ -31,6 +30,7 @@ from requests.exceptions import HTTPError, RequestException
 from autoemails.actions import SelfOrganisedRequestAction
 from autoemails.base_views import ActionManageMixin
 from autoemails.models import Trigger
+from extrequests.base_views import AMYCreateAndFetchObjectView
 from extrequests.filters import (
     TrainingRequestFilter,
     WorkshopRequestFilter,
@@ -68,6 +68,7 @@ from workshops.forms import (
     EventCreateForm,
 )
 from workshops.models import (
+    Event,
     TrainingRequest,
     WorkshopRequest,
     Tag,
@@ -157,43 +158,40 @@ class WorkshopRequestSetState(OnlyForAdminsMixin, ChangeRequestStateView):
     permanent = False
 
 
-@admin_required
-@permission_required(['workshops.change_workshoprequest',
-                      'workshops.add_event'],
-                     raise_exception=True)
-def workshoprequest_accept_event(request, request_id):
-    """Accept event request by creating a new event."""
-    wr = get_object_or_404(WorkshopRequest, state='p', pk=request_id)
+class WorkshopRequestAcceptEvent(OnlyForAdminsMixin, PermissionRequiredMixin,
+                                 AMYCreateAndFetchObjectView):
+    permission_required = ['workshops.change_workshoprequest',
+                           'workshops.add_event']
+    model = Event
+    form_class = EventCreateForm
+    template_name = 'requests/workshoprequest_accept_event.html'
 
-    if request.method == 'POST':
-        form = EventCreateForm(request.POST)
+    queryset_other = WorkshopRequest.objects.filter(state='p')
+    context_other_object_name = 'object'
+    pk_url_kwarg = 'request_id'
 
-        if form.is_valid():
-            event = form.save()
+    def get_context_data(self, **kwargs):
+        kwargs['title'] = "Accept and create a new event"
+        return super().get_context_data(**kwargs)
 
-            person = wr.host()
-            if person:
-                Task.objects.create(event=event, person=person,
-                                    role=Role.objects.get(name="host"))
+    def get_success_url(self):
+        return reverse('event_details', args=[self.object.slug])
 
-            wr.state = 'a'
-            wr.event = event
-            wr.save()
-            return redirect(reverse('event_details',
-                                    args=[event.slug]))
-        else:
-            messages.error(request, 'Fix errors below.')
+    def form_valid(self, form):
+        self.object = form.save()
 
-    else:
-        # non-POST request
-        form = EventCreateForm()
+        event = self.object
+        wr = self.other_object
 
-    context = {
-        'object': wr,
-        'form': form,
-    }
-    return render(request, 'requests/workshoprequest_accept_event.html',
-                  context)
+        person = wr.host()
+        if person:
+            Task.objects.create(event=event, person=person,
+                                role=Role.objects.get(name="host"))
+
+        wr.state = 'a'
+        wr.event = event
+        wr.save()
+        return super().form_valid(form)
 
 
 class WorkshopRequestAssign(OnlyForAdminsMixin, AssignView):
@@ -262,43 +260,40 @@ class WorkshopInquirySetState(OnlyForAdminsMixin, ChangeRequestStateView):
     permanent = False
 
 
-@admin_required
-@permission_required(['extrequests.change_workshopinquiryrequest',
-                      'workshops.add_event'],
-                     raise_exception=True)
-def workshopinquiry_accept_event(request, inquiry_id):
-    """Accept workshop inquiry by creating a new event."""
-    wr = get_object_or_404(WorkshopInquiryRequest, state='p', pk=inquiry_id)
+class WorkshopInquiryAcceptEvent(OnlyForAdminsMixin, PermissionRequiredMixin,
+                                 AMYCreateAndFetchObjectView):
+    permission_required = ['workshops.change_workshopinquiryrequest',
+                           'workshops.add_event']
+    model = Event
+    form_class = EventCreateForm
+    template_name = 'requests/workshopinquiry_accept_event.html'
 
-    if request.method == 'POST':
-        form = EventCreateForm(request.POST)
+    queryset_other = WorkshopInquiryRequest.objects.filter(state='p')
+    context_other_object_name = 'object'
+    pk_url_kwarg = 'inquiry_id'
 
-        if form.is_valid():
-            event = form.save()
+    def get_context_data(self, **kwargs):
+        kwargs['title'] = "Accept and create a new event"
+        return super().get_context_data(**kwargs)
 
-            person = wr.host()
-            if person:
-                Task.objects.create(event=event, person=person,
-                                    role=Role.objects.get(name="host"))
+    def get_success_url(self):
+        return reverse('event_details', args=[self.object.slug])
 
-            wr.state = 'a'
-            wr.event = event
-            wr.save()
-            return redirect(reverse('event_details',
-                                    args=[event.slug]))
-        else:
-            messages.error(request, 'Fix errors below.')
+    def form_valid(self, form):
+        self.object = form.save()
 
-    else:
-        # non-POST request
-        form = EventCreateForm()
+        event = self.object
+        wr = self.other_object
 
-    context = {
-        'object': wr,
-        'form': form,
-    }
-    return render(request, 'requests/workshopinquiry_accept_event.html',
-                  context)
+        person = wr.host()
+        if person:
+            Task.objects.create(event=event, person=person,
+                                role=Role.objects.get(name="host"))
+
+        wr.state = 'a'
+        wr.event = event
+        wr.save()
+        return super().form_valid(form)
 
 
 class WorkshopInquiryAssign(OnlyForAdminsMixin, AssignView):
@@ -371,65 +366,41 @@ class SelfOrganisedSubmissionSetState(OnlyForAdminsMixin,
     permanent = False
 
 
-@admin_required
-@permission_required(['extrequests.change_selforganisedsubmission',
-                      'workshops.add_event'],
-                     raise_exception=True)
-def selforganisedsubmission_accept_event(request, submission_id):
-    """Accept event request by creating a new event."""
-    wr = get_object_or_404(SelfOrganisedSubmission, state='p',
-                           pk=submission_id)
+class SelfOrganisedSubmissionAcceptEvent(OnlyForAdminsMixin,
+                                         PermissionRequiredMixin,
+                                         AMYCreateAndFetchObjectView):
+    permission_required = ['workshops.change_selforganisedsubmission',
+                           'workshops.add_event']
+    model = Event
+    form_class = EventCreateForm
+    template_name = 'requests/selforganisedsubmission_accept_event.html'
 
-    mix_match = wr.workshop_types.filter(mix_match=True).exists()
+    queryset_other = SelfOrganisedSubmission.objects.filter(state='p')
+    context_other_object_name = 'object'
+    pk_url_kwarg = 'submission_id'
 
-    FormClass = partial(
-        EventCreateForm,
-        show_lessons=mix_match,
-    )
+    def get_form_kwargs(self):
+        """Extend form kwargs with `initial` values.
 
-    if request.method == 'POST':
-        form = FormClass(request.POST)
+        The initial values are read from SelfOrganisedSubmission request
+        object, and from corresponding workshop page (if it's possible)."""
+        kwargs = super().get_form_kwargs()
 
-        if form.is_valid():
-            event = form.save()
+        mix_match = (
+            self.other_object.workshop_types.filter(mix_match=True).exists()
+        )
 
-            person = wr.host()
-            if person:
-                Task.objects.create(event=event, person=person,
-                                    role=Role.objects.get(name="host"))
+        kwargs['show_lessons'] = mix_match
 
-            wr.state = 'a'
-            wr.event = event
-            wr.save()
-
-            if SelfOrganisedRequestAction.check(event):
-                objs = dict(event=event, request=wr)
-                jobs, rqjobs = ActionManageMixin.add(
-                    action_class=SelfOrganisedRequestAction,
-                    logger=logger,
-                    scheduler=scheduler,
-                    triggers=Trigger.objects.filter(
-                        active=True, action="self-organised-request-form"
-                    ),
-                    context_objects=objs,
-                    object_=event,
-                    request=request,
-                )
-
-            return redirect(reverse('event_details',
-                                    args=[event.slug]))
-        else:
-            messages.error(request, 'Fix errors below.')
-
-    else:
-        # non-POST request
-        url = wr.workshop_url.strip()
+        url = self.other_object.workshop_url.strip()
         data = {
             'url': url,
-            'curricula': list(wr.workshop_types.all()),
-            'host': wr.host_organization() or wr.institution,
+            'curricula': list(self.other_object.workshop_types.all()),
+            'host': self.other_object.host_organization() or
+                self.other_object.institution,
             'administrator': Organization.objects.get(domain='self-organized'),
         }
+
         if mix_match:
             data['tags'] = [Tag.objects.get(name='Circuits')]
 
@@ -438,8 +409,9 @@ def selforganisedsubmission_accept_event(request, submission_id):
             parsed_data = parse_workshop_metadata(metadata)
         except (AttributeError, HTTPError, RequestException, WrongWorkshopURL):
             # ignore errors, but show warning instead
-            messages.warning(request, "Cannot automatically fill the form "
-                                      "from provided workshop URL.")
+            messages.warning(self.request,
+                             "Cannot automatically fill the form "
+                             "from provided workshop URL.")
         else:
             # keep working only if no exception occurred
             try:
@@ -447,33 +419,63 @@ def selforganisedsubmission_accept_event(request, submission_id):
                 parsed_data['language'] = Language.objects.get(subtag=lang)
             except (KeyError, ValueError, Language.DoesNotExist):
                 # ignore non-existing
-                messages.warning(request,
+                messages.warning(self.request,
                                  "Cannot automatically fill language.")
                 # it's easier to remove bad value than to leave
                 # 500 Server Error when the form is rendered
                 if 'language' in parsed_data:
                     del parsed_data['language']
 
-            # even if for some reason language doesn't exist, we can push
-            # an update
             data.update(parsed_data)
 
             if 'instructors' in data or 'helpers' in data:
                 instructors = data.get('instructors') or ['none']
                 helpers = data.get('helpers') or ['none']
-                data['comment'] = "Instructors: {}\n\nHelpers: {}" \
-                    .format(','.join(instructors), ','.join(helpers))
+                data['comment'] = (
+                    f"Instructors: {','.join(instructors)}\n\n"
+                    f"Helpers: {','.join(helpers)}"
+                )
 
-        # there's some data that we can push as initial for the form
-        form = FormClass(initial=data)
+        kwargs['initial'] = data
+        return kwargs
 
-    context = {
-        'object': wr,
-        'form': form,
-    }
-    return render(request,
-                  'requests/selforganisedsubmission_accept_event.html',
-                  context)
+    def get_context_data(self, **kwargs):
+        kwargs['title'] = "Accept and create a new event"
+        return super().get_context_data(**kwargs)
+
+    def get_success_url(self):
+        return reverse('event_details', args=[self.object.slug])
+
+    def form_valid(self, form):
+        self.object = form.save()
+
+        event = self.object
+        wr = self.other_object
+
+        person = wr.host()
+        if person:
+            Task.objects.create(event=event, person=person,
+                                role=Role.objects.get(name="host"))
+
+        wr.state = 'a'
+        wr.event = event
+        wr.save()
+
+        if SelfOrganisedRequestAction.check(event):
+            objs = dict(event=event, request=wr)
+            jobs, rqjobs = ActionManageMixin.add(
+                action_class=SelfOrganisedRequestAction,
+                logger=logger,
+                scheduler=scheduler,
+                triggers=Trigger.objects.filter(
+                    active=True, action="self-organised-request-form"
+                ),
+                context_objects=objs,
+                object_=event,
+                request=self.request,
+            )
+
+        return super().form_valid(form)
 
 
 class SelfOrganisedSubmissionAssign(OnlyForAdminsMixin, AssignView):

--- a/amy/workshops/base_views.py
+++ b/amy/workshops/base_views.py
@@ -65,24 +65,25 @@ class AMYCreateView(SuccessMessageMixin, FormInvalidMessageMixin, CreateView):
 
     template_name = 'generic_form.html'
 
-    def get_context_data(self, **kwargs):
-        context = super(AMYCreateView, self).get_context_data(**kwargs)
-
-        # self.model is available in CreateView as the model class being
-        # used to create new model instance
-        context['model'] = self.model
-
-        if self.model and issubclass(self.model, Model):
-            context['title'] = 'New {}'.format(self.model._meta.verbose_name)
-        else:
-            context['title'] = 'New object'
-
-        form = context['form']
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class=form_class)
         if not hasattr(form, 'helper'):
             # This is a default helper if no other is available.
             form.helper = BootstrapHelper(submit_label='Add')
+        return form
 
-        return context
+    def get_context_data(self, **kwargs):
+        # self.model is available in CreateView as the model class being
+        # used to create new model instance
+        kwargs['model'] = self.model
+
+        if 'title' not in kwargs:
+            if self.model and issubclass(self.model, Model):
+                kwargs['title'] = 'New {}'.format(self.model._meta.verbose_name)
+            else:
+                kwargs['title'] = 'New object'
+
+        return super().get_context_data(**kwargs)
 
     def get_success_message(self, cleaned_data):
         "Format self.success_message, used by messages framework from Django."
@@ -98,25 +99,26 @@ class AMYUpdateView(SuccessMessageMixin, UpdateView):
 
     template_name = 'generic_form.html'
 
-    def get_context_data(self, **kwargs):
-        context = super(AMYUpdateView, self).get_context_data(**kwargs)
-
-        # self.model is available in UpdateView as the model class being
-        # used to update model instance
-        context['model'] = self.model
-
-        context['view'] = self
-
-        # self.object is available in UpdateView as the object being currently
-        # edited
-        context['title'] = str(self.object)
-
-        form = context['form']
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class=form_class)
         if not hasattr(form, 'helper'):
             # This is a default helper if no other is available.
             form.helper = BootstrapHelper(submit_label='Update')
+        return form
 
-        return context
+    def get_context_data(self, **kwargs):
+        # self.model is available in UpdateView as the model class being
+        # used to update model instance
+        kwargs['model'] = self.model
+
+        kwargs['view'] = self
+
+        # self.object is available in UpdateView as the object being currently
+        # edited
+        if 'title' not in kwargs:
+            kwargs['title'] = str(self.object)
+
+        return super().get_context_data(**kwargs)
 
     def get_success_message(self, cleaned_data):
         "Format self.success_message, used by messages framework from Django."


### PR DESCRIPTION
This PR refactors and extends "accept and create event" views:

* `workshoprequest_accept_event` -> `WorkshopRequestAcceptEvent` (CBV)
* `workshopinquiry_accept_event` -> `WorkshopInquiryAcceptEvent` (CBV)
* `selforganisedsubmission_accept_event` -> `SelfOrganisedSubmissionAcceptEvent` (CBV)

All three new views share the same base view (new) `AMYCreateAndFetchObjectView`.

Tests were added for:
* accepting event behaviour
* creating `PostWorkshopAction`