### PR TITLE
Add ?next= param for GitHub login

### DIFF
--- a/amy/templates/account/login.html
+++ b/amy/templates/account/login.html
@@ -31,7 +31,7 @@
 
       <div class="col-12 col-md-5">
         <h4>For The Carpentries Instructors</h4>
-        <p><a class="btn btn-primary w-100" href="/login/github/"><i class="fab fa-github"></i> Log in with your GitHub account</a></p>
+        <p><a class="btn btn-primary w-100" href="{% url 'social:begin' 'github' %}{% if next %}?next={{ next }}{% endif %}"><i class="fab fa-github"></i> Log in with your GitHub account</a></p>
         <p>Having trouble logging in? Contact us at <a href="mailto:team@carpentries.org">team@carpentries.org</a>.</p>
       </div>
     </div>


### PR DESCRIPTION
This fixes #1640 by adding `?next=/asd` query for GitHub login button.
It will redirect to pointed resource after successful log in.
