### PR TITLE
Change order of the conflicting migrations

### DIFF
--- a/amy/extrequests/migrations/0022_auto_20200615_1436.py
+++ b/amy/extrequests/migrations/0022_auto_20200615_1436.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('extrequests', '0020_auto_20200501_1822'),
+        ('extrequests', '0021_workshopinquiryrequest_instructor_availability'),
     ]
 
     operations = [

--- a/amy/workshops/migrations/0217_auto_20200615_1436.py
+++ b/amy/workshops/migrations/0217_auto_20200615_1436.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('workshops', '0213_auto_20200501_1822'),
+        ('workshops', '0216_workshoprequest_instructor_availability'),
     ]
 
     operations = [


### PR DESCRIPTION
This fixes conflicting migrations (instructor availability checkbox vs verbiage for number of attendees for both workshop requests and inquiry requests).