### PR TITLE
Reduce required numer of supporting instructors for Introduction Email

### DIFF
--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -714,10 +714,10 @@ class InstructorsHostIntroductionAction(BaseAction):
             and not event.tags.filter(name__in=["cancelled", "unresponsive", "stalled"])
             # special "automated-email" tag
             and event.tags.filter(name__icontains="automated-email")
-            # roles: 1 host and 2+ instructors
+            # roles: 1 host and 2+ instructors, and perhaps 1+ supporting instr.
             and host
             and len(instructors) >= 2
-            and (online and len(supporting_instructors) >= 2 or not online)
+            and (online and len(supporting_instructors) >= 1 or not online)
         )
 
     def get_additional_context(self, objects, *args, **kwargs):
@@ -745,6 +745,8 @@ class InstructorsHostIntroductionAction(BaseAction):
         hosts = tasks.filter(role__name="host")
         instructors = tasks.filter(role__name="instructor")
         support = tasks.filter(role__name="supporting-instructor")
+        context["instructors"] = [instr.person for instr in instructors]
+        context["supporting_instructors"] = [instr.person for instr in support]
         context["host"] = hosts[0].person
         context["instructor1"] = instructors[0].person
         context["instructor2"] = instructors[1].person

--- a/amy/autoemails/tests/test_instructorshostintroductionaction.py
+++ b/amy/autoemails/tests/test_instructorshostintroductionaction.py
@@ -144,20 +144,17 @@ class TestInstructorsHostIntroductionAction(TestCase):
         )
         self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
 
-        # 8th case: for online require also 2 supporting instructors
+        # 8th case: for online require also 1 supporting instructor
         e.tags.add(Tag.objects.get(name="online"))
         self.assertEqual(InstructorsHostIntroductionAction.check(e), False)
         Task.objects.create(
             person=self.person4, role=self.supporting_instructor, event=e,
         )
-        Task.objects.create(
-            person=self.person5, role=self.supporting_instructor, event=e,
-        )
         self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
 
-        # 9th case: for online, more than 2 supporting instructors should still work
+        # 9th case: for online, more than 1 supporting instructors should still work
         Task.objects.create(
-            person=self.person1, role=self.supporting_instructor, event=e,
+            person=self.person5, role=self.supporting_instructor, event=e,
         )
         self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
 
@@ -210,8 +207,13 @@ class TestInstructorsHostIntroductionAction(TestCase):
             workshop_host=Organization.objects.first(),
             regional_coordinator_email=["admin-uk@carpentries.org"],
             host=host.person,
+            instructors=[instructor1.person, instructor2.person],
             instructor1=instructor1.person,
             instructor2=instructor2.person,
+            supporting_instructors=[
+                supporting_instructor1.person,
+                supporting_instructor2.person,
+            ],
             supporting_instructor1=supporting_instructor1.person,
             supporting_instructor2=supporting_instructor2.person,
             all_emails=[


### PR DESCRIPTION
This fixes #1680 by reducing number of required supporting instructors
to 1 in case of online events.

Additionally, list of instructors and supporting instructors is now included
in the email context.
