### PR TITLE
Add list of event tags to email body

### DIFF
--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -291,6 +291,7 @@ class NewInstructorAction(BaseAction):
         context["assignee"] = (
             event.assigned_to.full_name if event.assigned_to else "Regional Coordinator"
         )
+        context["tags"] = list(event.tags.values_list("name", flat=True))
 
         return context
 
@@ -443,6 +444,7 @@ class PostWorkshopAction(BaseAction):
         )
 
         context["reports_link"] = reports_link(event.slug)
+        context["tags"] = list(event.tags.values_list("name", flat=True))
 
         return context
 
@@ -558,5 +560,6 @@ class SelfOrganisedRequestAction(BaseAction):
         context["assignee"] = (
             event.assigned_to.full_name if event.assigned_to else "Regional Coordinator"
         )
+        context["tags"] = list(event.tags.values_list("name", flat=True))
 
         return context

--- a/amy/autoemails/tests/test_newinstructoraction.py
+++ b/amy/autoemails/tests/test_newinstructoraction.py
@@ -181,6 +181,7 @@ class TestNewInstructorAction(TestCase):
                 role=r,
                 task=t,
                 assignee="Regional Coordinator",
+                tags=['SWC'],
             ),
         )
 

--- a/amy/autoemails/tests/test_postworkshopaction.py
+++ b/amy/autoemails/tests/test_postworkshopaction.py
@@ -204,6 +204,7 @@ class TestPostWorkshopAction(TestCase):
                 all_emails=["hg@magic.uk", "hp@magic.uk"],
                 assignee="Regional Coordinator",
                 reports_link="https://workshop-reports.carpentries.org/?key=e18dd84d093be5cd6c6ccaf63d38a8477ca126f4&slug=test-event",
+                tags=['SWC', 'TTT'],
             ),
         )
 

--- a/amy/autoemails/tests/test_selforganisedrequestaction.py
+++ b/amy/autoemails/tests/test_selforganisedrequestaction.py
@@ -180,6 +180,7 @@ class TestSelfOrganisedRequestAction(TestCase):
                 short_notice=True,
                 all_emails=["harry@hogwarts.edu", "hg@magic.uk", "rw@magic.uk"],
                 assignee="Regional Coordinator",
+                tags=['LC', 'automated-email', 'Circuits'],
             ),
         )
 


### PR DESCRIPTION
This fixes #1647 by adding list of tags to each Action email context.
Tests were adjusted.

It's now possible to do:

```django
{% if "online" in tags %}
...
{% endif %}
```