### PR TITLE
Revert removal of comment box for Event Update

### DIFF
--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -1067,7 +1067,7 @@ class EventUpdate(
         return context
 
     def get_form_class(self):
-        return partial(EventForm, show_lessons=True, add_comment=False)
+        return partial(EventForm, show_lessons=True, add_comment=True)
 
     def get_logger(self):
         return logger


### PR DESCRIPTION
This fixes #1653 by showing the comment box for event update.
The comment box will be used for automatic comment made by the "Update from URL"
function.
