### PR TITLE
Fix: Introduction email drops empty contacts from event

### DIFF
--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -760,7 +760,9 @@ class InstructorsHostIntroductionAction(BaseAction):
         except IndexError:
             context["supporting_instructor2"] = None
 
-        additional_contacts = [email for email in event.contact.split(TAG_SEPARATOR)]
+        additional_contacts = [
+            email for email in event.contact.split(TAG_SEPARATOR) if email
+        ]
         context["all_emails"] = [t.person.email for t in tasks] + additional_contacts
 
         context["assignee"] = (

--- a/amy/autoemails/tests/test_instructorshostintroductionaction.py
+++ b/amy/autoemails/tests/test_instructorshostintroductionaction.py
@@ -161,19 +161,12 @@ class TestInstructorsHostIntroductionAction(TestCase):
         )
         self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
 
-    def testContext(self):
-        """Make sure `get_additional_context` works correctly."""
+    def testContextEmptyContact(self):
+        """Make sure `get_additional_context` works correctly when contacts are empty
+        for the event."""
         a = InstructorsHostIntroductionAction(
             trigger=Trigger(action="test-action", template=EmailTemplate())
         )
-
-        # method fails when obligatory objects are missing
-        with self.assertRaises(KeyError):
-            a.get_additional_context(dict())  # missing 'event'
-        with self.assertRaises(AttributeError):
-            # now event is present, but the method tries to execute `refresh_from_db`
-            # on it
-            a.get_additional_context(dict(event="dummy"))
 
         # totally fake Event
         e = Event.objects.create(
@@ -182,7 +175,7 @@ class TestInstructorsHostIntroductionAction(TestCase):
             administrator=Organization.objects.get(domain="carpentries.org"),
             start=date.today() + timedelta(days=7),
             end=date.today() + timedelta(days=8),
-            contact=TAG_SEPARATOR.join(["test@hogwart.com", "test2@magic.uk"]),
+            contact="",
             country="GB",
         )
         e.tags.set(Tag.objects.filter(name__in=["LC", "automated-email"]))
@@ -220,8 +213,6 @@ class TestInstructorsHostIntroductionAction(TestCase):
                 "hg@magic.uk",
                 "peter@webslinger.net",
                 "me@stark.com",
-                "test@hogwart.com",
-                "test2@magic.uk",
             ],
             assignee="Regional Coordinator",
             tags=["LC", "automated-email"],


### PR DESCRIPTION
The fix simply removes empty email addresses, which was cause for MailGun
errors.
