### PR TITLE
specify request form is for centrally org. wkshp

### DIFF
--- a/amy/templates/forms/workshop_landing.html
+++ b/amy/templates/forms/workshop_landing.html
@@ -24,7 +24,7 @@
         <a href="{% url 'workshop_inquiry' %}" class="btn btn-lg btn-primary">Request information about our workshops</a>
       </div>
       <div class="col-lg text-center my-3">
-        <a href="{% url 'workshop_request' %}" class="btn btn-lg btn-primary">Request a workshop</a>
+        <a href="{% url 'workshop_request' %}" class="btn btn-lg btn-primary">Request a centrally organised workshop</a>
       </div>
       <div class="col-lg text-center my-3">
         <a href="{% url 'selforganised_submission' %}" class="btn btn-lg btn-primary">Register a self-organised workshop</a><br>

--- a/amy/templates/forms/workshoprequest.html
+++ b/amy/templates/forms/workshoprequest.html
@@ -9,7 +9,7 @@
 {% block content %}
 
 <p class="lead">
-    Please fill out this form to request a Carpentries workshop. We will ask
+    Please fill out this form to request a centrally organised Carpentries workshop. We will ask
     you about dates, location and workshop type, so please plan to have this
     information available. If you would like more information about our
     workshops before scheduling, please


### PR DESCRIPTION
Fixes #1734 

Adds words "centrally organised" to the landing page button and to the intro text on the form itself.