### PR TITLE
replace travis-ci.org by travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](amy/static/amy-logo.png)
 
-![](https://travis-ci.org/carpentries/amy.svg?branch=master)
+![](https://travis-ci.com/carpentries/amy.svg?branch=master)
 [![](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
 [![](https://img.shields.io/badge/django-2.2+-blue.svg)](https://www.djangoproject.com/)
 [![](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENSE.md)


### PR DESCRIPTION
fix URL in travis badge