### PR TITLE
Dualfix: fix cancel error, fix double email for Introduction action

### DIFF
--- a/amy/autoemails/admin.py
+++ b/amy/autoemails/admin.py
@@ -12,10 +12,9 @@ from django.views.decorators.http import require_POST
 import django_rq
 from markdownx.widgets import AdminMarkdownxWidget
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
-from rq_scheduler.utils import from_unix
 
 from autoemails.forms import RescheduleForm, TemplateForm
+from autoemails.job import Job
 from autoemails.models import EmailTemplate, Trigger, RQJob
 from autoemails.utils import (
     check_status,

--- a/amy/autoemails/admin.py
+++ b/amy/autoemails/admin.py
@@ -367,6 +367,8 @@ class RQJobAdmin(admin.ModelAdmin):
         if job.is_queued or not job.get_status():
             job.cancel()  # for "pure" jobs
             scheduler.cancel(job)  # for scheduler-based jobs
+            rqjob.status = "cancelled"
+            rqjob.save()
 
             logger.debug(f"Job {rqjob.job_id} was cancelled.")
             messages.info(request, f"The job {rqjob.job_id} was cancelled.")

--- a/amy/autoemails/base_views.py
+++ b/amy/autoemails/base_views.py
@@ -2,8 +2,8 @@ from django.contrib import messages
 from django.urls import reverse
 from django.utils.html import format_html
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
 
+from autoemails.job import Job
 from autoemails.utils import (
     check_status,
     scheduled_execution_time,

--- a/amy/autoemails/tests/base.py
+++ b/amy/autoemails/tests/base.py
@@ -1,7 +1,8 @@
 import django_rq
 from fakeredis import FakeStrictRedis
-from redis import Redis
 from rq import Queue
+
+from autoemails.job import Job
 
 
 connection = FakeStrictRedis()
@@ -24,7 +25,7 @@ class FakeRedisTestCaseMixin:
         super().setUp()
         self.connection = connection
         # self.connection = Redis()
-        self.queue = Queue(is_async=False, connection=self.connection)
+        self.queue = Queue(is_async=False, connection=self.connection, job_class=Job)
         self.scheduler = django_rq.get_scheduler('testing', queue=self.queue)
         self.scheduler.connection = self.connection
 

--- a/amy/autoemails/tests/test_actionmanagemixin.py
+++ b/amy/autoemails/tests/test_actionmanagemixin.py
@@ -3,11 +3,11 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase, RequestFactory
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
 from rq_scheduler.utils import to_unix
 
 from autoemails.actions import NewInstructorAction
 from autoemails.base_views import ActionManageMixin
+from autoemails.job import Job
 from autoemails.models import EmailTemplate, Trigger, RQJob
 from autoemails.tests.base import FakeRedisTestCaseMixin, dummy_job
 from workshops.models import (

--- a/amy/autoemails/tests/test_admin_cancel.py
+++ b/amy/autoemails/tests/test_admin_cancel.py
@@ -148,6 +148,10 @@ class TestAdminJobCancel(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
                 )
             )
 
+        # job status updated
+        rqjob.refresh_from_db()
+        self.assertEqual(rqjob.status, "cancelled")
+
         # job data still available
         Job.fetch(rqjob.job_id, connection=self.scheduler.connection)
         # ...but nothing is scheduled

--- a/amy/autoemails/tests/test_admin_cancel.py
+++ b/amy/autoemails/tests/test_admin_cancel.py
@@ -1,14 +1,13 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.test import TestCase
 from django.urls import reverse
 from rq import Queue
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
-from rq_scheduler.utils import to_unix
 
 from autoemails import admin
 from autoemails.models import EmailTemplate, Trigger, RQJob
+from autoemails.job import Job
 from autoemails.tests.base import FakeRedisTestCaseMixin, dummy_job
 from workshops.tests.base import SuperuserMixin
 

--- a/amy/autoemails/tests/test_admin_edit_template.py
+++ b/amy/autoemails/tests/test_admin_edit_template.py
@@ -1,14 +1,13 @@
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, timedelta
 
 from django.test import TestCase
 from django.urls import reverse
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
-from rq_scheduler.utils import to_unix
 
 from autoemails import admin
 from autoemails.actions import NewInstructorAction
 from autoemails.models import EmailTemplate, Trigger, RQJob
+from autoemails.job import Job
 from autoemails.tests.base import FakeRedisTestCaseMixin, dummy_job
 from workshops.models import Event, Organization, Person, Role, Task
 from workshops.tests.base import SuperuserMixin
@@ -36,14 +35,15 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # test event and task
         LC_org = Organization.objects.create(domain="librarycarpentry.org",
                                              fullname="Library Carpentry")
-        self.event =Event.objects.create(
+        self.event = Event.objects.create(
             slug="test-event",
             host=Organization.objects.first(),
             administrator=LC_org,
             start=date.today() + timedelta(days=7),
             end=date.today() + timedelta(days=8),
         )
-        p = Person.objects.create(personal="Harry", family="Potter", email="hp@magic.uk")
+        p = Person.objects.create(personal="Harry", family="Potter",
+                                  email="hp@magic.uk")
         r = Role.objects.create(name="instructor")
         self.task = Task.objects.create(event=self.event, person=p, role=r)
 

--- a/amy/autoemails/tests/test_admin_reschedule.py
+++ b/amy/autoemails/tests/test_admin_reschedule.py
@@ -3,11 +3,11 @@ from datetime import datetime, timedelta, timezone
 from django.test import TestCase
 from django.urls import reverse
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
 from rq_scheduler.utils import to_unix
 
 from autoemails import admin
 from autoemails.models import EmailTemplate, Trigger, RQJob
+from autoemails.job import Job
 from autoemails.tests.base import FakeRedisTestCaseMixin, dummy_job
 from workshops.tests.base import SuperuserMixin
 

--- a/amy/autoemails/tests/test_admin_retry.py
+++ b/amy/autoemails/tests/test_admin_retry.py
@@ -1,14 +1,13 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.test import TestCase
 from django.urls import reverse
 from rq import Queue, SimpleWorker
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
-from rq_scheduler.utils import to_unix
 
 from autoemails import admin
 from autoemails.models import EmailTemplate, Trigger, RQJob
+from autoemails.job import Job
 from autoemails.tests.base import (
     FakeRedisTestCaseMixin,
     dummy_job,

--- a/amy/autoemails/tests/test_admin_sendnow.py
+++ b/amy/autoemails/tests/test_admin_sendnow.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timedelta
 
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.urls import reverse
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
 from rq_scheduler.utils import to_unix
 
 from autoemails import admin
 from autoemails.models import EmailTemplate, Trigger, RQJob
+from autoemails.job import Job
 from autoemails.tests.base import FakeRedisTestCaseMixin, dummy_job
 from workshops.tests.base import SuperuserMixin
 


### PR DESCRIPTION
This fixes #1693.

This also fixes a bug reported on Slack: two Introduction emails scheduled for single event.

Finally, this PR updates the RQJob status whenever it's cancelled.

More details in the comments.