### PR TITLE
Ask For Website + RecruitHelpers logic change

### DIFF
--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -985,7 +985,7 @@ class RecruitHelpersAction(BaseAction):
 
     @staticmethod
     def check(event: Event):
-        """Conditions for creating a AskForWebsiteAction."""
+        """Conditions for creating a RecruitHelpersAction."""
         hosts = event.task_set.filter(role__name="host")
         instructors = event.task_set.filter(role__name="instructor")
         helpers = event.task_set.filter(role__name="helper")

--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -868,9 +868,9 @@ class AskForWebsiteAction(BaseAction):
             and not event.tags.filter(name__in=["cancelled", "unresponsive", "stalled"])
             # must have "automated-email" tag
             and event.tags.filter(name__icontains="automated-email")
-            # must be self-organized
+            # must be self-organized or centrally-organised (ie. must have
+            # an administrator)
             and event.administrator
-            and event.administrator.domain == "self-organized"
             # cannot have a URL
             and not event.url
             # must have someone to send the email to

--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -1000,6 +1000,9 @@ class RecruitHelpersAction(BaseAction):
             and not event.tags.filter(name__in=["cancelled", "unresponsive", "stalled"])
             # must have "automated-email" tag
             and event.tags.filter(name__icontains="automated-email")
+            # must be centrally-organised
+            and event.administrator
+            and event.administrator.domain != "self-organized"
             # must have someone to send the email to
             and (len(instructors) >= 1 or len(hosts) >= 1)
             # can't have any helpers

--- a/amy/autoemails/tests/test_askforwebsiteaction.py
+++ b/amy/autoemails/tests/test_askforwebsiteaction.py
@@ -132,13 +132,13 @@ class TestAskForWebsiteAction(TestCase):
         # retest to make sure it's back to normal
         self.assertEqual(AskForWebsiteAction.check(e), True)
 
-        # 5th case: not self-organized
-        # result: FAIL
+        # 5th case: not self-organized (centrally-organised)
+        # result: OK
         e.administrator = Organization.objects.get(domain="carpentries.org")
         e.save()
-        self.assertEqual(AskForWebsiteAction.check(e), False)
+        self.assertEqual(AskForWebsiteAction.check(e), True)
 
-        # retest to make sure it's back to normal
+        # retest to make sure it stays the same
         e.administrator = Organization.objects.get(domain="self-organized")
         self.assertEqual(AskForWebsiteAction.check(e), True)
 

--- a/amy/autoemails/tests/test_recruithelpersaction.py
+++ b/amy/autoemails/tests/test_recruithelpersaction.py
@@ -107,6 +107,7 @@ class TestRecruitHelpersAction(TestCase):
             host=Organization.objects.first(),
             start=date.today() + timedelta(days=30),
             end=date.today() + timedelta(days=31),
+            administrator=Organization.objects.first(),
         )
         e.tags.set(Tag.objects.filter(name__in=["automated-email"]))
         Task.objects.bulk_create(
@@ -178,6 +179,18 @@ class TestRecruitHelpersAction(TestCase):
 
         # retest to make sure it's back to normal
         self.assertEqual(RecruitHelpersAction.check(e), True)
+
+        # 8th case: self-organised
+        # result: FAIL
+        e.administrator = Organization.objects.get(domain="self-organized")
+        e.save()
+        self.assertEqual(RecruitHelpersAction.check(e), False)
+        e.administrator = Organization.objects.first()
+        e.save()
+
+        # retest to make sure it's back to normal
+        self.assertEqual(RecruitHelpersAction.check(e), True)
+
 
     def testContext(self):
         """Make sure `get_additional_context` works correctly."""

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -2441,7 +2441,10 @@ class TestEventUpdateRecruitHelpers(
         self.host_role = Role.objects.create(name="host")
         self.instructor_role = Role.objects.create(name="instructor")
         self.helper_role = Role.objects.create(name="helper")
-        self.host_org = Organization.objects.first()
+        self.host_org = Organization.objects.create(
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
+        )
 
         self.instructor = Person.objects.create(
             personal="Hermione",
@@ -2637,7 +2640,10 @@ class TestEventDeleteRecruitHelpers(
         self.host_role = Role.objects.create(name="host")
         self.instructor_role = Role.objects.create(name="instructor")
         self.helper_role = Role.objects.create(name="helper")
-        self.host_org = Organization.objects.first()
+        self.host_org = Organization.objects.create(
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
+        )
 
         self.instructor = Person.objects.create(
             personal="Hermione",

--- a/amy/workshops/tests/test_tasks.py
+++ b/amy/workshops/tests/test_tasks.py
@@ -2052,7 +2052,10 @@ class TestTaskCreateRecruitHelpers(FakeRedisTestCaseMixin, SuperuserMixin, TestC
             username="weasley_ron",
         )
 
-        self.host_org = Organization.objects.first()
+        self.host_org = Organization.objects.create(
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
+        )
 
         self.test_event = Event.objects.create(
             slug="2020-08-18-test-event",
@@ -2232,7 +2235,10 @@ class TestTaskUpdateRecruitHelpers(FakeRedisTestCaseMixin, SuperuserMixin, TestC
             username="weasley_ron",
         )
 
-        self.host_org = Organization.objects.first()
+        self.host_org = Organization.objects.create(
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
+        )
 
         self.test_event = Event.objects.create(
             slug="2020-08-18-test-event",
@@ -2409,7 +2415,10 @@ class TestTaskDeleteRecruitHelpers(FakeRedisTestCaseMixin, SuperuserMixin, TestC
             username="weasley_ron",
         )
 
-        self.host_org = Organization.objects.first()
+        self.host_org = Organization.objects.create(
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
+        )
 
         self.test_event = Event.objects.create(
             slug="2020-08-18-test-event",


### PR DESCRIPTION
This PR fixes #1724 by adjusting the trigger logic for:

1. AskForWebsite: run for either self- or centrally-organised workshops
2. RecruitHelpers: don't run for self-organised workshops