### PR TITLE
update default email for workshop related tasks

### DIFF
--- a/amy/autoemails/tests/test_genericaction.py
+++ b/amy/autoemails/tests/test_genericaction.py
@@ -80,7 +80,7 @@ class TestGenericAction(TestCase):
                 "workshop_main_type": "SWC",
                 "dates": "Oct 30 - Nov 01, 2020",
                 "workshop_host": Organization.objects.first(),
-                "regional_coordinator_email": ["team@carpentries.org"],
+                "regional_coordinator_email": ["workshops@carpentries.org"],
                 "all_emails": [],
                 "assignee": "Regional Coordinator",
                 "tags": ["SWC"],

--- a/amy/templates/forms/selforganisedsubmission_confirm.html
+++ b/amy/templates/forms/selforganisedsubmission_confirm.html
@@ -20,7 +20,7 @@
     <li><a href="https://software-carpentry.org/">Software Carpentry</a></li>
     <li><a href="https://librarycarpentry.org/">Library Carpentry</a></li>
     <li><a href="https://carpentries.org/">The Carpentries</a></li>
-    <li>or contact <a href="mailto:team@carpentries.org">team@carpentries.org</a>.</li>
+    <li>or contact <a href="mailto:workshops@carpentries.org">workshops@carpentries.org</a>.</li>
 </ul>
 
 <p><a href="{% url 'selforganised_submission' %}">Click here</a> to submit another self-organised workshop.</p>

--- a/amy/templates/forms/trainingrequest_confirm.html
+++ b/amy/templates/forms/trainingrequest_confirm.html
@@ -10,7 +10,7 @@ you shortly. For more information please visit:</p>
     <li><a href="https://software-carpentry.org/">Software Carpentry</a></li>
     <li><a href="https://librarycarpentry.org/">Library Carpentry</a></li>
     <li><a href="https://carpentries.org/">The Carpentries</a></li>
-    <li>or contact <a href="mailto:team@carpentries.org">team@carpentries.org</a>.</li>
+    <li>or contact <a href="mailto:workshops@carpentries.org">workshops@carpentries.org</a>.</li>
 </ul>
 
 {% endblock %}

--- a/amy/templates/forms/workshopinquiry_confirm.html
+++ b/amy/templates/forms/workshopinquiry_confirm.html
@@ -14,7 +14,7 @@
     <li><a href="https://software-carpentry.org/">Software Carpentry</a></li>
     <li><a href="https://librarycarpentry.org/">Library Carpentry</a></li>
     <li><a href="https://carpentries.org/">The Carpentries</a></li>
-    <li>or contact <a href="mailto:team@carpentries.org">team@carpentries.org</a>.</li>
+    <li>or contact <a href="mailto:workshops@carpentries.org">workshops@carpentries.org</a>.</li>
 </ul>
 
 <p><a href="{% url 'workshop_inquiry' %}">Click here</a> to submit another workshop inquiry.</p>

--- a/amy/templates/forms/workshoprequest_confirm.html
+++ b/amy/templates/forms/workshoprequest_confirm.html
@@ -17,7 +17,7 @@
     <li><a href="https://software-carpentry.org/">Software Carpentry</a></li>
     <li><a href="https://librarycarpentry.org/">Library Carpentry</a></li>
     <li><a href="https://carpentries.org/">The Carpentries</a></li>
-    <li>or contact <a href="mailto:team@carpentries.org">team@carpentries.org</a>.</li>
+    <li>or contact <a href="mailto:workshops@carpentries.org">workshops@carpentries.org</a>.</li>
 </ul>
 
 <p><a href="{% url 'workshop_request' %}">Click here</a> to submit another workshop request.</p>

--- a/amy/workshops/management/commands/instructors_activity.py
+++ b/amy/workshops/management/commands/instructors_activity.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '-s', '--sender', action='store',
-            default='team@carpentries.org',
+            default='workshops@carpentries.org',
             help='E-mail used in "from:" field.',
         )
 

--- a/amy/workshops/tests/test_util.py
+++ b/amy/workshops/tests/test_util.py
@@ -1150,27 +1150,27 @@ class TestMatchingNotificationEmail(TestBase):
         # Online
         self.request.country = 'W3'
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['team@carpentries.org'])
+        self.assertEqual(results, ['workshops@carpentries.org'])
 
         # European Union
         self.request.country = 'EU'
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['team@carpentries.org'])
+        self.assertEqual(results, ['workshops@carpentries.org'])
 
         # United States
         self.request.country = 'US'
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['team@carpentries.org'])
+        self.assertEqual(results, ['workshops@carpentries.org'])
 
         # Poland
         self.request.country = 'PL'
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['team@carpentries.org'])
+        self.assertEqual(results, ['workshops@carpentries.org'])
 
         # unknown country code
         self.request.country = 'XY'
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['team@carpentries.org'])
+        self.assertEqual(results, ['workshops@carpentries.org'])
 
     def test_matching_Africa(self):
         """Testing just a subset of countries in Africa."""
@@ -1222,11 +1222,11 @@ class TestMatchingNotificationEmail(TestBase):
     def test_object_no_criteria(self):
         self.assertFalse(hasattr(self, 'country'))
         results = match_notification_email(self)
-        self.assertEqual(results, ['team@carpentries.org'])
+        self.assertEqual(results, ['workshops@carpentries.org'])
 
         self.country = None
         results = match_notification_email(self)
-        self.assertEqual(results, ['team@carpentries.org'])
+        self.assertEqual(results, ['workshops@carpentries.org'])
 
 
 class TestReportsLink(TestBase):

--- a/config/settings.py
+++ b/config/settings.py
@@ -436,7 +436,7 @@ if not DEBUG and (not ANYMAIL['MAILGUN_API_KEY'] or
 
 # NOTIFICATIONS
 # -----------------------------------------------------------------------------
-ADMIN_NOTIFICATION_CRITERIA_DEFAULT = 'team@carpentries.org'
+ADMIN_NOTIFICATION_CRITERIA_DEFAULT = 'workshops@carpentries.org'
 
 # ADMIN
 # ------------------------------------------------------------------------------

--- a/docs/sending_mails.md
+++ b/docs/sending_mails.md
@@ -23,7 +23,7 @@ UNIX command.  See [Sending](#sending) for more information.
 
 `-s SENDER`
 `--sender SENDER`
-: Set "From: " field value.  Default is `team@carpentries.org`.
+: Set "From: " field value.  Default is `workshops@carpentries.org`.
 
 ## Sending
 


### PR DESCRIPTION
addresses #1764

After talking with @sheraaronhurt, only workshop-related tasks should have a different point of contact. Occurrences that have to do with questions about how to update their profile information, etc. should continue to use `team@carpentries.org`. 

I think I replaced occurences that were appropriate. But feel free to reimplement/refactor.