### PR TITLE
Prefill WRF accept and create a new event form

### DIFF
--- a/amy/extrequests/base_views.py
+++ b/amy/extrequests/base_views.py
@@ -15,9 +15,7 @@ class WRFInitial:
         elif hasattr(self.other_object, "requested_workshop_types"):
             curricula = self.other_object.requested_workshop_types.all()
 
-        tag_names = [
-            C.carpentry for C in curricula if C.carpentry
-        ]
+        tag_names = [C.carpentry for C in curricula if C.carpentry]
         if curricula.filter(mix_match=True).exists():
             tag_names.append("Circuits")
         if self.other_object.online_inperson == "online":
@@ -67,10 +65,10 @@ class AMYCreateAndFetchObjectView(AMYCreateView):
 
     model_other = None
     queryset_other = None
-    context_other_object_name = 'other_object'
-    pk_url_kwarg = 'pk'
-    slug_field = 'slug'
-    slug_url_kwarg = 'slug'
+    context_other_object_name = "other_object"
+    pk_url_kwarg = "pk"
+    slug_field = "slug"
+    slug_url_kwarg = "slug"
     query_pk_and_slug = False
 
     def __init__(self, *args, **kwargs):
@@ -119,8 +117,8 @@ class AMYCreateAndFetchObjectView(AMYCreateView):
         This is necessary because having `pk_url_kwarg` / `slug_url_kwarg`
         makes this form into edit form."""
         kwargs = super().get_form_kwargs()
-        if 'instance' in kwargs:
-            del kwargs['instance']
+        if "instance" in kwargs:
+            del kwargs["instance"]
         return kwargs
 
     def get_context_data(self, **kwargs):

--- a/amy/extrequests/tests/test_selforganised_submissions.py
+++ b/amy/extrequests/tests/test_selforganised_submissions.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 
 from django.conf import settings
+from django.db.models import QuerySet
 from django.urls import reverse
 from requests_mock import Mocker
 
@@ -563,10 +564,10 @@ class TestAcceptingSelfOrgSubmPrefilledform(TestBase):
         expected = {
             # fields below are pre-filled without accessing the website
             "url": "http://nonexistent-url/",
-            "curricula": [Curriculum.objects.get(mix_match=True)],
+            "curricula": Curriculum.objects.filter(mix_match=True),
             "host": self.org_alpha,
             "administrator": Organization.objects.get(domain="self-organized"),
-            "tags": [Tag.objects.get(name="Circuits")],
+            "tags": Tag.objects.filter(name="Circuits"),
             # fields below can't get populated because the website doesn't
             # work
             "slug": None,
@@ -584,6 +585,9 @@ class TestAcceptingSelfOrgSubmPrefilledform(TestBase):
         }
         for key, value in expected.items():
             init = form[key].initial
+            if isinstance(value, QuerySet):
+                init = list(init)
+                value = list(value)
             self.assertEqual(init, value, f"Issue with {key}")
 
     @Mocker()
@@ -631,10 +635,10 @@ class TestAcceptingSelfOrgSubmPrefilledform(TestBase):
         expected = {
             # fields below are pre-filled without accessing the website
             "url": "http://nonexistent-url/",
-            "curricula": [Curriculum.objects.get(mix_match=True)],
+            "curricula": Curriculum.objects.filter(mix_match=True),
             "host": self.org_alpha,
             "administrator": Organization.objects.get(domain="self-organized"),
-            "tags": [Tag.objects.get(name="Circuits")],
+            "tags": Tag.objects.filter(name="Circuits"),
             # fields below are pre-filled from the website meta tags
             "slug": "2020-04-04-test",
             "language": Language.objects.get(subtag="en"),
@@ -652,6 +656,9 @@ class TestAcceptingSelfOrgSubmPrefilledform(TestBase):
         }
         for key, value in expected.items():
             init = form[key].initial
+            if isinstance(value, QuerySet):
+                init = list(init)
+                value = list(value)
             self.assertEqual(init, value, f"Issue with {key}")
 
 

--- a/amy/extrequests/tests/test_wrfinitial.py
+++ b/amy/extrequests/tests/test_wrfinitial.py
@@ -1,0 +1,128 @@
+from datetime import date
+
+from django.test import TestCase, RequestFactory
+from django.db.models import Q, QuerySet
+
+from extrequests.models import WorkshopInquiryRequest, SelfOrganisedSubmission
+from workshops.models import WorkshopRequest, Language, Curriculum, Tag, Organization
+from extrequests.views import (
+    WorkshopRequestAcceptEvent,
+    WorkshopInquiryAcceptEvent,
+    SelfOrganisedSubmissionAcceptEvent,
+)
+
+
+class InitialWRFTestMixin:
+    def setUp(self):
+        self.request = RequestFactory().get("/")
+        self.view = self.view_class()
+        self.view.setup(self.request)
+        self.view.other_object = self.setUpOther()
+        self.expected = {
+            "public_status": "public",
+            "curricula": Curriculum.objects.filter(slug__in=[
+                "swc-other",
+                "dc-other",
+                "lc-other",
+                "",  # mix & match
+            ]),
+            "tags": Tag.objects.filter(name__in=[
+                "Circuits",
+                "online",
+            ]),
+            "contact": "test@example.org;test2@example.org",
+            "host": Organization.objects.first(),
+            "start": date(2020, 11, 11),
+            "end": date(2020, 11, 12),
+            "slug": "2020-11-11-scotland",
+        }
+
+    def test_get_initial(self):
+        initial = self.view.get_initial()
+
+        self.assertEqual(initial.keys(), self.expected.keys())
+        for key in self.expected:
+            if isinstance(self.expected[key], QuerySet):
+                self.assertEqual(list(initial[key]), list(self.expected[key]))
+            else:
+                self.assertEqual(initial[key], self.expected[key])
+
+
+class TestInitialWorkshopRequestAccept(InitialWRFTestMixin, TestCase):
+    view_class = WorkshopRequestAcceptEvent
+
+    def setUpOther(self):
+        other_object = WorkshopRequest.objects.create(
+            state="p",
+            personal="Harry",
+            family="Potter",
+            email="harry@hogwarts.edu",
+            institution=Organization.objects.first(),
+            location="Scotland",
+            preferred_dates=date(2020, 11, 11),
+            language=Language.objects.get(name="English"),
+            number_attendees="10-40",
+            administrative_fee="nonprofit",
+            additional_contact="test@example.org;test2@example.org",
+            online_inperson="online",
+        )
+        # add "(swc|dc|lc)-other" and "mix & match" curricula
+        other_object.requested_workshop_types.set(Curriculum.objects.filter(
+            Q(carpentry__in=["SWC", "DC", "LC"], other=True)
+            | Q(mix_match=True)
+        ))
+        return other_object
+
+
+class TestInitialWorkshopInquiryAccept(InitialWRFTestMixin, TestCase):
+    view_class = WorkshopInquiryAcceptEvent
+
+    def setUpOther(self):
+        other_object = WorkshopInquiryRequest.objects.create(
+            state="p",
+            personal="Harry",
+            family="Potter",
+            email="harry@hogwarts.edu",
+            institution=Organization.objects.first(),
+            location="Scotland",
+            preferred_dates=date(2020, 11, 11),
+            language=Language.objects.get(name="English"),
+            number_attendees="10-40",
+            administrative_fee="nonprofit",
+            additional_contact="test@example.org;test2@example.org",
+            online_inperson="online",
+        )
+        # add "(swc|dc|lc)-other" and "mix & match" curricula
+        other_object.requested_workshop_types.set(Curriculum.objects.filter(
+            Q(carpentry__in=["SWC", "DC", "LC"], other=True)
+            | Q(mix_match=True)
+        ))
+        return other_object
+
+
+class TestInitialSelfOrganisedSubmissionAccept(InitialWRFTestMixin, TestCase):
+    view_class = SelfOrganisedSubmissionAcceptEvent
+
+    def setUp(self):
+        super().setUp()
+        self.expected["slug"] = "2020-11-11-xxx"
+
+    def setUpOther(self):
+        other_object = SelfOrganisedSubmission.objects.create(
+            state="p",
+            personal="Harry",
+            family="Potter",
+            email="harry@hogwarts.edu",
+            institution=Organization.objects.first(),
+            start=date(2020, 11, 11),
+            end=date(2020, 11, 12),
+            language=Language.objects.get(name="English"),
+            additional_contact="test@example.org;test2@example.org",
+            online_inperson="online",
+        )
+        # add "(swc|dc|lc)-other" and "mix & match" curricula
+        other_object.workshop_types.set(Curriculum.objects.filter(
+            Q(carpentry__in=["SWC", "DC", "LC"], other=True)
+            | Q(mix_match=True)
+        ))
+        return other_object

--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -452,6 +452,7 @@ class EventForm(forms.ModelForm):
             "longitude": TextInput,
             "invoice_status": RadioSelect,
             "tags": SelectMultiple(attrs={"size": Tag.ITEMS_VISIBLE_IN_SELECT_WIDGET}),
+            # "tags": CheckboxSelectMultiple(),
             "curricula": CheckboxSelectMultiple(),
             "lessons": CheckboxSelectMultiple(),
             "contact": Select2TagWidget,

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -807,7 +807,7 @@ class TagQuerySet(models.query.QuerySet):
 class Tag(models.Model):
     """Label for grouping events."""
 
-    ITEMS_VISIBLE_IN_SELECT_WIDGET = 15
+    ITEMS_VISIBLE_IN_SELECT_WIDGET = 19
 
     name = models.CharField(max_length=STR_MED, unique=True)
     details = models.CharField(max_length=STR_LONG)


### PR DESCRIPTION
This fixes #1561 by prefilling as many fields as possible, most notable:

1. `public_status`
2. `curricula`
3. tags based on curricula, `public_status`, Mix&Match or `workshop_listed`
4. contact data
5. host
6. start/end dates (if provided)
7. slug based on start/end dates and location (if provided)