### PR TITLE
Instructors-host introduction: adjustments for online events

### DIFF
--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -695,8 +695,13 @@ class InstructorsHostIntroductionAction(BaseAction):
         try:
             host = event.task_set.filter(role__name="host").first()
             instructors = event.task_set.filter(role__name="instructor")
+            supporting_instructors = event.task_set.filter(
+                role__name="supporting-instructor"
+            )
         except (Task.DoesNotExist, ValueError):
             return False
+
+        online = event.tags.filter(name="online")
 
         return bool(
             # is NOT self-organized
@@ -712,6 +717,7 @@ class InstructorsHostIntroductionAction(BaseAction):
             # roles: 1 host and 2+ instructors
             and host
             and len(instructors) >= 2
+            and (online and len(supporting_instructors) >= 2 or not online)
         )
 
     def get_additional_context(self, objects, *args, **kwargs):

--- a/amy/autoemails/tests/test_instructorshostintroductionaction.py
+++ b/amy/autoemails/tests/test_instructorshostintroductionaction.py
@@ -144,6 +144,23 @@ class TestInstructorsHostIntroductionAction(TestCase):
         )
         self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
 
+        # 8th case: for online require also 2 supporting instructors
+        e.tags.add(Tag.objects.get(name="online"))
+        self.assertEqual(InstructorsHostIntroductionAction.check(e), False)
+        Task.objects.create(
+            person=self.person4, role=self.supporting_instructor, event=e,
+        )
+        Task.objects.create(
+            person=self.person5, role=self.supporting_instructor, event=e,
+        )
+        self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
+
+        # 9th case: for online, more than 2 supporting instructors should still work
+        Task.objects.create(
+            person=self.person1, role=self.supporting_instructor, event=e,
+        )
+        self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
+
     def testContext(self):
         """Make sure `get_additional_context` works correctly."""
         a = InstructorsHostIntroductionAction(


### PR DESCRIPTION
This PR extends conditions for triggering action: for online
events, additionally two supporting instructors are required.
