### PR TITLE
Add form prefixes to Award create and Task create forms

### DIFF
--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -894,9 +894,6 @@ class PersonsMergeForm(forms.Form):
 
 
 class AwardForm(WidgetOverrideMixin, forms.ModelForm):
-
-    helper = BootstrapHelper(add_cancel_button=False)
-
     class Meta:
         model = Award
         fields = '__all__'
@@ -908,6 +905,11 @@ class AwardForm(WidgetOverrideMixin, forms.ModelForm):
             'awarded_by': ModelSelect2Widget(data_view='admin-lookup',
                                              attrs=SELECT2_SIDEBAR),
         }
+
+    def __init__(self, *args, **kwargs):
+        form_tag = kwargs.pop('form_tag', True)
+        super().__init__(*args, **kwargs)
+        self.helper = BootstrapHelper(add_cancel_button=False, form_tag=form_tag)
 
 
 class EventLookupForm(forms.Form):

--- a/amy/workshops/tests/test_badge.py
+++ b/amy/workshops/tests/test_badge.py
@@ -40,8 +40,8 @@ class TestBadge(TestBase):
         )
         award_add = swc_badge.click('Award new', index=0)
         form = award_add.forms[2]
-        self.assertSelected(form['badge'], 'Software Carpentry Instructor')
-        form['person'].force_value(self.spiderman.id)
+        self.assertSelected(form['award-badge'], 'Software Carpentry Instructor')
+        form['award-person'].force_value(self.spiderman.id)
         assert self.swc_instructor.award_set.count() == 3
         form.submit()
         assert self.swc_instructor.award_set.count() == 4

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -593,9 +593,9 @@ class TestEventViews(TestBase):
         self.assertEqual(event.attendance, 0)
 
         data = {
-            'role': self.learner.pk,
-            'event': event.pk,
-            'person': self.spiderman.pk,
+            'task-role': self.learner.pk,
+            'task-event': event.pk,
+            'task-person': self.spiderman.pk,
         }
         self.client.post(reverse('task_add'), data)
 

--- a/amy/workshops/tests/test_person.py
+++ b/amy/workshops/tests/test_person.py
@@ -97,7 +97,7 @@ class TestPerson(TestBase):
         url = reverse('person_edit', args=[self.spiderman.pk])
         person_edit = self.app.get(url, user='admin')
         award_form = person_edit.forms[2]
-        award_form['badge'] = self.swc_instructor.pk
+        award_form['award-badge'] = self.swc_instructor.pk
 
         self.assertEqual(self.spiderman.award_set.count(), 0)
         self.assertRedirects(award_form.submit(), url)
@@ -111,9 +111,9 @@ class TestPerson(TestBase):
 
         url = reverse('person_edit', args=[self.spiderman.pk])
         person_edit = self.app.get(url, user='admin')
-        task_form = person_edit.forms[4]
-        task_form['event'].force_value(Event.objects.first().pk)
-        task_form['role'] = role.pk
+        task_form = person_edit.forms[3]
+        task_form['task-event'].force_value(Event.objects.first().pk)
+        task_form['task-role'] = role.pk
 
         self.assertEqual(self.spiderman.task_set.count(), 0)
         self.assertRedirects(task_form.submit(), url)
@@ -380,11 +380,11 @@ class TestPerson(TestBase):
 
         # Test workflow starting from clicking at "instructor badge" label
         swc_res = trainees.click('^<strike>instructor badge</strike>$')
-        self.assertSelected(swc_res.forms['main-form']['badge'],
+        self.assertSelected(swc_res.forms['main-form']['award-badge'],
                             '---------')
-        self.assertEqual(int(swc_res.forms['main-form']['event'].value),
+        self.assertEqual(int(swc_res.forms['main-form']['award-event'].value),
                          training.pk)
-        swc_res.forms['main-form']['badge'].select(self.swc_instructor.pk)
+        swc_res.forms['main-form']['award-badge'].select(self.swc_instructor.pk)
         res = swc_res.forms['main-form'].submit()
         self.assertRedirects(res, reverse('all_trainees'))
         self.assertEqual(trainee.award_set.last().badge, self.swc_instructor)
@@ -395,11 +395,11 @@ class TestPerson(TestBase):
 
         # Test workflow starting from clicking at "instructor badge" label
         dc_res = trainees.click('^<strike>instructor badge</strike>$')
-        self.assertSelected(dc_res.forms['main-form']['badge'],
+        self.assertSelected(dc_res.forms['main-form']['award-badge'],
                             '---------')
-        self.assertEqual(int(dc_res.forms['main-form']['event'].value),
+        self.assertEqual(int(dc_res.forms['main-form']['award-event'].value),
                          training.pk)
-        dc_res.forms['main-form']['badge'].select(self.dc_instructor.pk)
+        dc_res.forms['main-form']['award-badge'].select(self.dc_instructor.pk)
         res = dc_res.forms['main-form'].submit()
         self.assertRedirects(res, reverse('all_trainees'))
         self.assertEqual(trainee.award_set.last().badge, self.dc_instructor)

--- a/amy/workshops/tests/test_tasks.py
+++ b/amy/workshops/tests/test_tasks.py
@@ -398,9 +398,9 @@ class TestTaskCreateAutoEmails(FakeRedisTestCaseMixin, SuperuserMixin,
 
         self.client.force_login(self.admin)
         data = {
-            'event': self.test_event_1.pk,
-            'person': self.test_person_1.pk,
-            'role': role.pk,
+            'task-event': self.test_event_1.pk,
+            'task-person': self.test_person_1.pk,
+            'task-role': role.pk,
         }
         response = self.client.post(reverse('task_add'), data, follow=True)
         # with open('test.html', 'w', encoding='utf-8') as f:
@@ -720,9 +720,9 @@ class TestTaskDeleteAutoEmails(FakeRedisTestCaseMixin, SuperuserMixin,
 
         self.client.force_login(self.admin)
         data = {
-            'event': self.event_1.pk,
-            'person': self.person_1.pk,
-            'role': self.instructor.pk,
+            'task-event': self.event_1.pk,
+            'task-person': self.person_1.pk,
+            'task-role': self.instructor.pk,
         }
         response = self.client.post(reverse('task_add'), data, follow=True)
         self.assertContains(response, "New email was scheduled")

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -582,10 +582,10 @@ class PersonUpdate(OnlyForAdminsMixin, UserPassesTestMixin,
         context.update({
             'awards': self.object.award_set.select_related('event', 'badge')
                           .order_by('badge__name'),
-            'award_form': AwardForm(**kwargs),
             'tasks': self.object.task_set.select_related('role', 'event')
                          .order_by('-event__slug'),
-            'task_form': TaskForm(**kwargs),
+            'award_form': AwardForm(form_tag=False, prefix="award", **kwargs),
+            'task_form': TaskForm(form_tag=False, prefix="task", **kwargs),
         })
         return context
 
@@ -1363,6 +1363,13 @@ class TaskCreate(OnlyForAdminsMixin, PermissionRequiredMixin,
     model = Task
     form_class = TaskForm
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update({
+            'prefix': "task"
+        })
+        return kwargs
+
     def post(self, request, *args, **kwargs):
         """Save request in `self.request`."""
         self.request = request
@@ -1530,6 +1537,13 @@ class MockAwardCreate(OnlyForAdminsMixin, PermissionRequiredMixin,
     model = Award
     form_class = AwardForm
     populate_fields = ['badge', 'person']
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update({
+            'prefix': "award"
+        })
+        return kwargs
 
     def get_initial(self, **kwargs):
         initial = super().get_initial(**kwargs)


### PR DESCRIPTION
Prefixes added only in Person Update page.
Task Create and Award Create views updated with form prefix.

This fixes #1650 .