### PR TITLE
Supporting Instructor role count

### DIFF
--- a/amy/templates/workshops/person.html
+++ b/amy/templates/workshops/person.html
@@ -152,6 +152,7 @@
       <p>Summary:</p>
       <ul>
         <li>Instructor: {{ person.num_taught }} times</li>
+        <li>Supporting Instructor: {{ person.num_supporting }} times</li>        
         <li>Helper: {{ person.num_helper }} times</li>
         <li>Learner: {{ person.num_learner }} times</li>
       </ul>

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -247,6 +247,13 @@ class PersonDetails(OnlyForAdminsMixin, AMYDetailView):
                     output_field=IntegerField(),
                 )
             ),
+
+            num_supporting=Count(
+                Case(
+                    When(task__role__name="supporting-instructor", then=Value(1)),
+                    output_field=IntegerField(),
+                )
+            ),
         )
         .prefetch_related(
             "award_set__badge",


### PR DESCRIPTION
This fixes #1720  by adding "Supporting Instructor" to the role count for Instructor, Helper, and Learner.