### PR TITLE
Make accordion work in Django form

### DIFF
--- a/amy/extforms/forms.py
+++ b/amy/extforms/forms.py
@@ -92,9 +92,6 @@ class TrainingRequestForm(forms.ModelForm):
             initial['group_name'] = initial_group_name
             initial['review_process'] = 'preapproved'
         super().__init__(*args, initial=initial, **kwargs)
-        if initial_group_name is not None:
-            field = self.fields['group_name']
-            field.widget = field.hidden_widget()
 
         # set up a layout object for the helper
         self.helper.layout = self.helper.build_default_layout(self)

--- a/amy/extforms/tests/test_training_request_form.py
+++ b/amy/extforms/tests/test_training_request_form.py
@@ -143,8 +143,8 @@ class GroupNameFieldTestsBase(TestBase):
 class WhenGroupNameIsPrefilledIn(GroupNameFieldTestsBase):
     url_suffix = '?group=asdf qwer'
 
-    def test_then_the_group_name_field_should_be_not_displayed(self):
-        self.assertEqual(self.form['group_name'].attrs.get('type'), 'hidden')
+    def test_then_the_group_name_field_should_be_displayed(self):
+        self.assertNotEqual(self.form['group_name'].attrs.get('type'), 'hidden')
 
     def test_then_the_prefilled_in_value_should_be_used(self):
         self.fillin_and_submit()

--- a/amy/templates/bootstrap4/layout/radio-accordion.html
+++ b/amy/templates/bootstrap4/layout/radio-accordion.html
@@ -31,4 +31,9 @@
     </div>
     {% endfor %}
   </div>
+  {% for option in field %}
+    <script>
+      $('#collapse_{{ field.auto_id }}_{{ forloop.counter }}').collapse('{% if option.data.attrs.checked %}show{% else %}hide{% endif %}');
+    </script>
+  {% endfor %}
 </div>


### PR DESCRIPTION
fixes #1723 

The accordion worked fine when I copied the HTML into a JSFiddle. I noticed that triggering the "collapse" function in JavaScript allowed the accordion to work again.

It seems that the field was hidden intentionally for the pre-filled group name. I removed that in light of #1723. 

Hopefully I did this correctly!

Unfortunately, I'm not sure the best way to test for this behavior.