### PR TITLE
Add instructors to PostWorkshopAction context

### DIFF
--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -361,11 +361,17 @@ class PostWorkshopAction(BaseAction):
             list(match_notification_email(event))
 
         # to get only people from the task set
+        context['instructors'] = list(
+            Person.objects.filter(
+                task__in=event.task_set.filter(role__name='instructor')
+            )
+        )
         context['helpers'] = list(
             Person.objects.filter(
                 task__in=event.task_set.filter(role__name='helper')
             )
         )
+
         # querying over Person.objects lets us get rid of duplicates
         context['all_emails'] = list(
             Person.objects.filter(

--- a/amy/autoemails/tests/test_postworkshopaction.py
+++ b/amy/autoemails/tests/test_postworkshopaction.py
@@ -194,6 +194,7 @@ class TestPostWorkshopAction(TestCase):
                 dates=e.human_readable_date,
                 host=Organization.objects.first(),
                 regional_coordinator_email=['admin-uk@carpentries.org'],
+                instructors=[p2],
                 helpers=[p1, p3],
                 all_emails=['hg@magic.uk', 'hp@magic.uk'],
                 assignee='Regional Coordinator',


### PR DESCRIPTION
List of event-associated instructors will be available in templates
under `instructors`.
