### PR TITLE
feature: Dashboard events filtered to logged in user by default.

### DIFF
--- a/amy/dashboard/tests/test_landing_page.py
+++ b/amy/dashboard/tests/test_landing_page.py
@@ -17,6 +17,18 @@ class TestAdminDashboard(TestBase):
         self._setUpEvents()
         self._setUpUsersAndLogin()
 
+        # assign an upcoming event to the logged in user
+        self.assigned_upcoming_event = Event.objects.active().upcoming_events().first()
+        self.assigned_upcoming_event.assigned_to = self.admin
+        self.assigned_upcoming_event.save()
+
+        # assign an unpublished event to the logged in user
+        self.assigned_unpublished_event = (
+            Event.objects.active().unpublished_events().first()
+        )
+        self.assigned_unpublished_event.assigned_to = self.admin
+        self.assigned_unpublished_event.save()
+
     def test_has_upcoming_events(self):
         """Test that the admin dashboard is passed some
         upcoming_events in the context."""
@@ -25,43 +37,45 @@ class TestAdminDashboard(TestBase):
         response = self.client.get(f"{reverse('admin-dashboard')}?assigned_to=")
 
         # This will fail if the context variable doesn't exist
-        events = response.context['current_events']
+        events = response.context["current_events"]
 
-        # all current events should be shown
+        # all unassigned current events should be shown
         num_current_events = (
-            Event.objects.upcoming_events() | Event.objects.ongoing_events()
-        ).active().count()
+            Event.objects.current_events().filter(assigned_to=None).count()
+        )
         self.assertEqual(len(events), num_current_events)
-        
+
         # They should all be labeled 'upcoming'.
-        assert all([('upcoming' in e.slug or 'ongoing' in e.slug)
-                    for e in events])
+        assert all([("upcoming" in e.slug or "ongoing" in e.slug) for e in events])
 
     def test_no_inactive_events(self):
         """Make sure we don't display stalled or completed events on the
         dashboard."""
-        stalled_tag = Tag.objects.get(name='stalled')
-        unresponsive_tag = Tag.objects.get(name='unresponsive')
-        cancelled_tag = Tag.objects.get(name='unresponsive')
+        stalled_tag = Tag.objects.get(name="stalled")
+        unresponsive_tag = Tag.objects.get(name="unresponsive")
+        cancelled_tag = Tag.objects.get(name="unresponsive")
 
         stalled = Event.objects.create(
-            slug='stalled-event', host=Organization.objects.first(),
+            slug="stalled-event",
+            host=Organization.objects.first(),
         )
         stalled.tags.add(stalled_tag)
 
         unresponsive = Event.objects.create(
-            slug='unresponsive-event', host=Organization.objects.first(),
+            slug="unresponsive-event",
+            host=Organization.objects.first(),
         )
         unresponsive.tags.add(unresponsive_tag)
 
         cancelled = Event.objects.create(
-            slug='cancelled-event', host=Organization.objects.first(),
+            slug="cancelled-event",
+            host=Organization.objects.first(),
         )
         cancelled.tags.add(cancelled_tag)
 
-        completed = Event.objects.create(slug='completed-event',
-                                         completed=True,
-                                         host=Organization.objects.first())
+        completed = Event.objects.create(
+            slug="completed-event", completed=True, host=Organization.objects.first()
+        )
 
         # stalled event appears in unfiltered list of events
         self.assertNotIn(stalled, Event.objects.unpublished_events())
@@ -69,15 +83,15 @@ class TestAdminDashboard(TestBase):
         self.assertNotIn(cancelled, Event.objects.unpublished_events())
         self.assertNotIn(completed, Event.objects.unpublished_events())
 
-        response = self.client.get(reverse('admin-dashboard'))
-        self.assertNotIn(stalled, response.context['unpublished_events'])
-        self.assertNotIn(unresponsive, response.context['unpublished_events'])
-        self.assertNotIn(cancelled, response.context['unpublished_events'])
-        self.assertNotIn(completed, response.context['unpublished_events'])
-    
-    def test_default_events(self):
-        """The admin dashboard shows the events assigned to the current logged in 
-        user by default."""
+        response = self.client.get(f"{reverse('admin-dashboard')}?assigned_to=")
+        self.assertNotIn(stalled, response.context["unpublished_events"])
+        self.assertNotIn(unresponsive, response.context["unpublished_events"])
+        self.assertNotIn(cancelled, response.context["unpublished_events"])
+        self.assertNotIn(completed, response.context["unpublished_events"])
+
+    def test_events_default(self):
+        """The admin dashboard shows the events assigned to the current logged in
+        user by default (when the url is /dashboard/admin/)."""
         upcoming_event = Event.objects.upcoming_events().first()
         upcoming_event.assigned_to = self.admin
         upcoming_event.save()
@@ -86,17 +100,80 @@ class TestAdminDashboard(TestBase):
         unpublished_event.assigned_to = self.admin
         unpublished_event.save()
 
-        
-        response = self.client.get(reverse('admin-dashboard'))
+        response = self.client.get(reverse("admin-dashboard"))
 
         # This will fail if the context variable doesn't exist
-        current_events = response.context['current_events']
-        unpublished_events = response.context['unpublished_events']
-        assigned_to = response.context['assigned_to']
+        current_events = response.context["current_events"]
+        unpublished_events = response.context["unpublished_events"]
+        assigned_to = response.context["assigned_to"]
 
         self.assertEqual(list(current_events), [upcoming_event])
         self.assertEqual(list(unpublished_events), [unpublished_event])
-        self.assertEqual(assigned_to, self.admin) 
+        self.assertEqual(assigned_to, self.admin)
+
+    def test_events_assigned_to_none(self):
+        """The admin dashboard shows all events if assigned to is None
+        (when the url is /dashboard/admin/?assigned_to=)."""
+        response = self.client.get(reverse("admin-dashboard"))
+
+        # This will fail if the context variable doesn't exist
+        current_events = response.context["current_events"]
+        unpublished_events = response.context["unpublished_events"]
+        assigned_to = response.context["assigned_to"]
+
+        self.assertEqual(list(current_events), [self.assigned_upcoming_event])
+        self.assertEqual(list(unpublished_events), [self.assigned_unpublished_event])
+        self.assertEqual(assigned_to, self.admin)
+
+    def test_events_assigned_to_another_user(self):
+        """The admin dashboard shows all events assigned to a particular user
+        if that user is specified in the assigned_to
+        (when the url is /dashboard/admin/?assigned_to=other_user)."""
+        other_admin = Person.objects.create_superuser(
+            username="other_admin",
+            personal="OtherSuper",
+            family="User",
+            email="other_sudo@example.org",
+            password="admin",
+        )
+        other_admin.data_privacy_agreement = True  # TODO does this need to be here?
+        other_admin.save()
+
+        # Add an upcoming event to the logged in admin (self.admin)
+        # and one to other_admin
+        upcoming_event = (
+            Event.objects.active()
+            .filter(assigned_to__isnull=True)
+            .upcoming_events()
+            .first()
+        )
+        upcoming_event.assigned_to = other_admin
+        upcoming_event.save()
+
+        # Add an unpublished event to logged in admin (self.admin)
+        # and another to other_admin
+        unpublished_event = (
+            Event.objects.active()
+            .filter(assigned_to__isnull=True)
+            .unpublished_events()
+            .first()
+        )
+        unpublished_event.assigned_to = other_admin
+        unpublished_event.save()
+
+        response = self.client.get(
+            f"{reverse('admin-dashboard')}?assigned_to={other_admin.id}"
+        )
+
+        # This will fail if the context variable doesn't exist
+        current_events = response.context["current_events"]
+        unpublished_events = response.context["unpublished_events"]
+        assigned_to = response.context["assigned_to"]
+
+        self.assertEqual(list(current_events), [upcoming_event])
+        self.assertEqual(list(unpublished_events), [unpublished_event])
+        self.assertEqual(assigned_to, other_admin)
+
 
 class TestDispatch(TestBase):
     """Test that the right dashboard (trainee or admin dashboard) is displayed
@@ -104,56 +181,72 @@ class TestDispatch(TestBase):
 
     def test_superuser_logs_in(self):
         person = Person.objects.create_superuser(
-            username='admin', personal='', family='',
-            email='admin@example.org', password='pass')
+            username="admin",
+            personal="",
+            family="",
+            email="admin@example.org",
+            password="pass",
+        )
         person.data_privacy_agreement = True
         person.save()
 
-        rv = self.client.post(reverse('login'),
-                              {'username':'admin', 'password':'pass'},
-                              follow=True)
+        rv = self.client.post(
+            reverse("login"), {"username": "admin", "password": "pass"}, follow=True
+        )
 
-        self.assertEqual(rv.resolver_match.view_name, 'admin-dashboard')
+        self.assertEqual(rv.resolver_match.view_name, "admin-dashboard")
 
     def test_mentor_logs_in(self):
         mentor = Person.objects.create_user(
-            username='user', personal='', family='',
-            email='mentor@example.org', password='pass')
-        admins = Group.objects.get(name='administrators')
+            username="user",
+            personal="",
+            family="",
+            email="mentor@example.org",
+            password="pass",
+        )
+        admins = Group.objects.get(name="administrators")
         mentor.groups.add(admins)
         mentor.data_privacy_agreement = True
         mentor.save()
 
-        rv = self.client.post(reverse('login'),
-                              {'username': 'user', 'password': 'pass'},
-                              follow=True)
+        rv = self.client.post(
+            reverse("login"), {"username": "user", "password": "pass"}, follow=True
+        )
 
-        self.assertEqual(rv.resolver_match.view_name, 'admin-dashboard')
+        self.assertEqual(rv.resolver_match.view_name, "admin-dashboard")
 
     def test_steering_committee_member_logs_in(self):
         mentor = Person.objects.create_user(
-            username='user', personal='', family='',
-            email='user@example.org', password='pass')
-        steering_committee= Group.objects.get(name='steering committee')
+            username="user",
+            personal="",
+            family="",
+            email="user@example.org",
+            password="pass",
+        )
+        steering_committee = Group.objects.get(name="steering committee")
         mentor.groups.add(steering_committee)
         mentor.data_privacy_agreement = True
         mentor.save()
 
-        rv = self.client.post(reverse('login'),
-                              {'username': 'user', 'password': 'pass'},
-                              follow=True)
+        rv = self.client.post(
+            reverse("login"), {"username": "user", "password": "pass"}, follow=True
+        )
 
-        self.assertEqual(rv.resolver_match.view_name, 'admin-dashboard')
+        self.assertEqual(rv.resolver_match.view_name, "admin-dashboard")
 
     def test_trainee_logs_in(self):
         self.trainee = Person.objects.create_user(
-            username='trainee', personal='', family='',
-            email='trainee@example.org', password='pass')
+            username="trainee",
+            personal="",
+            family="",
+            email="trainee@example.org",
+            password="pass",
+        )
         self.trainee.data_privacy_agreement = True
         self.trainee.save()
 
-        rv = self.client.post(reverse('login'),
-                              {'username': 'trainee', 'password': 'pass'},
-                              follow=True)
+        rv = self.client.post(
+            reverse("login"), {"username": "trainee", "password": "pass"}, follow=True
+        )
 
-        self.assertEqual(rv.resolver_match.view_name, 'trainee-dashboard')
+        self.assertEqual(rv.resolver_match.view_name, "trainee-dashboard")

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -55,7 +55,10 @@ def dispatch(request):
 def admin_dashboard(request):
     """Home page for admins."""
 
-    assignment_form = AssignmentForm(request.GET)
+    data = request.GET.copy()
+    if "assigned_to" not in data:
+        data["assigned_to"] = request.user.id
+    assignment_form = AssignmentForm(data)
     assigned_to: Optional[Person] = None
     if assignment_form.is_valid():
         assigned_to = assignment_form.cleaned_data["assigned_to"]
@@ -81,10 +84,9 @@ def admin_dashboard(request):
     # assigned events that have unaccepted changes
     updated_metadata = Event.objects.active().filter(metadata_changed=True)
 
-    if assigned_to is not None:
-        current_events = current_events.filter(assigned_to=assigned_to)
-        unpublished_events = unpublished_events.filter(assigned_to=assigned_to)
-        updated_metadata = updated_metadata.filter(assigned_to=assigned_to)
+    current_events = current_events.filter(assigned_to=assigned_to)
+    unpublished_events = unpublished_events.filter(assigned_to=assigned_to)
+    updated_metadata = updated_metadata.filter(assigned_to=assigned_to)
 
     context = {
         'title': None,

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -998,6 +998,15 @@ class EventQuerySet(models.query.QuerySet):
 
         return queryset
 
+    def current_events(self):
+        """Return current events.
+
+        Current events are active ongoing events and active upcoming events
+        (see `ongoing_events` and `upcoming_events` above).
+        """
+        queryset = (self.upcoming_events() | self.ongoing_events()).active()
+        return queryset
+
     def unpublished_conditional(self):
         """Return conditional for events without: start OR country OR venue OR
         url OR are marked as 'cancelled' (ie. unpublished events). This will be


### PR DESCRIPTION
By default going to `/dashboard/admin/` the logged in user will be selected:
<img width="1432" alt="Screen Shot 2021-02-18 at 11 16 13 PM" src="https://user-images.githubusercontent.com/12959365/108470816-5f299980-723f-11eb-83d7-ed0de726e6eb.png">

When the user is deselected `/dashboard/admin/?assigned_to=` all the unassigned events are viewable:
<img width="1432" alt="Screen Shot 2021-02-18 at 11 15 58 PM" src="https://user-images.githubusercontent.com/12959365/108470844-694b9800-723f-11eb-84aa-f4a039e8adbe.png">


Fixes #1784