### PR TITLE
make Administrator field required

### DIFF
--- a/amy/extrequests/tests/test_dc_selforganized_event_requests.py
+++ b/amy/extrequests/tests/test_dc_selforganized_event_requests.py
@@ -61,6 +61,7 @@ class TestDCSelfOrganizedEventRequestForm(TestBase):
         minimal_event = {
             'slug': '2018-08-29-first-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [Tag.objects.first().pk],
             'invoice_status': 'not-invoiced',
         }

--- a/amy/extrequests/tests/test_event_requests.py
+++ b/amy/extrequests/tests/test_event_requests.py
@@ -139,6 +139,7 @@ class TestEventRequestsViews(TestBase):
         data = {
             'slug': '2016-06-30-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
             'invoice_status': 'unknown',
         }

--- a/amy/extrequests/tests/test_event_submissions.py
+++ b/amy/extrequests/tests/test_event_submissions.py
@@ -32,6 +32,7 @@ class TestEventSubmitForm(TestBase):
         minimal_event = {
             'slug': '1970-01-01-first-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [Tag.objects.first().pk],
             'invoice_status': 'not-invoiced',
         }

--- a/amy/extrequests/tests/test_selforganised_submissions.py
+++ b/amy/extrequests/tests/test_selforganised_submissions.py
@@ -321,6 +321,7 @@ class TestSelfOrganisedSubmissionViews(TestBase):
         data = {
             'slug': '2018-10-28-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
         }
         rv = self.client.post(
@@ -445,6 +446,7 @@ class TestAcceptingSelfOrgSubmission(TestBase):
         data = {
             'slug': '2018-10-28-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
         }
         rv = self.client.post(self.url, data)
@@ -465,6 +467,7 @@ class TestAcceptingSelfOrgSubmission(TestBase):
         data = {
             'slug': '2019-08-18-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
         }
         rv = self.client.post(self.url, data)

--- a/amy/extrequests/tests/test_workshop_inquiries.py
+++ b/amy/extrequests/tests/test_workshop_inquiries.py
@@ -430,6 +430,7 @@ class TestWorkshopInquiryViews(TestBase):
         data = {
             'slug': '2018-10-28-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
             'invoice_status': 'unknown',
         }
@@ -547,6 +548,7 @@ class TestAcceptingWorkshopInquiry(TestBase):
         data = {
             'slug': '2018-10-28-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
         }
         rv = self.client.post(self.url, data)
@@ -566,6 +568,7 @@ class TestAcceptingWorkshopInquiry(TestBase):
         data = {
             'slug': '2019-08-18-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
         }
         rv = self.client.post(self.url, data)

--- a/amy/extrequests/tests/test_workshop_requests.py
+++ b/amy/extrequests/tests/test_workshop_requests.py
@@ -373,6 +373,7 @@ class TestWorkshopRequestViews(TestBase):
         data = {
             'slug': '2018-10-28-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
             'invoice_status': 'unknown',
         }
@@ -483,6 +484,7 @@ class TestAcceptingWorkshopInquiry(TestBase):
         data = {
             'slug': '2018-10-28-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
         }
         rv = self.client.post(self.url, data)
@@ -502,6 +504,7 @@ class TestAcceptingWorkshopInquiry(TestBase):
         data = {
             'slug': '2019-08-18-test-event',
             'host': Organization.objects.first().pk,
+            'administrator': Organization.objects.administrators().first().id,
             'tags': [1],
         }
         rv = self.client.post(self.url, data)

--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -383,7 +383,7 @@ class EventForm(forms.ModelForm):
 
     administrator = forms.ModelChoiceField(
         label="Administrator",
-        required=False,
+        required=True,
         help_text=Event._meta.get_field("administrator").help_text,
         queryset=Organization.objects.administrators(),
         widget=ModelSelect2Widget(data_view="administrator-org-lookup"),

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -275,6 +275,7 @@ class TestEventFormComments(TestBase):
         data = {
             "slug": "2018-12-28-test-event",
             "host": self.org_alpha.id,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [self.test_tag.id],
             "comment": "",
         }
@@ -289,6 +290,7 @@ class TestEventFormComments(TestBase):
         data = {
             "slug": "2018-12-28-test-event",
             "host": self.org_alpha.id,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [self.test_tag.id],
             "comment": "This is a test comment.",
         }
@@ -464,6 +466,7 @@ class TestEventViews(TestBase):
         data = {
             "slug": "2016-07-09-test",
             "host": self.test_host.id,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [self.test_tag.id],
             "assigned_to": self.admin.pk,
             "invoice_status": "unknown",
@@ -494,6 +497,7 @@ class TestEventViews(TestBase):
         https://github.com/swcarpentry/amy/issues/436"""
         data = {
             "host": self.test_host.id,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [self.test_tag.id],
             "slug": "2016-06-30-test-event",
             "start": date(2015, 7, 20),
@@ -507,6 +511,7 @@ class TestEventViews(TestBase):
 
         data = {
             "host": self.test_host.id,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [self.test_tag.id],
             "slug": "2016-06-30-test-event",
             "start": date(2015, 7, 20),
@@ -518,6 +523,7 @@ class TestEventViews(TestBase):
 
         data = {
             "host": self.test_host.id,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [self.test_tag.id],
             "slug": "2016-06-30-test-event2",
             "start": date(2015, 7, 20),
@@ -540,6 +546,7 @@ class TestEventViews(TestBase):
 
         data = {
             "host": self.test_host.id,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [self.test_tag.id],
             "slug": "2016-06-30-test-event",
             "manual_attendance": -36,
@@ -570,6 +577,7 @@ class TestEventViews(TestBase):
         data = {
             "slug": "2016-06-30-test-event",
             "host": self.test_host.id,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [self.test_tag.id],
             "manual_attendance": "",
         }
@@ -662,6 +670,7 @@ class TestEventViews(TestBase):
         data = {
             "slug": "",
             "host": Organization.objects.all()[0].pk,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [Tag.objects.first().pk],
             "invoice_status": "unknown",
         }
@@ -707,6 +716,7 @@ class TestEventViews(TestBase):
         data = {
             "slug": "2018-09-02-open-applications",
             "host": self.org_alpha.pk,
+            "administrator": Organization.objects.administrators().first().id,
             "tags": [Tag.objects.get(name="SWC").pk],
             "invoice_status": "unknown",
             "open_TTT_applications": True,


### PR DESCRIPTION
This makes the Administrator field required.

The model still has `null=True, blank=True,`.
If we have historic data where we don't have Administrator I'm ok leaving those but moving ahead I want all future data to be one of the options available in the drop down.  @pbanaszkiewicz  Is there anything else that needs to be done for this? 