### PR TITLE
Use additional contacts in PostWorkshopAction

### DIFF
--- a/amy/autoemails/tests/test_postworkshopaction.py
+++ b/amy/autoemails/tests/test_postworkshopaction.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from autoemails.actions import PostWorkshopAction
 from autoemails.models import Trigger, EmailTemplate
+from workshops.fields import TAG_SEPARATOR
 from workshops.models import Task, Role, Person, Event, Tag, Organization
 
 
@@ -164,6 +165,8 @@ class TestPostWorkshopAction(TestCase):
             end=date.today() + timedelta(days=8),
             country="GB",
             venue="Ministry of Magic",
+            # additionally testing the empty email
+            contact=TAG_SEPARATOR.join(["peter@webslinger.net", ""])
         )
         e.tags.set(Tag.objects.filter(name__in=["TTT", "SWC"]))
         p1 = Person.objects.create(
@@ -208,7 +211,12 @@ class TestPostWorkshopAction(TestCase):
                 instructors=[p2],
                 supporting_instructors=[p4],
                 helpers=[p1, p3],
-                all_emails=["hg@magic.uk", "draco@malfoy.com", "hp@magic.uk"],
+                all_emails=[
+                    "hg@magic.uk",
+                    "draco@malfoy.com",
+                    "hp@magic.uk",
+                    "peter@webslinger.net",
+                ],
                 assignee="Regional Coordinator",
                 reports_link="https://workshop-reports.carpentries.org/"
                              "?key=e18dd84d093be5cd6c6ccaf63d38a8477ca126f4"


### PR DESCRIPTION
This fixes #1679 by using `event.contact` in PostWorkshopAction.

Additionally a condition for empty contact was added in one point in Introduction email action.