### PR TITLE
Fix Select2TagWidget error when value is empty list

### DIFF
--- a/amy/workshops/fields.py
+++ b/amy/workshops/fields.py
@@ -190,7 +190,11 @@ class Select2TagWidget(Select2BootstrapMixin, DS2_Select2TagWidget):
     def optgroups(self, name, value, attrs=None):
         """Example from
         https://django-select2.readthedocs.io/en/latest/django_select2.html#django_select2.forms.Select2TagWidget"""
-        values = value[0].split(TAG_SEPARATOR) if value[0] else []
+        try:
+            values = value[0].split(TAG_SEPARATOR)
+        except (IndexError, AttributeError):
+            values = []
+
         selected = set(values)
         subgroup = [
             self.create_option(name, v, v, selected, i)

--- a/amy/workshops/tests/test_fields.py
+++ b/amy/workshops/tests/test_fields.py
@@ -1,28 +1,28 @@
 from django.core.exceptions import ValidationError
 
 from workshops.tests.base import TestBase
-from workshops.fields import NullableGithubUsernameField
+from workshops.fields import NullableGithubUsernameField, Select2TagWidget
 
 
 class TestNullableGHUsernameField(TestBase):
     def setUp(self):
         self.passing = [
-            'harrypotter',
-            'hp',
-            'hpotter',
-            'harry-potter',
-            'harry-potter123',
-            'Harry-Potter',
-            '',
+            "harrypotter",
+            "hp",
+            "hpotter",
+            "harry-potter",
+            "harry-potter123",
+            "Harry-Potter",
+            "",
             None,
         ]
 
         self.failing = [
-            'harry_potter',
-            'harry--potter',
-            '-harry',
-            'potter-',
-            'harry-averyveryverylongmiddlename-potter',
+            "harry_potter",
+            "harry--potter",
+            "-harry",
+            "potter-",
+            "harry-averyveryverylongmiddlename-potter",
         ]
 
         self.field = NullableGithubUsernameField()
@@ -37,3 +37,30 @@ class TestNullableGHUsernameField(TestBase):
         for username in self.failing:
             with self.assertRaises(ValidationError):
                 self.field.run_validators(username)
+
+
+class TestSelect2TagWidget(TestBase):
+    def setUp(self):
+        self.widget = Select2TagWidget()
+
+    def test_optgroups(self):
+        # incorrect input
+        self.assertEqual(self.widget.optgroups("name", []), [(None, [], 0)])
+
+        # correct input (1 value)
+        option1 = self.widget.create_option("name", "Harry", "Harry", set(["Harry"]), 0)
+        self.assertEqual(
+            self.widget.optgroups("name", ["Harry"]), [(None, [option1], 0,)],
+        )
+
+        # correct input (2 values)
+        option1 = self.widget.create_option(
+            "name", "Harry", "Harry", set(["Harry", "Ron"]), 0
+        )
+        option2 = self.widget.create_option(
+            "name", "Ron", "Ron", set(["Harry", "Ron"]), 1
+        )
+        self.assertEqual(
+            self.widget.optgroups("name", ["Harry;Ron"]),
+            [(None, [option1, option2], 0,)],
+        )


### PR DESCRIPTION
This fixes #1651 by working around the issue of empty
list as an argument to `Select2TagWidget.optgroups()`.