### PR TITLE
fix: Update main branch name after transition from master

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,8 +8,8 @@ If you would like to know what we need help with, please see the
 
 ## Coding Guidelines
 
-*   Please base your work from `develop` branch, not `master`! `develop`
-    contains latest work that will later become a new release, while `master`
+*   Please base your work from `develop` branch, not `main`! `develop`
+    contains latest work that will later become a new release, while `main`
     contains latest stable release.
 *   All new code must be [PEP8 compatible][pep8], but legacy code should
     not be modified unless its meaning is being changed.

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,7 +2,7 @@ name: build docs
 on:
   push:
     branches:
-      - master
+      - main
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](amy/static/amy-logo.png)
 
-![](https://travis-ci.com/carpentries/amy.svg?branch=master)
+![](https://travis-ci.com/carpentries/amy.svg?branch=main)
 [![](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
 [![](https://img.shields.io/badge/django-2.2+-blue.svg)](https://www.djangoproject.com/)
 [![](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENSE.md)

--- a/docs/procedures.md
+++ b/docs/procedures.md
@@ -38,15 +38,15 @@ Execute the following commands on your local machine, not production.
         upstream	git@github.com:carpentries/amy.git (fetch)
         upstream	git@github.com:carpentries/amy.git (push)
 
-3.  Make sure your local `develop` and `master` branches are up to date:
+3.  Make sure your local `develop` and `main` branches are up to date:
 
         $ git checkout develop
         $ git pull upstream develop
         $ git push origin develop
 
-        $ git checkout master
-        $ git pull upstream master
-        $ git push origin master
+        $ git checkout main
+        $ git pull upstream main
+        $ git push origin main
 
     Pushes to your `origin` remote are optional.
 
@@ -56,12 +56,12 @@ Execute the following commands on your local machine, not production.
         $ AMY_VERSION=v2.X.Y
         $ AMY_NEXT_VERSION=v2.X+1.0-dev
 
-5.  Merge `develop` into `master` branch (be careful, as there are sometimes conflicts that need to be manually resolved):
+5.  Merge `develop` into `main` branch (be careful, as there are sometimes conflicts that need to be manually resolved):
 
-        $ git checkout master
+        $ git checkout main
         $ git merge --no-ff develop
 
-6.  Bump version on `master`:
+6.  Bump version on `main`:
 
         $ make bumpversion CURRENT=$AMY_CURRENT NEXT=$AMY_VERSION
         $ git add amy/workshops/__init__.py package.json
@@ -78,10 +78,10 @@ Execute the following commands on your local machine, not production.
     Omit `-s` flag if you cannot create signed tags.
     See [Git documentation](https://git-scm.com/book/tr/v2/Git-Tools-Signing-Your-Work) for more info about signed tags.
 
-9.  Push `master` and the new tag everywhere:
+9.  Push `main` and the new tag everywhere:
 
-        $ git push origin master --tags
-        $ git push upstream master --tags
+        $ git push origin main --tags
+        $ git push upstream main --tags
 
 10. Bump version on `develop`:
 


### PR DESCRIPTION
Changes references of the master branch to main.

Fixes #1794


