### PR TITLE
Add Circuits to PostWorkshopAction tag check list

### DIFF
--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -466,7 +466,7 @@ class PostWorkshopAction(BaseAction):
             # must have "automated-email" tag
             and event.tags.filter(name__icontains="automated-email")
             # must have LC, DC, or SWC tags
-            and event.tags.filter(name__in=["LC", "DC", "SWC"])
+            and event.tags.filter(name__in=["LC", "DC", "SWC", "Circuits"])
             # must not be self-organized or instructor training
             # 2020-02-11: only for workshops administered by other than
             #             Instructor Training

--- a/amy/autoemails/tests/test_postworkshopaction.py
+++ b/amy/autoemails/tests/test_postworkshopaction.py
@@ -143,6 +143,29 @@ class TestPostWorkshopAction(TestCase):
         e.administrator = Organization.objects.get(domain="librarycarpentry.org")
         self.assertEqual(PostWorkshopAction.check(e), True)
 
+    def testCheckConditionsCircuits(self):
+        """Make sure `check` works for "Circuits" workshops too."""
+        e = Event.objects.create(
+            slug="test-event",
+            host=Organization.objects.first(),
+            administrator=Organization.objects.get(domain="librarycarpentry.org"),
+            start=date.today() + timedelta(days=7),
+            end=date.today() + timedelta(days=8),
+        )
+        e.tags.set(Tag.objects.filter(name__in=["automated-email"]))
+        p = Person.objects.create(
+            personal="Harry", family="Potter", email="hp@magic.uk"
+        )
+        r = Role.objects.create(name="host")
+        Task.objects.create(event=e, person=p, role=r)
+
+        # 1st case: fail
+        self.assertEqual(PostWorkshopAction.check(e), False)
+
+        # 2nd case: success
+        e.tags.add(Tag.objects.get(name="Circuits"))
+        self.assertEqual(PostWorkshopAction.check(e), True)
+
     def testContext(self):
         """Make sure `get_additional_context` works correctly."""
         a = PostWorkshopAction(


### PR DESCRIPTION
This fixes #1681 by extending list of tags for triggering
Post Workshop action. Questions raised in the issue still remain.
