### PR TITLE
tech: Apply Black to the entire codebase.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+# Migrate code style to Black

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,1 +1,3 @@
 # Migrate code style to Black
+8ae6bfea62e0714cc86371c0618a43987a42ee10
+78b659721671dffbccaf2f1a38695b1f9cb50be0

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ before starting work on new features.
     $ cd amy
     ~~~
 
+1.   Configure git to automatically ignore revisions in the `.git-blame-ignore-revs`:
+
+    ~~~
+    $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+    ~~~  
+
 1.  Install Django and other dependencies:
 
     ~~~

--- a/amy/api/apps.py
+++ b/amy/api/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class ApiConfig(AppConfig):
-    name = 'api'
+    name = "api"

--- a/amy/api/filters.py
+++ b/amy/api/filters.py
@@ -11,43 +11,47 @@ from workshops.models import Event, Task, Tag, Person, Badge
 
 
 class EventFilter(filters.FilterSet):
-    start_after = filters.DateFilter(field_name='start', lookup_expr='gte')
-    start_before = filters.DateFilter(field_name='start', lookup_expr='lte')
-    end_after = filters.DateFilter(field_name='end', lookup_expr='gte')
-    end_before = filters.DateFilter(field_name='end', lookup_expr='lte')
+    start_after = filters.DateFilter(field_name="start", lookup_expr="gte")
+    start_before = filters.DateFilter(field_name="start", lookup_expr="lte")
+    end_after = filters.DateFilter(field_name="end", lookup_expr="gte")
+    end_before = filters.DateFilter(field_name="end", lookup_expr="lte")
     tags = filters.ModelMultipleChoiceFilter(
-        field_name='tags__name',
-        to_field_name='name',
+        field_name="tags__name",
+        to_field_name="name",
         queryset=Tag.objects.all(),
         conjoined=True,
     )
     order_by = filters.OrderingFilter(
         fields=(
-            'slug',
-            'start',
-            'end',
+            "slug",
+            "start",
+            "end",
         ),
     )
 
     class Meta:
         model = Event
         fields = (
-            'completed', 'tags',
-            'administrator', 'host',
-            'start', 'start_before', 'start_after',
-            'end', 'end_before', 'end_after',
-            'country',
+            "completed",
+            "tags",
+            "administrator",
+            "host",
+            "start",
+            "start_before",
+            "start_after",
+            "end",
+            "end_before",
+            "end_after",
+            "country",
         )
 
 
 class TaskFilter(filters.FilterSet):
-    role = filters.CharFilter(field_name='role__name')
+    role = filters.CharFilter(field_name="role__name")
 
     class Meta:
         model = Task
-        fields = (
-            'role',
-        )
+        fields = ("role",)
 
 
 def filter_instructors(queryset, name, value):
@@ -61,20 +65,27 @@ def filter_instructors(queryset, name, value):
 
 
 class PersonFilter(filters.FilterSet):
-    is_instructor = filters.BooleanFilter(method=filter_instructors,
-                                          label='Is instructor?')
+    is_instructor = filters.BooleanFilter(
+        method=filter_instructors, label="Is instructor?"
+    )
 
     order_by = NamesOrderingFilter(
-        fields=(
-            'email',
-        ),
+        fields=("email",),
     )
 
     class Meta:
         model = Person
         fields = (
-            'badges', 'username', 'personal', 'middle', 'family', 'email',
-            'may_contact', 'publish_profile', 'github', 'country',
+            "badges",
+            "username",
+            "personal",
+            "middle",
+            "family",
+            "email",
+            "may_contact",
+            "publish_profile",
+            "github",
+            "country",
         )
 
 
@@ -83,15 +94,15 @@ class IdInFilter(filters.BaseInFilter, filters.NumberFilter):
 
 
 class TrainingRequestFilterIDs(TrainingRequestFilter):
-    ids = IdInFilter(field_name='id', lookup_expr='in')
+    ids = IdInFilter(field_name="id", lookup_expr="in")
 
     class Meta(TrainingRequestFilter.Meta):
         fields = [
-            'ids',
-            'search',
-            'group_name',
-            'state',
-            'matched',
-            'affiliation',
-            'location',
+            "ids",
+            "search",
+            "group_name",
+            "state",
+            "matched",
+            "affiliation",
+            "location",
         ]

--- a/amy/api/filters.py
+++ b/amy/api/filters.py
@@ -1,4 +1,3 @@
-from django.forms import widgets
 from django_filters import rest_framework as filters
 
 from extrequests.filters import (

--- a/amy/api/renderers.py
+++ b/amy/api/renderers.py
@@ -8,58 +8,56 @@ from api.serializers import (
 
 class TrainingRequestCSVColumns:
     translation_labels = {
-        'created_at': 'Created at',
-        'last_updated_at': 'Last updated at',
-        'state': 'State',
-        'person': 'Matched Trainee',
-        'person_id': 'Matched Trainee ID',
-        'awards': 'Badges',
-        'training_tasks': 'Training Tasks',
-        'review_process': 'Application Type',
-        'group_name': 'Registration Code',
-        'personal': 'Personal',
-        'middle': 'Middle',
-        'family': 'Family',
-        'email': 'Email',
-        'secondary_email': 'Secondary email',
-        'github': 'GitHub username',
-        'underrepresented': 'Underrepresented',
-        'underrepresented_details': 'Underrepresented (reason)',
-        'occupation': 'Occupation',
-        'occupation_other': 'Occupation (other)',
-        'affiliation': 'Affiliation',
-        'location': 'Location',
-        'country': 'Country',
-        'underresourced': 'Underresourced institution',
-        'domains': 'Expertise areas',
-        'domains_other': 'Expertise areas (other)',
-        'nonprofit_teaching_experience': 'Non-profit teaching experience',
-        'previous_involvement': 'Previous Involvement',
-        'previous_training': 'Previous Training in Teaching',
-        'previous_training_other': 'Previous Training (other)',
-        'previous_training_explanation': 'Previous Training (explanation)',
-        'previous_experience': 'Previous Experience in Teaching',
-        'previous_experience_other': 'Previous Experience (other)',
-        'previous_experience_explanation': 'Previous Experience (explanation)',
-        'programming_language_usage_frequency': 'Programming Language Usage',
-        'teaching_frequency_expectation': 'Teaching Frequency Expectation',
-        'teaching_frequency_expectation_other': 'Teaching Frequency Expectation (other)',
-        'max_travelling_frequency': 'Max Travelling Frequency',
-        'max_travelling_frequency_other': 'Max Travelling Frequency (other)',
-        'reason': 'Reason for undertaking training',
-        'user_notes': 'User notes',
-        'training_completion_agreement': 'Training completion agreement (yes/no)',
-        'workshop_teaching_agreement': 'Workshop teaching agreement (yes/no)',
-        'data_privacy_agreement': 'Data privacy agreement (yes/no)',
-        'code_of_conduct_agreement': 'Code of Conduct agreement (yes/no)',
+        "created_at": "Created at",
+        "last_updated_at": "Last updated at",
+        "state": "State",
+        "person": "Matched Trainee",
+        "person_id": "Matched Trainee ID",
+        "awards": "Badges",
+        "training_tasks": "Training Tasks",
+        "review_process": "Application Type",
+        "group_name": "Registration Code",
+        "personal": "Personal",
+        "middle": "Middle",
+        "family": "Family",
+        "email": "Email",
+        "secondary_email": "Secondary email",
+        "github": "GitHub username",
+        "underrepresented": "Underrepresented",
+        "underrepresented_details": "Underrepresented (reason)",
+        "occupation": "Occupation",
+        "occupation_other": "Occupation (other)",
+        "affiliation": "Affiliation",
+        "location": "Location",
+        "country": "Country",
+        "underresourced": "Underresourced institution",
+        "domains": "Expertise areas",
+        "domains_other": "Expertise areas (other)",
+        "nonprofit_teaching_experience": "Non-profit teaching experience",
+        "previous_involvement": "Previous Involvement",
+        "previous_training": "Previous Training in Teaching",
+        "previous_training_other": "Previous Training (other)",
+        "previous_training_explanation": "Previous Training (explanation)",
+        "previous_experience": "Previous Experience in Teaching",
+        "previous_experience_other": "Previous Experience (other)",
+        "previous_experience_explanation": "Previous Experience (explanation)",
+        "programming_language_usage_frequency": "Programming Language Usage",
+        "teaching_frequency_expectation": "Teaching Frequency Expectation",
+        "teaching_frequency_expectation_other": "Teaching Frequency Expectation (other)",
+        "max_travelling_frequency": "Max Travelling Frequency",
+        "max_travelling_frequency_other": "Max Travelling Frequency (other)",
+        "reason": "Reason for undertaking training",
+        "user_notes": "User notes",
+        "training_completion_agreement": "Training completion agreement (yes/no)",
+        "workshop_teaching_agreement": "Workshop teaching agreement (yes/no)",
+        "data_privacy_agreement": "Data privacy agreement (yes/no)",
+        "code_of_conduct_agreement": "Code of Conduct agreement (yes/no)",
     }
 
     def __init__(self):
         self.header = self.serializer.Meta.fields
         self.labels = {
-            k: v
-            for k, v in self.translation_labels.items()
-            if k in self.header
+            k: v for k, v in self.translation_labels.items() if k in self.header
         }
 
 
@@ -69,4 +67,4 @@ class TrainingRequestCSVRenderer(CSVRenderer, TrainingRequestCSVColumns):
 
 class TrainingRequestManualScoreCSVRenderer(CSVRenderer, TrainingRequestCSVColumns):
     serializer = TrainingRequestForManualScoringSerializer
-    format = 'csv2'
+    format = "csv2"

--- a/amy/api/renderers.py
+++ b/amy/api/renderers.py
@@ -43,7 +43,7 @@ class TrainingRequestCSVColumns:
         "previous_experience_explanation": "Previous Experience (explanation)",
         "programming_language_usage_frequency": "Programming Language Usage",
         "teaching_frequency_expectation": "Teaching Frequency Expectation",
-        "teaching_frequency_expectation_other": "Teaching Frequency Expectation (other)",
+        "teaching_frequency_expectation_other": "Teaching Frequency Expectation (other)",  # noqa: line too long
         "max_travelling_frequency": "Max Travelling Frequency",
         "max_travelling_frequency_other": "Max Travelling Frequency (other)",
         "reason": "Reason for undertaking training",

--- a/amy/api/tests/test_api_structure.py
+++ b/amy/api/tests/test_api_structure.py
@@ -16,28 +16,36 @@ from workshops.models import (
 class TestAPIStructure(APITestCase):
     def setUp(self):
         self.admin = Person.objects.create_superuser(
-            username='admin', personal='Super', family='User',
-            email='sudo@example.org', password='admin',
+            username="admin",
+            personal="Super",
+            family="User",
+            email="sudo@example.org",
+            password="admin",
         )
         self.admin.data_privacy_agreement = True
         self.admin.airport = Airport.objects.first()
         self.admin.save()
 
-        self.event = Event.objects.create(slug='test-event',
-                                          host=Organization.objects.first(),
-                                          administrator=Organization.objects.first(),
-                                          assigned_to=self.admin)
-
-        self.award = Award.objects.create(
-            person=self.admin, badge=Badge.objects.first(), event=self.event,
+        self.event = Event.objects.create(
+            slug="test-event",
+            host=Organization.objects.first(),
+            administrator=Organization.objects.first(),
+            assigned_to=self.admin,
         )
 
-        self.instructor_role = Role.objects.create(name='instructor')
+        self.award = Award.objects.create(
+            person=self.admin,
+            badge=Badge.objects.first(),
+            event=self.event,
+        )
 
-        self.task = Task.objects.create(event=self.event, person=self.admin,
-                                        role=self.instructor_role)
+        self.instructor_role = Role.objects.create(name="instructor")
 
-        self.client.login(username='admin', password='admin')
+        self.task = Task.objects.create(
+            event=self.event, person=self.admin, role=self.instructor_role
+        )
+
+        self.client.login(username="admin", password="admin")
 
     def test_structure_for_list_views(self):
         """Ensure we have list-type views in exact places."""
@@ -49,28 +57,26 @@ class TestAPIStructure(APITestCase):
         # → organizations
         # → airports
         # → reports
-        index = self.client.get(reverse('api:root'))
+        index = self.client.get(reverse("api:root"))
         index_links = {
-            'person-list': reverse('api:person-list'),
-            'event-list': reverse('api:event-list'),
-            'organization-list': reverse('api:organization-list'),
-            'airport-list': reverse('api:airport-list'),
+            "person-list": reverse("api:person-list"),
+            "event-list": reverse("api:event-list"),
+            "organization-list": reverse("api:organization-list"),
+            "airport-list": reverse("api:airport-list"),
         }
         for endpoint, link in index_links.items():
             self.assertIn(link, index.data[endpoint])
 
-        person = self.client.get(reverse('api:person-detail',
-                                         args=[self.admin.pk]))
+        person = self.client.get(reverse("api:person-detail", args=[self.admin.pk]))
         person_links = {
-            'awards': reverse('api:person-awards-list', args=[self.admin.pk]),
+            "awards": reverse("api:person-awards-list", args=[self.admin.pk]),
         }
         for endpoint, link in person_links.items():
             self.assertIn(link, person.data[endpoint])
 
-        event = self.client.get(reverse('api:event-detail',
-                                        args=[self.event.slug]))
+        event = self.client.get(reverse("api:event-detail", args=[self.event.slug]))
         event_links = {
-            'tasks': reverse('api:event-tasks-list', args=[self.event.slug]),
+            "tasks": reverse("api:event-tasks-list", args=[self.event.slug]),
         }
         for endpoint, link in event_links.items():
             self.assertIn(link, event.data[endpoint])
@@ -90,42 +96,43 @@ class TestAPIStructure(APITestCase):
         # airport (no links)
         # award
         #   → event-detail
-        event = self.client.get(reverse('api:event-detail',
-                                        args=[self.event.slug]))
+        event = self.client.get(reverse("api:event-detail", args=[self.event.slug]))
         event_links = {
-            'host': reverse('api:organization-detail', args=[self.event.host.domain]),
-            'administrator': reverse('api:organization-detail',
-                                     args=[self.event.administrator.domain]),
-            'tasks': reverse('api:event-tasks-list', args=[self.event.slug]),
-            'assigned_to': reverse('api:person-detail',
-                                   args=[self.event.assigned_to.pk])
+            "host": reverse("api:organization-detail", args=[self.event.host.domain]),
+            "administrator": reverse(
+                "api:organization-detail", args=[self.event.administrator.domain]
+            ),
+            "tasks": reverse("api:event-tasks-list", args=[self.event.slug]),
+            "assigned_to": reverse(
+                "api:person-detail", args=[self.event.assigned_to.pk]
+            ),
         }
         for attr, link in event_links.items():
             self.assertIn(link, event.data[attr])
 
-        task = self.client.get(reverse('api:event-tasks-detail',
-                                       args=[self.event.slug, self.task.pk]))
+        task = self.client.get(
+            reverse("api:event-tasks-detail", args=[self.event.slug, self.task.pk])
+        )
         task_links = {
-            'person': reverse('api:person-detail', args=[self.admin.pk]),
+            "person": reverse("api:person-detail", args=[self.admin.pk]),
         }
         for attr, link in task_links.items():
             self.assertIn(link, task.data[attr])
 
-        person = self.client.get(reverse('api:person-detail',
-                                         args=[self.admin.pk]))
+        person = self.client.get(reverse("api:person-detail", args=[self.admin.pk]))
         person_links = {
-            'airport': reverse('api:airport-detail',
-                               args=[self.admin.airport.iata]),
-            'awards': reverse('api:person-awards-list', args=[self.admin.pk]),
-            'tasks': reverse('api:person-tasks-list', args=[self.admin.pk]),
+            "airport": reverse("api:airport-detail", args=[self.admin.airport.iata]),
+            "awards": reverse("api:person-awards-list", args=[self.admin.pk]),
+            "tasks": reverse("api:person-tasks-list", args=[self.admin.pk]),
         }
         for attr, link in person_links.items():
             self.assertIn(link, person.data[attr])
 
-        award = self.client.get(reverse('api:person-awards-detail',
-                                        args=[self.admin.pk, self.award.pk]))
+        award = self.client.get(
+            reverse("api:person-awards-detail", args=[self.admin.pk, self.award.pk])
+        )
         award_links = {
-            'event': reverse('api:event-detail', args=[self.award.event.slug]),
+            "event": reverse("api:event-detail", args=[self.award.event.slug]),
         }
         for attr, link in award_links.items():
             self.assertIn(link, award.data[attr])

--- a/amy/api/tests/test_export.py
+++ b/amy/api/tests/test_export.py
@@ -32,15 +32,19 @@ class BaseExportingTest(APITestCase):
 
     def setup_admin(self):
         self.admin = Person.objects.create_superuser(
-                username="admin", personal="Super", family="User",
-                email="sudo@example.org", password='admin')
+            username="admin",
+            personal="Super",
+            family="User",
+            email="sudo@example.org",
+            password="admin",
+        )
         self.admin.data_privacy_agreement = True
         self.admin.save()
 
     def login(self):
-        if not hasattr(self, 'admin'):
+        if not hasattr(self, "admin"):
             self.setup_admin()
-        self.client.login(username='admin', password='admin')
+        self.client.login(username="admin", password="admin")
 
 
 class TestExportingPersonData(BaseExportingTest):
@@ -50,48 +54,54 @@ class TestExportingPersonData(BaseExportingTest):
 
         # prepare user
         self.user = Person(
-            username="primary_user", personal="User", family="Primary",
-            email="primary_user@amy.com", is_active=True,
+            username="primary_user",
+            personal="User",
+            family="Primary",
+            email="primary_user@amy.com",
+            is_active=True,
             data_privacy_agreement=True,
         )
-        self.user.set_password('password')
+        self.user.set_password("password")
         self.user.save()
 
         # save API endpoint URL
-        self.url = reverse('api:export-person-data')
+        self.url = reverse("api:export-person-data")
 
     def login(self):
         """Overwrite BaseExportingTest's login method: instead of loggin in
         as an admin, use a normal user."""
-        self.client.login(username='primary_user', password='password')
+        self.client.login(username="primary_user", password="password")
 
     def prepare_data(self, user):
         """Populate relational fields for the user."""
 
         # create and set airport for the user
         airport = Airport.objects.create(
-            iata='DDD', fullname='Airport 55x105',
-            country='CM',
-            latitude=55.0, longitude=105.0,
+            iata="DDD",
+            fullname="Airport 55x105",
+            country="CM",
+            latitude=55.0,
+            longitude=105.0,
         )
         self.user.airport = airport
         self.user.save()
 
         # create a fake organization
         test_host = Organization.objects.create(
-            domain='example.com', fullname='Test Organization')
+            domain="example.com", fullname="Test Organization"
+        )
 
         # create an event that will later be used
         event = Event.objects.create(
             start=datetime.date(2018, 6, 16),
             end=datetime.date(2018, 6, 17),
-            slug='2018-06-16-AMY-event',
+            slug="2018-06-16-AMY-event",
             host=test_host,
-            url='http://example.org/2018-06-16-AMY-event',
+            url="http://example.org/2018-06-16-AMY-event",
         )
 
         # add a role
-        Role.objects.create(name='instructor', verbose_name='Instructor')
+        Role.objects.create(name="instructor", verbose_name="Instructor")
 
         # add an admin user
         self.setup_admin()
@@ -100,81 +110,80 @@ class TestExportingPersonData(BaseExportingTest):
         # one badge was awarded for the event
         award1 = Award.objects.create(
             person=self.user,
-            badge=Badge.objects.get(name='swc-instructor'),
+            badge=Badge.objects.get(name="swc-instructor"),
             event=event,
             awarded=datetime.date(2018, 6, 16),
         )
         # second badge was awarded without any connected event
         award2 = Award.objects.create(
             person=self.user,
-            badge=Badge.objects.get(name='dc-instructor'),
+            badge=Badge.objects.get(name="dc-instructor"),
             awarded=datetime.date(2018, 6, 16),
         )
 
         # user took part in the event as an instructor
         self.user.task_set.create(
-            event=event, role=Role.objects.get(name='instructor'),
+            event=event,
+            role=Role.objects.get(name="instructor"),
         )
 
         # user knows a couple of languages
-        self.user.languages.set(
-            Language.objects.filter(name__in=['English', 'French'])
-        )
+        self.user.languages.set(Language.objects.filter(name__in=["English", "French"]))
 
         # add training requests
         training_request = TrainingRequest.objects.create(
             # mixins
             data_privacy_agreement=True,
             code_of_conduct_agreement=True,
-            state='p',  # pending
-
+            state="p",  # pending
             person=self.user,
-            review_process='preapproved',
-            group_name='Mosquitos',
-            personal='User',
-            middle='',
-            family='Primary',
-            email='primary_user@amy.com',
-            secondary_email='not-used-often@amy.com',
-            github='primary_user',
-            occupation='undisclosed',
-            occupation_other='',
-            affiliation='AMY',
-            location='Worldwide',
-            country='W3',
+            review_process="preapproved",
+            group_name="Mosquitos",
+            personal="User",
+            middle="",
+            family="Primary",
+            email="primary_user@amy.com",
+            secondary_email="not-used-often@amy.com",
+            github="primary_user",
+            occupation="undisclosed",
+            occupation_other="",
+            affiliation="AMY",
+            location="Worldwide",
+            country="W3",
             underresourced=False,
             # need to set it below
             # domains=KnowledgeDomain.objects.first(),
-            domains_other='E-commerce',
-            underrepresented='yes',
-            underrepresented_details='LGBTQ',
-            nonprofit_teaching_experience='Voluntary teacher',
+            domains_other="E-commerce",
+            underrepresented="yes",
+            underrepresented_details="LGBTQ",
+            nonprofit_teaching_experience="Voluntary teacher",
             # need to set it below
             # previous_involvement=Role.objects.filter(name='instructor'),
-            previous_training='course',
-            previous_training_other='',
-            previous_training_explanation='A course for voluntary teaching',
-            previous_experience='ta',
-            previous_experience_other='',
-            previous_experience_explanation='After the course I became a TA',
-            programming_language_usage_frequency='weekly',
-            teaching_frequency_expectation='monthly',
-            max_travelling_frequency='not-at-all',
-            max_travelling_frequency_other='',
-            reason='I want to became an instructor',
-            user_notes='I like trains',
+            previous_training="course",
+            previous_training_other="",
+            previous_training_explanation="A course for voluntary teaching",
+            previous_experience="ta",
+            previous_experience_other="",
+            previous_experience_explanation="After the course I became a TA",
+            programming_language_usage_frequency="weekly",
+            teaching_frequency_expectation="monthly",
+            max_travelling_frequency="not-at-all",
+            max_travelling_frequency_other="",
+            reason="I want to became an instructor",
+            user_notes="I like trains",
             training_completion_agreement=True,
             workshop_teaching_agreement=True,
         )
         training_request.domains.set([KnowledgeDomain.objects.first()])
         training_request.previous_involvement.set(
-            Role.objects.filter(name='instructor'))
+            Role.objects.filter(name="instructor")
+        )
 
         # add some training progress
         TrainingProgress.objects.create(
             trainee=self.user,
-            requirement=TrainingRequirement.objects.get(name='Discussion'),
-            state='p',  # passed
+            requirement=TrainingRequirement.objects.get(name="Discussion"),
+            state="p",  # passed
             event=event,
             evaluated_by=None,
             discarded=False,
@@ -182,12 +191,12 @@ class TestExportingPersonData(BaseExportingTest):
         )
         TrainingProgress.objects.create(
             trainee=self.user,
-            requirement=TrainingRequirement.objects.get(name='DC Homework'),
-            state='f',  # failed
+            requirement=TrainingRequirement.objects.get(name="DC Homework"),
+            state="f",  # failed
             event=None,
             evaluated_by=self.admin,
             discarded=False,
-            url='http://example.org/homework',
+            url="http://example.org/homework",
         )
 
     def test_unauthorized_access(self):
@@ -206,28 +215,31 @@ class TestExportingPersonData(BaseExportingTest):
         no-one else."""
         # prepare a different user
         self.second_user = Person(
-            username="secondary_user", personal="User", family="Secondary",
-            email="secondary_user@amy.com", is_active=True,
+            username="secondary_user",
+            personal="User",
+            family="Secondary",
+            email="secondary_user@amy.com",
+            is_active=True,
             data_privacy_agreement=True,
         )
-        self.second_user.set_password('password')
+        self.second_user.set_password("password")
         self.second_user.save()
 
         # login as first user
-        self.client.login(username='primary_user', password='password')
+        self.client.login(username="primary_user", password="password")
 
         # retrieve endpoint
         rv = self.client.get(self.url)
         self.assertEqual(rv.status_code, 200)
         # make sure this endpoint returns current user data
-        self.assertEqual(rv.json()['username'], 'primary_user')
+        self.assertEqual(rv.json()["username"], "primary_user")
 
         # login as second user
-        self.client.login(username='secondary_user', password='password')
+        self.client.login(username="secondary_user", password="password")
         rv = self.client.get(self.url)
         self.assertEqual(rv.status_code, 200)
         # make sure this endpoint does not return first user data now
-        self.assertEqual(rv.json()['username'], 'secondary_user')
+        self.assertEqual(rv.json()["username"], "secondary_user")
 
     def test_all_related_objects_shown(self):
         """Test if all related fields are present in data output."""
@@ -243,41 +255,41 @@ class TestExportingPersonData(BaseExportingTest):
 
         # make sure these fields are NOT in the API output
         missing_fields = [
-            'password',
-            'is_active',
+            "password",
+            "is_active",
         ]
 
         # simple (non-relational) fields expected in API output
         expected_fields = [
-            'data_privacy_agreement',
-            'personal',
-            'middle',
-            'family',
-            'email',
-            'username',
-            'gender',
-            'may_contact',
-            'publish_profile',
-            'github',
-            'twitter',
-            'url',
-            'user_notes',
-            'affiliation',
-            'occupation',
-            'orcid',
+            "data_privacy_agreement",
+            "personal",
+            "middle",
+            "family",
+            "email",
+            "username",
+            "gender",
+            "may_contact",
+            "publish_profile",
+            "github",
+            "twitter",
+            "url",
+            "user_notes",
+            "affiliation",
+            "occupation",
+            "orcid",
         ]
 
         # relational fields expected in API output
         expected_relational = [
-            'airport',
-            'badges',
-            'lessons',
-            'domains',
-            'languages',
-            'tasks',  # renamed in serializer (was: task_set)
-            'awards',  # renamed in serializer (was: award_set)
-            'training_requests',  # renamed from "trainingrequest_set"
-            'training_progresses',  # renamed from "trainingprogress_set"
+            "airport",
+            "badges",
+            "lessons",
+            "domains",
+            "languages",
+            "tasks",  # renamed in serializer (was: task_set)
+            "awards",  # renamed in serializer (was: award_set)
+            "training_requests",  # renamed from "trainingrequest_set"
+            "training_progresses",  # renamed from "trainingprogress_set"
         ]
 
         # ensure missing fields are not to be found in API output
@@ -305,192 +317,186 @@ class TestExportingPersonData(BaseExportingTest):
         expected = dict()
 
         # test expected Airport output
-        expected['airport'] = {
-            'iata': 'DDD',
-            'fullname': 'Airport 55x105',
-            'country': 'CM',
-            'latitude': 55.0,
-            'longitude': 105.0,
+        expected["airport"] = {
+            "iata": "DDD",
+            "fullname": "Airport 55x105",
+            "country": "CM",
+            "latitude": 55.0,
+            "longitude": 105.0,
         }
-        self.assertEqual(data['airport'], expected['airport'])
+        self.assertEqual(data["airport"], expected["airport"])
 
         # test expected Badges output
-        expected['badges'] = [
+        expected["badges"] = [
             {
-                'name': 'swc-instructor',
-                'title': 'Software Carpentry Instructor',
-                'criteria': 'Teaching at Software Carpentry workshops or'
-                            ' online',
+                "name": "swc-instructor",
+                "title": "Software Carpentry Instructor",
+                "criteria": "Teaching at Software Carpentry workshops or" " online",
             },
             {
-                'name': 'dc-instructor',
-                'title': 'Data Carpentry Instructor',
-                'criteria': 'Teaching at Data Carpentry workshops or'
-                            ' online',
+                "name": "dc-instructor",
+                "title": "Data Carpentry Instructor",
+                "criteria": "Teaching at Data Carpentry workshops or" " online",
             },
         ]
-        self.assertEqual(data['badges'], expected['badges'])
+        self.assertEqual(data["badges"], expected["badges"])
 
         # test expected Awards output
-        expected['awards'] = [
+        expected["awards"] = [
             {
-                'badge': 'swc-instructor',
-                'awarded': '2018-06-16',
-                'event': {
-                    'slug': '2018-06-16-AMY-event',
-                    'start': '2018-06-16',
-                    'end': '2018-06-17',
-                    'tags': [],
-                    'website_url': 'http://example.org/2018-06-16-AMY-event',
-                    'venue': '',
-                    'address': '',
-                    'country': '',
-                    'latitude': None,
-                    'longitude': None,
-                }
+                "badge": "swc-instructor",
+                "awarded": "2018-06-16",
+                "event": {
+                    "slug": "2018-06-16-AMY-event",
+                    "start": "2018-06-16",
+                    "end": "2018-06-17",
+                    "tags": [],
+                    "website_url": "http://example.org/2018-06-16-AMY-event",
+                    "venue": "",
+                    "address": "",
+                    "country": "",
+                    "latitude": None,
+                    "longitude": None,
+                },
             },
             {
-                'badge': 'dc-instructor',
-                'awarded': '2018-06-16',
-                'event': None,
+                "badge": "dc-instructor",
+                "awarded": "2018-06-16",
+                "event": None,
             },
         ]
-        self.assertEqual(data['awards'], expected['awards'])
+        self.assertEqual(data["awards"], expected["awards"])
 
         # test expected Tasks output
-        expected['tasks'] = [
+        expected["tasks"] = [
             {
-                'event': {
-                    'slug': '2018-06-16-AMY-event',
-                    'start': '2018-06-16',
-                    'end': '2018-06-17',
-                    'tags': [],
-                    'website_url': 'http://example.org/2018-06-16-AMY-event',
-                    'venue': '',
-                    'address': '',
-                    'country': '',
-                    'latitude': None,
-                    'longitude': None,
+                "event": {
+                    "slug": "2018-06-16-AMY-event",
+                    "start": "2018-06-16",
+                    "end": "2018-06-17",
+                    "tags": [],
+                    "website_url": "http://example.org/2018-06-16-AMY-event",
+                    "venue": "",
+                    "address": "",
+                    "country": "",
+                    "latitude": None,
+                    "longitude": None,
                 },
-                'role': 'instructor',
+                "role": "instructor",
             },
         ]
-        self.assertEqual(data['tasks'], expected['tasks'])
+        self.assertEqual(data["tasks"], expected["tasks"])
 
         # test expected Languages output
-        expected['languages'] = [
-            'English',
-            'French',
+        expected["languages"] = [
+            "English",
+            "French",
         ]
-        self.assertEqual(data['languages'], expected['languages'])
+        self.assertEqual(data["languages"], expected["languages"])
 
         # test expected TrainingRequests output
-        expected['training_requests'] = [
+        expected["training_requests"] = [
             {
                 # these are generated by Django, so we borrow them from the
                 # output
-                'created_at': data['training_requests'][0]['created_at'],
-                'last_updated_at':
-                    data['training_requests'][0]['last_updated_at'],
-                'state': 'Pending',
-                'review_process': 'preapproved',
-                'group_name': 'Mosquitos',
-                'personal': 'User',
-                'middle': '',
-                'family': 'Primary',
-                'email': 'primary_user@amy.com',
-                'secondary_email': 'not-used-often@amy.com',
-                'github': 'primary_user',
-                'occupation': 'undisclosed',
-                'occupation_other': '',
-                'affiliation': 'AMY',
-                'location': 'Worldwide',
-                'country': 'W3',
-                'underresourced': False,
-                'domains': ['Chemistry'],
-                'domains_other': 'E-commerce',
-                'underrepresented': 'yes',
-                'underrepresented_details': 'LGBTQ',
-                'nonprofit_teaching_experience': 'Voluntary teacher',
-                'previous_involvement': ['instructor'],
-                'previous_training': 'A certification or short course',
-                'previous_training_other': '',
-                'previous_training_explanation':
-                    'A course for voluntary teaching',
-                'previous_experience': 'Teaching assistant for a full course',
-                'previous_experience_other': '',
-                'previous_experience_explanation':
-                    'After the course I became a TA',
-                'programming_language_usage_frequency': 'A few times a week',
-                'teaching_frequency_expectation': 'Several times a year',
-                'teaching_frequency_expectation_other': '',
-                'max_travelling_frequency': 'Not at all',
-                'max_travelling_frequency_other': '',
-                'reason': 'I want to became an instructor',
-                'user_notes': 'I like trains',
-                'training_completion_agreement': True,
-                'workshop_teaching_agreement': True,
-                'data_privacy_agreement': True,
-                'code_of_conduct_agreement': True,
+                "created_at": data["training_requests"][0]["created_at"],
+                "last_updated_at": data["training_requests"][0]["last_updated_at"],
+                "state": "Pending",
+                "review_process": "preapproved",
+                "group_name": "Mosquitos",
+                "personal": "User",
+                "middle": "",
+                "family": "Primary",
+                "email": "primary_user@amy.com",
+                "secondary_email": "not-used-often@amy.com",
+                "github": "primary_user",
+                "occupation": "undisclosed",
+                "occupation_other": "",
+                "affiliation": "AMY",
+                "location": "Worldwide",
+                "country": "W3",
+                "underresourced": False,
+                "domains": ["Chemistry"],
+                "domains_other": "E-commerce",
+                "underrepresented": "yes",
+                "underrepresented_details": "LGBTQ",
+                "nonprofit_teaching_experience": "Voluntary teacher",
+                "previous_involvement": ["instructor"],
+                "previous_training": "A certification or short course",
+                "previous_training_other": "",
+                "previous_training_explanation": "A course for voluntary teaching",
+                "previous_experience": "Teaching assistant for a full course",
+                "previous_experience_other": "",
+                "previous_experience_explanation": "After the course I became a TA",
+                "programming_language_usage_frequency": "A few times a week",
+                "teaching_frequency_expectation": "Several times a year",
+                "teaching_frequency_expectation_other": "",
+                "max_travelling_frequency": "Not at all",
+                "max_travelling_frequency_other": "",
+                "reason": "I want to became an instructor",
+                "user_notes": "I like trains",
+                "training_completion_agreement": True,
+                "workshop_teaching_agreement": True,
+                "data_privacy_agreement": True,
+                "code_of_conduct_agreement": True,
             }
         ]
 
-        self.assertEqual(len(data['training_requests']), 1)
-        self.assertEqual(data['training_requests'][0],
-                         expected['training_requests'][0])
+        self.assertEqual(len(data["training_requests"]), 1)
+        self.assertEqual(data["training_requests"][0], expected["training_requests"][0])
 
         # test expected TrainingProgress output
-        expected['training_progresses'] = [
+        expected["training_progresses"] = [
             {
                 # these are generated by Django, so we borrow them from the
                 # output
-                'created_at': data['training_progresses'][0]['created_at'],
-                'last_updated_at':
-                    data['training_progresses'][0]['last_updated_at'],
-                'requirement': {
-                    'name': 'Discussion',
-                    'url_required': False,
-                    'event_required': False,
+                "created_at": data["training_progresses"][0]["created_at"],
+                "last_updated_at": data["training_progresses"][0]["last_updated_at"],
+                "requirement": {
+                    "name": "Discussion",
+                    "url_required": False,
+                    "event_required": False,
                 },
-                'state': 'Passed',
-                'discarded': False,
-                'evaluated_by': None,
-                'event': {
-                    'slug': '2018-06-16-AMY-event',
-                    'start': '2018-06-16',
-                    'end': '2018-06-17',
-                    'tags': [],
-                    'website_url': 'http://example.org/2018-06-16-AMY-event',
-                    'venue': '',
-                    'address': '',
-                    'country': '',
-                    'latitude': None,
-                    'longitude': None,
+                "state": "Passed",
+                "discarded": False,
+                "evaluated_by": None,
+                "event": {
+                    "slug": "2018-06-16-AMY-event",
+                    "start": "2018-06-16",
+                    "end": "2018-06-17",
+                    "tags": [],
+                    "website_url": "http://example.org/2018-06-16-AMY-event",
+                    "venue": "",
+                    "address": "",
+                    "country": "",
+                    "latitude": None,
+                    "longitude": None,
                 },
-                'url': None,
+                "url": None,
             },
             {
                 # these are generated by Django, so we borrow them from the
                 # output
-                'created_at': data['training_progresses'][1]['created_at'],
-                'last_updated_at':
-                    data['training_progresses'][1]['last_updated_at'],
-                'requirement': {
-                    'name': 'DC Homework',
-                    'url_required': True,
-                    'event_required': False,
+                "created_at": data["training_progresses"][1]["created_at"],
+                "last_updated_at": data["training_progresses"][1]["last_updated_at"],
+                "requirement": {
+                    "name": "DC Homework",
+                    "url_required": True,
+                    "event_required": False,
                 },
-                'state': 'Failed',
-                'discarded': False,
-                'evaluated_by': {
-                    'name': 'Super User',
+                "state": "Failed",
+                "discarded": False,
+                "evaluated_by": {
+                    "name": "Super User",
                 },
-                'event': None,
-                'url': 'http://example.org/homework',
+                "event": None,
+                "url": "http://example.org/homework",
             },
         ]
-        self.assertEqual(len(data['training_progresses']), 2)
-        self.assertEqual(data['training_progresses'][0],
-                         expected['training_progresses'][0])
-        self.assertEqual(data['training_progresses'][1],
-                         expected['training_progresses'][1])
+        self.assertEqual(len(data["training_progresses"]), 2)
+        self.assertEqual(
+            data["training_progresses"][0], expected["training_progresses"][0]
+        )
+        self.assertEqual(
+            data["training_progresses"][1], expected["training_progresses"][1]
+        )

--- a/amy/api/tests/test_export.py
+++ b/amy/api/tests/test_export.py
@@ -1,10 +1,7 @@
 import datetime
-import json
-from unittest.mock import patch
 
 from django.urls import reverse
-from rest_framework import status
-from rest_framework.test import APITestCase, APIRequestFactory
+from rest_framework.test import APITestCase
 
 from workshops.models import (
     Badge,
@@ -20,7 +17,6 @@ from workshops.models import (
     TrainingRequirement,
     TrainingProgress,
 )
-from workshops.util import universal_date_format
 
 
 class BaseExportingTest(APITestCase):
@@ -108,14 +104,14 @@ class TestExportingPersonData(BaseExportingTest):
 
         # award user some badges via awards (intermediary model)
         # one badge was awarded for the event
-        award1 = Award.objects.create(
+        Award.objects.create(
             person=self.user,
             badge=Badge.objects.get(name="swc-instructor"),
             event=event,
             awarded=datetime.date(2018, 6, 16),
         )
         # second badge was awarded without any connected event
-        award2 = Award.objects.create(
+        Award.objects.create(
             person=self.user,
             badge=Badge.objects.get(name="dc-instructor"),
             awarded=datetime.date(2018, 6, 16),

--- a/amy/api/tests/test_trainingrequests.py
+++ b/amy/api/tests/test_trainingrequests.py
@@ -25,60 +25,63 @@ from workshops.models import (
 
 class TestListingTrainingRequests(APITestCase):
     view = TrainingRequests
-    url = 'api:training-requests'
+    url = "api:training-requests"
     maxDiff = None
 
     def setUp(self):
         # admin
         self.admin = Person.objects.create_superuser(
-                username="admin", personal="Super", family="User",
-                email="sudo@example.org", password='admin')
+            username="admin",
+            personal="Super",
+            family="User",
+            email="sudo@example.org",
+            password="admin",
+        )
         self.admin.data_privacy_agreement = True
         self.admin.save()
 
         # some roles don't exist
-        self.learner = Role.objects.create(name='learner',
-                                           verbose_name='Learner')
-        Role.objects.create(name='helper', verbose_name='Helper')
+        self.learner = Role.objects.create(name="learner", verbose_name="Learner")
+        Role.objects.create(name="helper", verbose_name="Helper")
 
         # some tags don't exist either
-        self.ttt = Tag.objects.create(name='TTT', details='Training')
+        self.ttt = Tag.objects.create(name="TTT", details="Training")
 
         # first training request (pending)
         self.tr1 = TrainingRequest(
-            state='p',
+            state="p",
             person=None,
-            review_process='preapproved',
-            group_name='GummiBears',
-            personal='Zummi',
-            middle='',
-            family='Gummi-Glen',
-            email='zummi@gummibears.com',
+            review_process="preapproved",
+            group_name="GummiBears",
+            personal="Zummi",
+            middle="",
+            family="Gummi-Glen",
+            email="zummi@gummibears.com",
             github=None,
-            occupation='',
-            occupation_other='Magician',
-            affiliation='Gummi-Glen',
-            location='Forest',
-            country='US',
+            occupation="",
+            occupation_other="Magician",
+            affiliation="Gummi-Glen",
+            location="Forest",
+            country="US",
             underresourced=True,
-            domains_other='Magic',
-            underrepresented='yes',
-            underrepresented_details='LGBTQ',
-            nonprofit_teaching_experience='None',
-            previous_training='none',
-            previous_training_other='',
-            previous_training_explanation='I have no formal education',
-            previous_experience='hours',
-            previous_experience_other='',
-            previous_experience_explanation='I taught other Gummies',
-            programming_language_usage_frequency='not-much',
-            teaching_frequency_expectation='monthly',
-            teaching_frequency_expectation_other='',
-            max_travelling_frequency='not-at-all',
-            max_travelling_frequency_other='',
-            reason='I hope to pass on the Gummi Wisdom one day, and to do that'
-                   ' I must know how to do it efficiently.',
-            user_notes='',
+            domains_other="Magic",
+            underrepresented="yes",
+            underrepresented_details="LGBTQ",
+            nonprofit_teaching_experience="None",
+            previous_training="none",
+            previous_training_other="",
+            previous_training_explanation="I have no formal education",
+            previous_experience="hours",
+            previous_experience_other="",
+            previous_experience_explanation="I taught other Gummies",
+            programming_language_usage_frequency="not-much",
+            teaching_frequency_expectation="monthly",
+            teaching_frequency_expectation_other="",
+            max_travelling_frequency="not-at-all",
+            max_travelling_frequency_other="",
+            reason="I hope to pass on the Gummi Wisdom one day, and to do that"
+            " I must know how to do it efficiently.",
+            user_notes="",
             training_completion_agreement=True,
             workshop_teaching_agreement=True,
             data_privacy_agreement=True,
@@ -86,77 +89,75 @@ class TestListingTrainingRequests(APITestCase):
         )
         self.tr1.save()
         self.tr1.domains.set(
-            KnowledgeDomain.objects.filter(name__in=['Chemistry', 'Medicine'])
+            KnowledgeDomain.objects.filter(name__in=["Chemistry", "Medicine"])
         )
         # no previous involvement
         self.tr1.previous_involvement.clear()
 
         # second training request (accepted)
         self.tr2 = TrainingRequest(
-            state='a',
+            state="a",
             person=self.admin,
-            review_process='preapproved',
-            group_name='GummiBears',
-            personal='Grammi',
-            middle='',
-            family='Gummi-Glen',
-            email='grammi@gummibears.com',
-            secondary_email='personal@gummibears.com',
+            review_process="preapproved",
+            group_name="GummiBears",
+            personal="Grammi",
+            middle="",
+            family="Gummi-Glen",
+            email="grammi@gummibears.com",
+            secondary_email="personal@gummibears.com",
             github=None,
-            occupation='',
-            occupation_other='Cook',
-            affiliation='Gummi-Glen',
-            location='Forest',
-            country='US',
+            occupation="",
+            occupation_other="Cook",
+            affiliation="Gummi-Glen",
+            location="Forest",
+            country="US",
             underresourced=True,
-            domains_other='Cooking',
-            underrepresented='no',
-            underrepresented_details='Male',
-            nonprofit_teaching_experience='None',
-            previous_training='none',
-            previous_training_other='',
-            previous_training_explanation='I have no formal education',
-            previous_experience='hours',
-            previous_experience_other='',
-            previous_experience_explanation='I taught other Gummies',
-            programming_language_usage_frequency='not-much',
-            teaching_frequency_expectation='monthly',
-            teaching_frequency_expectation_other='',
-            max_travelling_frequency='not-at-all',
-            max_travelling_frequency_other='',
-            reason='I need to pass on the Gummiberry juice recipe one day, and'
-                   ' to do that I must know how to do it efficiently.',
-            user_notes='',
+            domains_other="Cooking",
+            underrepresented="no",
+            underrepresented_details="Male",
+            nonprofit_teaching_experience="None",
+            previous_training="none",
+            previous_training_other="",
+            previous_training_explanation="I have no formal education",
+            previous_experience="hours",
+            previous_experience_other="",
+            previous_experience_explanation="I taught other Gummies",
+            programming_language_usage_frequency="not-much",
+            teaching_frequency_expectation="monthly",
+            teaching_frequency_expectation_other="",
+            max_travelling_frequency="not-at-all",
+            max_travelling_frequency_other="",
+            reason="I need to pass on the Gummiberry juice recipe one day, and"
+            " to do that I must know how to do it efficiently.",
+            user_notes="",
             training_completion_agreement=True,
             workshop_teaching_agreement=True,
             data_privacy_agreement=True,
             code_of_conduct_agreement=True,
         )
         self.tr2.save()
-        self.tr2.domains.set(
-            KnowledgeDomain.objects.filter(name__in=['Chemistry'])
-        )
+        self.tr2.domains.set(KnowledgeDomain.objects.filter(name__in=["Chemistry"]))
         self.tr2.previous_involvement.set(
-            Role.objects.filter(name__in=['learner', 'helper'])
+            Role.objects.filter(name__in=["learner", "helper"])
         )
 
         # add TTT event self.admin was matched to
         self.ttt_event = Event(
-            slug='2018-07-12-TTT-event',
+            slug="2018-07-12-TTT-event",
             host=Organization.objects.first(),
         )
         self.ttt_event.save()
-        self.ttt_event.tags.set(Tag.objects.filter(name='TTT'))
+        self.ttt_event.tags.set(Tag.objects.filter(name="TTT"))
         self.admin.task_set.create(role=self.learner, event=self.ttt_event)
 
         # add some badges
         self.admin.award_set.create(
-            badge=Badge.objects.get(name='swc-instructor'),
-            awarded=datetime.date(2018, 7, 12)
+            badge=Badge.objects.get(name="swc-instructor"),
+            awarded=datetime.date(2018, 7, 12),
         )
         self.admin.award_set.create(
-            badge=Badge.objects.get(name='dc-instructor'),
-            awarded=datetime.date(2018, 7, 12)
+            badge=Badge.objects.get(name="dc-instructor"),
+            awarded=datetime.date(2018, 7, 12),
         )
 
         current_tz = timezone.get_current_timezone()
@@ -167,120 +168,113 @@ class TestListingTrainingRequests(APITestCase):
                 # due to "strange feature" in DRF, the DateTimeField serialized
                 # representation gets rid of '+00:00' and changes it to 'Z'
                 # if the representation is in UTC
-                'created_at':
-                    self.tr1.created_at.astimezone(current_tz).isoformat()
-                                       .replace("+00:00", "Z"),
-                'last_updated_at':
-                    self.tr1.last_updated_at.astimezone(current_tz).isoformat()
-                                            .replace("+00:00", "Z"),
-                'state': 'Pending',
-                'person': None,
-                'person_id': None,
-                'awards': '',
-                'training_tasks': '',
-                'review_process': 'preapproved',
-                'group_name': 'GummiBears',
-                'personal': 'Zummi',
-                'middle': '',
-                'family': 'Gummi-Glen',
-                'email': 'zummi@gummibears.com',
-                'secondary_email': '',
-                'github': None,
-                'underrepresented': 'yes',
-                'underrepresented_details': 'LGBTQ',
-                'occupation': '',
-                'occupation_other': 'Magician',
-                'affiliation': 'Gummi-Glen',
-                'location': 'Forest',
-                'country': 'US',
-                'underresourced': True,
-                'domains': 'Chemistry, Medicine',
-                'domains_other': 'Magic',
-                'nonprofit_teaching_experience': 'None',
-                'previous_involvement': '',
-                'previous_training': 'None',
-                'previous_training_other': '',
-                'previous_training_explanation': 'I have no formal education',
-                'previous_experience': 'A few hours',
-                'previous_experience_other': '',
-                'previous_experience_explanation': 'I taught other Gummies',
-                'programming_language_usage_frequency':
-                    'Never or almost never',
-                'teaching_frequency_expectation': 'Several times a year',
-                'teaching_frequency_expectation_other': '',
-                'max_travelling_frequency': 'Not at all',
-                'max_travelling_frequency_other': '',
-                'reason':
-                    'I hope to pass on the Gummi Wisdom one day, and to do '
-                    'that I must know how to do it efficiently.',
-                'user_notes': '',
-                'training_completion_agreement': True,
-                'workshop_teaching_agreement': True,
-                'data_privacy_agreement': True,
-                'code_of_conduct_agreement': True,
+                "created_at": self.tr1.created_at.astimezone(current_tz)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "last_updated_at": self.tr1.last_updated_at.astimezone(current_tz)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "state": "Pending",
+                "person": None,
+                "person_id": None,
+                "awards": "",
+                "training_tasks": "",
+                "review_process": "preapproved",
+                "group_name": "GummiBears",
+                "personal": "Zummi",
+                "middle": "",
+                "family": "Gummi-Glen",
+                "email": "zummi@gummibears.com",
+                "secondary_email": "",
+                "github": None,
+                "underrepresented": "yes",
+                "underrepresented_details": "LGBTQ",
+                "occupation": "",
+                "occupation_other": "Magician",
+                "affiliation": "Gummi-Glen",
+                "location": "Forest",
+                "country": "US",
+                "underresourced": True,
+                "domains": "Chemistry, Medicine",
+                "domains_other": "Magic",
+                "nonprofit_teaching_experience": "None",
+                "previous_involvement": "",
+                "previous_training": "None",
+                "previous_training_other": "",
+                "previous_training_explanation": "I have no formal education",
+                "previous_experience": "A few hours",
+                "previous_experience_other": "",
+                "previous_experience_explanation": "I taught other Gummies",
+                "programming_language_usage_frequency": "Never or almost never",
+                "teaching_frequency_expectation": "Several times a year",
+                "teaching_frequency_expectation_other": "",
+                "max_travelling_frequency": "Not at all",
+                "max_travelling_frequency_other": "",
+                "reason": "I hope to pass on the Gummi Wisdom one day, and to do "
+                "that I must know how to do it efficiently.",
+                "user_notes": "",
+                "training_completion_agreement": True,
+                "workshop_teaching_agreement": True,
+                "data_privacy_agreement": True,
+                "code_of_conduct_agreement": True,
             },
             {
                 # due to "strange feature" in DRF, the DateTimeField serialized
                 # representation gets rid of '+00:00' and changes it to 'Z'
                 # if the representation is in UTC
-                'created_at':
-                    self.tr2.created_at.astimezone(current_tz).isoformat()
-                                       .replace("+00:00", "Z"),
-                'last_updated_at':
-                    self.tr2.last_updated_at.astimezone(current_tz).isoformat()
-                                            .replace("+00:00", "Z"),
-                'state': 'Accepted',
-                'person': 'Super User',
-                'person_id': self.admin.pk,
-                'awards': 'swc-instructor 2018-07-12, '
-                          'dc-instructor 2018-07-12',
-                'training_tasks': '2018-07-12-TTT-event',
-                'review_process': 'preapproved',
-                'group_name': 'GummiBears',
-                'personal': 'Grammi',
-                'middle': '',
-                'family': 'Gummi-Glen',
-                'email': 'grammi@gummibears.com',
-                'secondary_email': 'personal@gummibears.com',
-                'github': None,
-                'underrepresented': 'no',
-                'underrepresented_details': 'Male',
-                'occupation': '',
-                'occupation_other': 'Cook',
-                'affiliation': 'Gummi-Glen',
-                'location': 'Forest',
-                'country': 'US',
-                'underresourced': True,
-                'domains': 'Chemistry',
-                'domains_other': 'Cooking',
-                'nonprofit_teaching_experience': 'None',
-                'previous_involvement': 'learner, helper',
-                'previous_training': 'None',
-                'previous_training_other': '',
-                'previous_training_explanation': 'I have no formal education',
-                'previous_experience': 'A few hours',
-                'previous_experience_other': '',
-                'previous_experience_explanation':
-                    'I taught other Gummies',
-                'programming_language_usage_frequency':
-                    'Never or almost never',
-                'teaching_frequency_expectation': 'Several times a year',
-                'teaching_frequency_expectation_other': '',
-                'max_travelling_frequency': 'Not at all',
-                'max_travelling_frequency_other': '',
-                'reason':
-                    'I need to pass on the Gummiberry juice recipe one day,'
-                    ' and to do that I must know how to do it efficiently.',
-                'user_notes': '',
-                'training_completion_agreement': True,
-                'workshop_teaching_agreement': True,
-                'data_privacy_agreement': True,
-                'code_of_conduct_agreement': True,
+                "created_at": self.tr2.created_at.astimezone(current_tz)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "last_updated_at": self.tr2.last_updated_at.astimezone(current_tz)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "state": "Accepted",
+                "person": "Super User",
+                "person_id": self.admin.pk,
+                "awards": "swc-instructor 2018-07-12, " "dc-instructor 2018-07-12",
+                "training_tasks": "2018-07-12-TTT-event",
+                "review_process": "preapproved",
+                "group_name": "GummiBears",
+                "personal": "Grammi",
+                "middle": "",
+                "family": "Gummi-Glen",
+                "email": "grammi@gummibears.com",
+                "secondary_email": "personal@gummibears.com",
+                "github": None,
+                "underrepresented": "no",
+                "underrepresented_details": "Male",
+                "occupation": "",
+                "occupation_other": "Cook",
+                "affiliation": "Gummi-Glen",
+                "location": "Forest",
+                "country": "US",
+                "underresourced": True,
+                "domains": "Chemistry",
+                "domains_other": "Cooking",
+                "nonprofit_teaching_experience": "None",
+                "previous_involvement": "learner, helper",
+                "previous_training": "None",
+                "previous_training_other": "",
+                "previous_training_explanation": "I have no formal education",
+                "previous_experience": "A few hours",
+                "previous_experience_other": "",
+                "previous_experience_explanation": "I taught other Gummies",
+                "programming_language_usage_frequency": "Never or almost never",
+                "teaching_frequency_expectation": "Several times a year",
+                "teaching_frequency_expectation_other": "",
+                "max_travelling_frequency": "Not at all",
+                "max_travelling_frequency_other": "",
+                "reason": "I need to pass on the Gummiberry juice recipe one day,"
+                " and to do that I must know how to do it efficiently.",
+                "user_notes": "",
+                "training_completion_agreement": True,
+                "workshop_teaching_agreement": True,
+                "data_privacy_agreement": True,
+                "code_of_conduct_agreement": True,
             },
         ]
 
-    @patch.object(TrainingRequests, 'request', query_params=QueryDict(),
-                  create=True)
+    @patch.object(TrainingRequests, "request", query_params=QueryDict(), create=True)
     def test_serialization(self, mock_request):
         # we're mocking a request here because it's not possible to create
         # a fake request context for the view
@@ -295,38 +289,37 @@ class TestListingTrainingRequests(APITestCase):
         url = reverse(self.url)
 
         # get CSV-formatted output
-        self.client.login(username='admin', password='admin')
-        response = self.client.get(url, {'format': 'csv'})
-        content = response.content.decode('utf-8')
+        self.client.login(username="admin", password="admin")
+        response = self.client.get(url, {"format": "csv"})
+        content = response.content.decode("utf-8")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         firstline = content.splitlines()[0]
         expected_firstline = (
-            'Created at,Last updated at,State,Matched Trainee,'
-            'Matched Trainee ID,Badges,Training Tasks,'
-            'Application Type,Registration Code,'
-            'Personal,Middle,Family,Email,Secondary email,GitHub username,'
-            'Underrepresented,'
-            'Underrepresented (reason),Occupation,Occupation (other),'
-            'Affiliation,Location,Country,Underresourced institution,'
-            'Expertise areas,Expertise areas (other),'
-            'Non-profit teaching experience,Previous Involvement,'
-            'Previous Training in Teaching,Previous Training (other),'
-            'Previous Training (explanation),Previous Experience in Teaching,'
-            'Previous Experience (other),Previous Experience (explanation),'
-            'Programming Language Usage,Teaching Frequency Expectation,'
-            'Teaching Frequency Expectation (other),Max Travelling Frequency,'
-            'Max Travelling Frequency (other),Reason for undertaking training,'
-            'User notes,Training completion agreement (yes/no),'
-            'Workshop teaching agreement (yes/no),'
-            'Data privacy agreement (yes/no),'
-            'Code of Conduct agreement (yes/no)'
+            "Created at,Last updated at,State,Matched Trainee,"
+            "Matched Trainee ID,Badges,Training Tasks,"
+            "Application Type,Registration Code,"
+            "Personal,Middle,Family,Email,Secondary email,GitHub username,"
+            "Underrepresented,"
+            "Underrepresented (reason),Occupation,Occupation (other),"
+            "Affiliation,Location,Country,Underresourced institution,"
+            "Expertise areas,Expertise areas (other),"
+            "Non-profit teaching experience,Previous Involvement,"
+            "Previous Training in Teaching,Previous Training (other),"
+            "Previous Training (explanation),Previous Experience in Teaching,"
+            "Previous Experience (other),Previous Experience (explanation),"
+            "Programming Language Usage,Teaching Frequency Expectation,"
+            "Teaching Frequency Expectation (other),Max Travelling Frequency,"
+            "Max Travelling Frequency (other),Reason for undertaking training,"
+            "User notes,Training completion agreement (yes/no),"
+            "Workshop teaching agreement (yes/no),"
+            "Data privacy agreement (yes/no),"
+            "Code of Conduct agreement (yes/no)"
         )
 
         self.assertEqual(firstline, expected_firstline)
 
-    @patch.object(TrainingRequests, 'request', query_params=QueryDict(),
-                  create=True)
+    @patch.object(TrainingRequests, "request", query_params=QueryDict(), create=True)
     def test_M2M_columns(self, mock_request):
         """Some columns are M2M fields, but should be displayed as a string,
         not array /list/."""
@@ -335,16 +328,15 @@ class TestListingTrainingRequests(APITestCase):
         response = serializer_class(self.view().get_queryset(), many=True)
         self.assertEqual(len(response.data), 2)
 
-        self.assertEqual(response.data[0]['domains'], 'Chemistry, Medicine')
-        self.assertEqual(response.data[1]['previous_involvement'],
-                         'learner, helper')
+        self.assertEqual(response.data[0]["domains"], "Chemistry, Medicine")
+        self.assertEqual(response.data[1]["previous_involvement"], "learner, helper")
 
     def test_selected_ids(self):
         """Test if filtering by IDs works properly."""
         url = reverse(self.url)
 
-        self.client.login(username='admin', password='admin')
-        response = self.client.get(url, {'ids': '{}'.format(self.tr2.pk)})
+        self.client.login(username="admin", password="admin")
+        response = self.client.get(url, {"ids": "{}".format(self.tr2.pk)})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         json = response.json()

--- a/amy/autoemails/actions.py
+++ b/amy/autoemails/actions.py
@@ -516,9 +516,7 @@ class PostWorkshopAction(BaseAction):
             Person.objects.filter(task__in=event.task_set.filter(role__name="helper"))
         )
         context["hosts"] = list(
-            Person.objects.filter(
-                task__in=event.task_set.filter(role__name="host")
-            )
+            Person.objects.filter(task__in=event.task_set.filter(role__name="host"))
         )
 
         # querying over Person.objects lets us get rid of duplicates

--- a/amy/autoemails/apps.py
+++ b/amy/autoemails/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class AutoemailsConfig(AppConfig):
-    name = 'autoemails'
+    name = "autoemails"

--- a/amy/autoemails/base_views.py
+++ b/amy/autoemails/base_views.py
@@ -11,8 +11,7 @@ from .utils import (
 
 
 class ActionManageMixin:
-    """Mixin used for adding/removing Actions related to an object.
-    """
+    """Mixin used for adding/removing Actions related to an object."""
 
     def get_logger(self):
         raise NotImplementedError()
@@ -96,12 +95,12 @@ class ActionManageMixin:
                 messages.info(
                     request,
                     format_html(
-                        'New email ({}) was scheduled to run '
+                        "New email ({}) was scheduled to run "
                         '<relative-time datetime="{}">{}</relative-time>: '
                         '<a href="{}">{}</a>.',
                         trigger.get_action_display(),
                         scheduled_at.isoformat(),
-                        '{:%Y-%m-%d %H:%M}'.format(scheduled_at),
+                        "{:%Y-%m-%d %H:%M}".format(scheduled_at),
                         reverse("admin:autoemails_rqjob_preview", args=[rqj.pk]),
                         job.id,
                     ),
@@ -112,7 +111,13 @@ class ActionManageMixin:
 
     @staticmethod
     def remove(
-        action_class, logger, scheduler, connection, jobs, object_, request=None,
+        action_class,
+        logger,
+        scheduler,
+        connection,
+        jobs,
+        object_,
+        request=None,
     ):
         Action = action_class
         action_name = Action.__name__

--- a/amy/autoemails/forms.py
+++ b/amy/autoemails/forms.py
@@ -18,13 +18,17 @@ class RescheduleForm(forms.Form):
 
 class TemplateForm(forms.Form):
     template = MarkdownxFormField(
-        label="Markdown body", widget=AdminMarkdownxWidget, required=True,
+        label="Markdown body",
+        widget=AdminMarkdownxWidget,
+        required=True,
     )
 
 
 class GenericEmailScheduleForm(forms.ModelForm):
     body_template = MarkdownxFormField(
-        label="Markdown body", widget=AdminMarkdownxWidget, required=True,
+        label="Markdown body",
+        widget=AdminMarkdownxWidget,
+        required=True,
     )
     helper = BootstrapHelper(
         wider_labels=True,

--- a/amy/autoemails/models.py
+++ b/amy/autoemails/models.py
@@ -320,7 +320,10 @@ class RQJob(CreatedUpdatedMixin, models.Model):
     """Simple class for storing Redis Queue job's ID."""
 
     job_id = models.CharField(
-        max_length=100, blank=False, null=False, verbose_name="RQ Job ID",
+        max_length=100,
+        blank=False,
+        null=False,
+        verbose_name="RQ Job ID",
     )
 
     trigger = models.ForeignKey(

--- a/amy/autoemails/tests/base.py
+++ b/amy/autoemails/tests/base.py
@@ -26,7 +26,7 @@ class FakeRedisTestCaseMixin:
         self.connection = connection
         # self.connection = Redis()
         self.queue = Queue(is_async=False, connection=self.connection, job_class=Job)
-        self.scheduler = django_rq.get_scheduler('testing', queue=self.queue)
+        self.scheduler = django_rq.get_scheduler("testing", queue=self.queue)
         self.scheduler.connection = self.connection
 
     def tearDown(self):

--- a/amy/autoemails/tests/test_action.py
+++ b/amy/autoemails/tests/test_action.py
@@ -79,7 +79,8 @@ Sincerely,
     def prepare_trigger(self):
         """Create a sample trigger using our sample template."""
         self.trigger = Trigger.objects.create(
-            action="new-instructor", template=self.template,
+            action="new-instructor",
+            template=self.template,
         )
 
     def prepare_context(self):

--- a/amy/autoemails/tests/test_actionmanagemixin.py
+++ b/amy/autoemails/tests/test_actionmanagemixin.py
@@ -26,33 +26,38 @@ class TestActionManageMixin(FakeRedisTestCaseMixin, TestCase):
 
         # prepare some necessary objects
         self.template = EmailTemplate.objects.create()
-        self.trigger = Trigger.objects.create(action='test-action',
-                                              template=self.template)
+        self.trigger = Trigger.objects.create(
+            action="test-action", template=self.template
+        )
 
         # totally fake Task, Role and Event data
-        Tag.objects.bulk_create([
-            Tag(name='SWC'),
-            Tag(name='DC'),
-            Tag(name='LC'),
-        ])
+        Tag.objects.bulk_create(
+            [
+                Tag(name="SWC"),
+                Tag(name="DC"),
+                Tag(name="LC"),
+            ]
+        )
         self.event = Event.objects.create(
-            slug='test-event',
+            slug="test-event",
             host=Organization.objects.first(),
             start=date.today() + timedelta(days=7),
             end=date.today() + timedelta(days=8),
-            country='GB',
-            venue='Ministry of Magic',
-            address='Underground',
+            country="GB",
+            venue="Ministry of Magic",
+            address="Underground",
             latitude=20.0,
             longitude=20.0,
-            url='https://test-event.example.com',
+            url="https://test-event.example.com",
         )
-        self.event.tags.set(Tag.objects.filter(name__in=['SWC', 'DC', 'LC']))
-        self.person = Person.objects.create(personal='Harry', family='Potter',
-                                            email='hp@magic.uk')
-        self.role = Role.objects.create(name='instructor')
-        self.task = Task.objects.create(event=self.event, person=self.person,
-                                        role=self.role)
+        self.event.tags.set(Tag.objects.filter(name__in=["SWC", "DC", "LC"]))
+        self.person = Person.objects.create(
+            personal="Harry", family="Potter", email="hp@magic.uk"
+        )
+        self.role = Role.objects.create(name="instructor")
+        self.task = Task.objects.create(
+            event=self.event, person=self.person, role=self.role
+        )
 
     def testNotImplementedMethods(self):
         a = ActionManageMixin()
@@ -111,7 +116,7 @@ class TestActionManageMixin(FakeRedisTestCaseMixin, TestCase):
             def request(self):
                 # fake request created thanks to RequestFactory from Django
                 # Test Client
-                req = RequestFactory().post('/tasks/create')
+                req = RequestFactory().post("/tasks/create")
                 return req
 
         # almost identical action object to a one that is created in the view
@@ -146,10 +151,12 @@ class TestActionManageMixin(FakeRedisTestCaseMixin, TestCase):
         self.assertEqual(job.instance, action)
 
         # job appeared in the queue
-        enqueued_job, enqueued_timestamp = list(self.scheduler.get_jobs(
-            until=to_unix(datetime.utcnow() + action.launch_at),
-            with_times=True,
-        ))[0]
+        enqueued_job, enqueued_timestamp = list(
+            self.scheduler.get_jobs(
+                until=to_unix(datetime.utcnow() + action.launch_at),
+                with_times=True,
+            )
+        )[0]
         self.assertEqual(job, enqueued_job)
 
         # job appeared in the queue with correct timestamp (we accept +- 1min)
@@ -218,7 +225,7 @@ class TestActionManageMixin(FakeRedisTestCaseMixin, TestCase):
             def request(self):
                 # fake request created thanks to RequestFactory from Django
                 # Test Client
-                req = RequestFactory().post('/tasks/create')
+                req = RequestFactory().post("/tasks/create")
                 return req
 
             def get_jobs(self, as_id_list=True):

--- a/amy/autoemails/tests/test_admin_edit_template.py
+++ b/amy/autoemails/tests/test_admin_edit_template.py
@@ -25,16 +25,17 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
 
         # fake RQJob
         self.email = EmailTemplate.objects.create(slug="test-1")
-        self.trigger = Trigger.objects.create(action="new-instructor",
-                                              template=self.email)
-        self.rqjob = RQJob.objects.create(job_id="fake-id",
-                                          trigger=self.trigger)
+        self.trigger = Trigger.objects.create(
+            action="new-instructor", template=self.email
+        )
+        self.rqjob = RQJob.objects.create(job_id="fake-id", trigger=self.trigger)
 
         self.new_template = "Welcome to AMY!"
 
         # test event and task
-        LC_org = Organization.objects.create(domain="librarycarpentry.org",
-                                             fullname="Library Carpentry")
+        LC_org = Organization.objects.create(
+            domain="librarycarpentry.org", fullname="Library Carpentry"
+        )
         self.event = Event.objects.create(
             slug="test-event",
             host=Organization.objects.first(),
@@ -42,8 +43,9 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
             start=date.today() + timedelta(days=7),
             end=date.today() + timedelta(days=8),
         )
-        p = Person.objects.create(personal="Harry", family="Potter",
-                                  email="hp@magic.uk")
+        p = Person.objects.create(
+            personal="Harry", family="Potter", email="hp@magic.uk"
+        )
         r = Role.objects.create(name="instructor")
         self.task = Task.objects.create(event=self.event, person=p, role=r)
 
@@ -56,30 +58,29 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # log admin user
         self._logSuperuserIn()
 
-        url = reverse('admin:autoemails_rqjob_edit_template', args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_edit_template", args=[self.rqjob.pk])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 405)  # Method not allowed
 
     def test_view_access_by_anonymous(self):
-        url = reverse('admin:autoemails_rqjob_edit_template',
-                      args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_edit_template", args=[self.rqjob.pk])
         rv = self.client.post(url)
         self.assertEqual(rv.status_code, 302)
         # cannot check by assertRedirect because there's additional `?next`
         # parameter
-        self.assertTrue(rv.url.startswith(reverse('login')))
+        self.assertTrue(rv.url.startswith(reverse("login")))
 
     def test_view_access_by_admin(self):
         # log admin user
         self._logSuperuserIn()
 
         # try accessing the view again
-        url = reverse('admin:autoemails_rqjob_edit_template',
-                      args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_edit_template", args=[self.rqjob.pk])
         rv = self.client.post(url)
         self.assertEqual(rv.status_code, 302)
-        self.assertRedirects(rv, reverse('admin:autoemails_rqjob_preview',
-                                         args=[self.rqjob.pk]))
+        self.assertRedirects(
+            rv, reverse("admin:autoemails_rqjob_preview", args=[self.rqjob.pk])
+        )
 
     def test_no_such_job(self):
         # log admin user
@@ -88,11 +89,11 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         with self.assertRaises(NoSuchJobError):
             Job.fetch(self.rqjob.job_id, connection=self.scheduler.connection)
 
-        url = reverse('admin:autoemails_rqjob_edit_template', args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_edit_template", args=[self.rqjob.pk])
         rv = self.client.post(url, follow=True)
         self.assertIn(
-            'The corresponding job in Redis was probably already executed',
-            rv.content.decode('utf-8'),
+            "The corresponding job in Redis was probably already executed",
+            rv.content.decode("utf-8"),
         )
 
     def test_job_not_in_scheduled_jobs_queue(self):
@@ -105,19 +106,15 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         Job.fetch(job1.id, connection=self.scheduler.connection)  # no error
         with self.connection.pipeline() as pipe:
             pipe.watch(self.scheduler.scheduled_jobs_key)
-            self.assertIsNone(
-                pipe.zscore(
-                    self.scheduler.scheduled_jobs_key, job1.id
-                )
-            )
-        url = reverse('admin:autoemails_rqjob_edit_template', args=[rqjob1.pk])
+            self.assertIsNone(pipe.zscore(self.scheduler.scheduled_jobs_key, job1.id))
+        url = reverse("admin:autoemails_rqjob_edit_template", args=[rqjob1.pk])
         payload = {
-            'template': self.new_template,
+            "template": self.new_template,
         }
         rv = self.client.post(url, payload, follow=True)
         self.assertIn(
             f"The job {job1.id} template cannot be updated.",
-            rv.content.decode('utf-8'),
+            rv.content.decode("utf-8"),
         )
 
         # case 2: job is no longer in the RQ-Scheduler queue, but it was there!
@@ -130,11 +127,11 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # move job to the queue so it's executed
         self.scheduler.enqueue_job(job2)
         Job.fetch(job2.id, connection=self.scheduler.connection)  # no error
-        url = reverse('admin:autoemails_rqjob_edit_template', args=[rqjob2.pk])
+        url = reverse("admin:autoemails_rqjob_edit_template", args=[rqjob2.pk])
         rv = self.client.post(url, payload, follow=True)
         self.assertIn(
             f"The job {job2.id} template cannot be updated.",
-            rv.content.decode('utf-8'),
+            rv.content.decode("utf-8"),
         )
 
     def test_job_template_updated_correctly(self):
@@ -151,13 +148,14 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         )
         rqjob = RQJob.objects.create(job_id=job.id, trigger=self.trigger)
         Job.fetch(job.id, connection=self.scheduler.connection)  # no error
-        url = reverse('admin:autoemails_rqjob_edit_template', args=[rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_edit_template", args=[rqjob.pk])
         payload = {
-            'template': self.new_template,
+            "template": self.new_template,
         }
         rv = self.client.post(url, payload, follow=True)
         self.assertIn(
-            f'The job {job.id} template was updated', rv.content.decode('utf-8'),
+            f"The job {job.id} template was updated",
+            rv.content.decode("utf-8"),
         )
 
         job.refresh()

--- a/amy/autoemails/tests/test_admin_preview.py
+++ b/amy/autoemails/tests/test_admin_preview.py
@@ -31,10 +31,10 @@ class TestAdminJobPreview(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
 
         # fake RQJob
         self.email = EmailTemplate.objects.create(slug="test-1")
-        self.trigger = Trigger.objects.create(action="new-instructor",
-                                              template=self.email)
-        self.rqjob = RQJob.objects.create(job_id="fake-id",
-                                          trigger=self.trigger)
+        self.trigger = Trigger.objects.create(
+            action="new-instructor", template=self.email
+        )
+        self.rqjob = RQJob.objects.create(job_id="fake-id", trigger=self.trigger)
 
     def tearDown(self):
         super().tearDown()
@@ -44,32 +44,36 @@ class TestAdminJobPreview(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
     def prepare_data(self):
         """Create some real data (real Event, Task, Person, or action)."""
         # totally fake Task, Role and Event data
-        Tag.objects.bulk_create([
-            Tag(name='SWC'),
-            Tag(name='DC'),
-            Tag(name='LC'),
-        ])
+        Tag.objects.bulk_create(
+            [
+                Tag(name="SWC"),
+                Tag(name="DC"),
+                Tag(name="LC"),
+            ]
+        )
         self.event = Event.objects.create(
-            slug='test-event',
+            slug="test-event",
             host=Organization.objects.first(),
             start=date.today() + timedelta(days=7),
             end=date.today() + timedelta(days=8),
-            country='GB',
-            venue='Ministry of Magic',
-            address='Underground',
+            country="GB",
+            venue="Ministry of Magic",
+            address="Underground",
             latitude=20.0,
             longitude=20.0,
-            url='https://test-event.example.com',
+            url="https://test-event.example.com",
         )
-        self.event.tags.set(Tag.objects.filter(name__in=['SWC', 'DC', 'LC']))
-        self.person = Person.objects.create(personal='Harry', family='Potter',
-                                            email='hp@magic.uk')
-        self.role = Role.objects.create(name='instructor')
-        self.task = Task.objects.create(event=self.event, person=self.person,
-                                        role=self.role)
+        self.event.tags.set(Tag.objects.filter(name__in=["SWC", "DC", "LC"]))
+        self.person = Person.objects.create(
+            personal="Harry", family="Potter", email="hp@magic.uk"
+        )
+        self.role = Role.objects.create(name="instructor")
+        self.task = Task.objects.create(
+            event=self.event, person=self.person, role=self.role
+        )
 
     def test_view_access_by_anonymous(self):
-        url = reverse('admin:autoemails_rqjob_preview', args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_preview", args=[self.rqjob.pk])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 302)
 
@@ -78,7 +82,7 @@ class TestAdminJobPreview(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         self._logSuperuserIn()
 
         # try accessing the view again
-        url = reverse('admin:autoemails_rqjob_preview', args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_preview", args=[self.rqjob.pk])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 200)
 
@@ -86,20 +90,20 @@ class TestAdminJobPreview(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # log admin user
         self._logSuperuserIn()
 
-        url = reverse('admin:autoemails_rqjob_preview', args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_preview", args=[self.rqjob.pk])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 200)
 
         # We can't fetch a non-existing Job (id: "fake-id"), so almost all
         # fields are None'd.
-        self.assertEqual(rv.context['rqjob'], self.rqjob)
-        self.assertEqual(rv.context['job'], None)
-        self.assertEqual(rv.context['job_scheduled'], None)
-        self.assertEqual(rv.context['instance'], None)
-        self.assertEqual(rv.context['trigger'], None)
-        self.assertEqual(rv.context['template'], None)
-        self.assertEqual(rv.context['email'], None)
-        self.assertEqual(rv.context['adn_context'], None)
+        self.assertEqual(rv.context["rqjob"], self.rqjob)
+        self.assertEqual(rv.context["job"], None)
+        self.assertEqual(rv.context["job_scheduled"], None)
+        self.assertEqual(rv.context["instance"], None)
+        self.assertEqual(rv.context["trigger"], None)
+        self.assertEqual(rv.context["template"], None)
+        self.assertEqual(rv.context["email"], None)
+        self.assertEqual(rv.context["adn_context"], None)
 
     def test_preview_job_properties_nonexist(self):
         # create some dummy job
@@ -110,20 +114,20 @@ class TestAdminJobPreview(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # log admin user
         self._logSuperuserIn()
 
-        url = reverse('admin:autoemails_rqjob_preview', args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_preview", args=[self.rqjob.pk])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 200)
 
         # We can fetch the Job (id isn't fake anymore), but almost all
         # fields are None'd.
-        self.assertEqual(rv.context['rqjob'], self.rqjob)
-        self.assertEqual(rv.context['job'], job)
-        self.assertEqual(rv.context['job_scheduled'], None)
-        self.assertEqual(rv.context['instance'], None)
-        self.assertEqual(rv.context['trigger'], None)
-        self.assertEqual(rv.context['template'], None)
-        self.assertEqual(rv.context['email'], None)
-        self.assertEqual(rv.context['adn_context'], None)
+        self.assertEqual(rv.context["rqjob"], self.rqjob)
+        self.assertEqual(rv.context["job"], job)
+        self.assertEqual(rv.context["job_scheduled"], None)
+        self.assertEqual(rv.context["instance"], None)
+        self.assertEqual(rv.context["trigger"], None)
+        self.assertEqual(rv.context["template"], None)
+        self.assertEqual(rv.context["email"], None)
+        self.assertEqual(rv.context["adn_context"], None)
 
     def test_preview_scheduled_job(self):
         # prepare fake data
@@ -144,20 +148,20 @@ class TestAdminJobPreview(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # log admin user
         self._logSuperuserIn()
 
-        url = reverse('admin:autoemails_rqjob_preview', args=[rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_preview", args=[rqjob.pk])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 200)
 
         # We can fetch the Job, it's coming from NewInstructorAction.__call__
-        self.assertEqual(rv.context['rqjob'], rqjob)
-        self.assertEqual(rv.context['job'], job)
-        self.assertEqual(rv.context['job_scheduled'], scheduled)
-        self.assertEqual(rv.context['instance'], action)
-        self.assertEqual(rv.context['trigger'], self.trigger)
-        self.assertEqual(rv.context['template'], self.trigger.template)
+        self.assertEqual(rv.context["rqjob"], rqjob)
+        self.assertEqual(rv.context["job"], job)
+        self.assertEqual(rv.context["job_scheduled"], scheduled)
+        self.assertEqual(rv.context["instance"], action)
+        self.assertEqual(rv.context["trigger"], self.trigger)
+        self.assertEqual(rv.context["template"], self.trigger.template)
         # can't compare emails directly, __eq__ is not implemented
-        self.assertTrue(compare_emails(rv.context['email'], email))
-        self.assertEqual(rv.context['adn_context'], action.context)
+        self.assertTrue(compare_emails(rv.context["email"], email))
+        self.assertEqual(rv.context["adn_context"], action.context)
 
     def test_preview_invoked_job(self):
         # prepare fake data
@@ -186,17 +190,17 @@ class TestAdminJobPreview(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # log admin user
         self._logSuperuserIn()
 
-        url = reverse('admin:autoemails_rqjob_preview', args=[rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_preview", args=[rqjob.pk])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 200)
 
         # We can fetch the Job, it's coming from NewInstructorAction.__call__
-        self.assertEqual(rv.context['rqjob'], rqjob)
-        self.assertEqual(rv.context['job'], job)
-        self.assertEqual(rv.context['job_scheduled'], scheduled)
-        self.assertEqual(rv.context['instance'], action)
-        self.assertEqual(rv.context['trigger'], self.trigger)
-        self.assertEqual(rv.context['template'], self.trigger.template)
+        self.assertEqual(rv.context["rqjob"], rqjob)
+        self.assertEqual(rv.context["job"], job)
+        self.assertEqual(rv.context["job_scheduled"], scheduled)
+        self.assertEqual(rv.context["instance"], action)
+        self.assertEqual(rv.context["trigger"], self.trigger)
+        self.assertEqual(rv.context["template"], self.trigger.template)
         # can't compare emails directly, __eq__ is not implemented
-        self.assertTrue(compare_emails(rv.context['email'], email))
-        self.assertEqual(rv.context['adn_context'], action.context)
+        self.assertTrue(compare_emails(rv.context["email"], email))
+        self.assertEqual(rv.context["adn_context"], action.context)

--- a/amy/autoemails/tests/test_admin_queue.py
+++ b/amy/autoemails/tests/test_admin_queue.py
@@ -11,7 +11,7 @@ from workshops.tests.base import SuperuserMixin
 class TestAdminQueueView(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
     def setUp(self):
         super().setUp()
-        self.url = reverse('admin:autoemails_emailtemplate_queue')
+        self.url = reverse("admin:autoemails_emailtemplate_queue")
         self._setUpSuperuser()  # creates self.admin
 
         # save scheduler and connection data
@@ -29,7 +29,7 @@ class TestAdminQueueView(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         self.assertEqual(rv.status_code, 302)
         # cannot check by assertRedirect because there's additional `?next`
         # parameter
-        self.assertTrue(rv.url.startswith(reverse('login')))
+        self.assertTrue(rv.url.startswith(reverse("login")))
 
     def test_view_access_by_admin(self):
         # log admin user
@@ -48,7 +48,7 @@ class TestAdminQueueView(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         self.assertEqual(rv.status_code, 200)
 
         # make sure there were no jobs listed
-        self.assertEqual(rv.context['queue'], [])
+        self.assertEqual(rv.context["queue"], [])
 
     def test_not_empty_queue(self):
         # log admin user
@@ -59,7 +59,7 @@ class TestAdminQueueView(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         self.assertEqual(rv.status_code, 200)
 
         # make sure we start with no jobs listed
-        self.assertEqual(rv.context['queue'], [])
+        self.assertEqual(rv.context["queue"], [])
 
         # schedule some dummy job
         job = self.scheduler.enqueue_in(timedelta(hours=1), dummy_job)
@@ -68,9 +68,9 @@ class TestAdminQueueView(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # refresh queue list
         rv = self.client.get(self.url)
         self.assertEqual(rv.status_code, 200)
-        self.assertNotEqual(rv.context['queue'], [])
+        self.assertNotEqual(rv.context["queue"], [])
 
         # first element contains a pair of (job, scheduled time)
-        queue = rv.context['queue']
+        queue = rv.context["queue"]
         job2, time = queue[0]
         self.assertEqual(job, job2)

--- a/amy/autoemails/tests/test_admin_reschedule.py
+++ b/amy/autoemails/tests/test_admin_reschedule.py
@@ -24,10 +24,10 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
 
         # fake RQJob
         self.email = EmailTemplate.objects.create(slug="test-1")
-        self.trigger = Trigger.objects.create(action="new-instructor",
-                                              template=self.email)
-        self.rqjob = RQJob.objects.create(job_id="fake-id",
-                                          trigger=self.trigger)
+        self.trigger = Trigger.objects.create(
+            action="new-instructor", template=self.email
+        )
+        self.rqjob = RQJob.objects.create(job_id="fake-id", trigger=self.trigger)
 
     def tearDown(self):
         super().tearDown()
@@ -38,30 +38,29 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # log admin user
         self._logSuperuserIn()
 
-        url = reverse('admin:autoemails_rqjob_reschedule', args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_reschedule", args=[self.rqjob.pk])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 405)  # Method not allowed
 
     def test_view_access_by_anonymous(self):
-        url = reverse('admin:autoemails_rqjob_reschedule',
-                      args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_reschedule", args=[self.rqjob.pk])
         rv = self.client.post(url)
         self.assertEqual(rv.status_code, 302)
         # cannot check by assertRedirect because there's additional `?next`
         # parameter
-        self.assertTrue(rv.url.startswith(reverse('login')))
+        self.assertTrue(rv.url.startswith(reverse("login")))
 
     def test_view_access_by_admin(self):
         # log admin user
         self._logSuperuserIn()
 
         # try accessing the view again
-        url = reverse('admin:autoemails_rqjob_reschedule',
-                      args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_reschedule", args=[self.rqjob.pk])
         rv = self.client.post(url)
         self.assertEqual(rv.status_code, 302)
-        self.assertRedirects(rv, reverse('admin:autoemails_rqjob_preview',
-                                         args=[self.rqjob.pk]))
+        self.assertRedirects(
+            rv, reverse("admin:autoemails_rqjob_preview", args=[self.rqjob.pk])
+        )
 
     def test_no_such_job(self):
         # log admin user
@@ -70,11 +69,11 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         with self.assertRaises(NoSuchJobError):
             Job.fetch(self.rqjob.job_id, connection=self.scheduler.connection)
 
-        url = reverse('admin:autoemails_rqjob_reschedule', args=[self.rqjob.pk])
+        url = reverse("admin:autoemails_rqjob_reschedule", args=[self.rqjob.pk])
         rv = self.client.post(url, follow=True)
         self.assertIn(
-            'The corresponding job in Redis was probably already executed',
-            rv.content.decode('utf-8'),
+            "The corresponding job in Redis was probably already executed",
+            rv.content.decode("utf-8"),
         )
 
     def test_job_not_in_scheduled_jobs_queue(self):
@@ -87,26 +86,22 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         Job.fetch(job1.id, connection=self.scheduler.connection)  # no error
         with self.connection.pipeline() as pipe:
             pipe.watch(self.scheduler.scheduled_jobs_key)
-            self.assertIsNone(
-                pipe.zscore(
-                    self.scheduler.scheduled_jobs_key, job1.id
-                )
-            )
-        url = reverse('admin:autoemails_rqjob_reschedule', args=[rqjob1.pk])
-        scheduled_execution = (
-            datetime.now(tz=timezone.utc) + timedelta(days=1, minutes=15)
+            self.assertIsNone(pipe.zscore(self.scheduler.scheduled_jobs_key, job1.id))
+        url = reverse("admin:autoemails_rqjob_reschedule", args=[rqjob1.pk])
+        scheduled_execution = datetime.now(tz=timezone.utc) + timedelta(
+            days=1, minutes=15
         )
         scheduled_execution = scheduled_execution.replace(microsecond=0)
         payload = {
-            'scheduled_execution': scheduled_execution,
-            'scheduled_execution_0': f'{scheduled_execution:%Y-%m-%d}',
-            'scheduled_execution_1': f'{scheduled_execution:%H:%M:%S}',
+            "scheduled_execution": scheduled_execution,
+            "scheduled_execution_0": f"{scheduled_execution:%Y-%m-%d}",
+            "scheduled_execution_1": f"{scheduled_execution:%H:%M:%S}",
         }
         rv = self.client.post(url, payload, follow=True)
         self.assertIn(
             f"The job {job1.id} was not rescheduled. It is probably "
-            'already executing or has recently executed',
-            rv.content.decode('utf-8'),
+            "already executing or has recently executed",
+            rv.content.decode("utf-8"),
         )
 
         # case 2: job is no longer in the RQ-Scheduler queue, but it was there!
@@ -119,12 +114,12 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         # move job to the queue so it's executed
         self.scheduler.enqueue_job(job2)
         Job.fetch(job2.id, connection=self.scheduler.connection)  # no error
-        url = reverse('admin:autoemails_rqjob_reschedule', args=[rqjob2.pk])
+        url = reverse("admin:autoemails_rqjob_reschedule", args=[rqjob2.pk])
         rv = self.client.post(url, payload, follow=True)
         self.assertIn(
             f"The job {job2.id} was not rescheduled. It is probably "
-            'already executing or has recently executed',
-            rv.content.decode('utf-8'),
+            "already executing or has recently executed",
+            rv.content.decode("utf-8"),
         )
 
     def test_job_rescheduled_correctly(self):
@@ -137,26 +132,24 @@ class TestAdminJobReschedule(SuperuserMixin, FakeRedisTestCaseMixin, TestCase):
         )
         rqjob = RQJob.objects.create(job_id=job.id, trigger=self.trigger)
         Job.fetch(job.id, connection=self.scheduler.connection)  # no error
-        url = reverse('admin:autoemails_rqjob_reschedule', args=[rqjob.pk])
-        scheduled_execution = (
-            datetime.now(tz=timezone.utc) + timedelta(days=1, minutes=15)
+        url = reverse("admin:autoemails_rqjob_reschedule", args=[rqjob.pk])
+        scheduled_execution = datetime.now(tz=timezone.utc) + timedelta(
+            days=1, minutes=15
         )
         scheduled_execution = scheduled_execution.replace(microsecond=0)
         payload = {
-            'scheduled_execution': scheduled_execution,
-            'scheduled_execution_0': f'{scheduled_execution:%Y-%m-%d}',
-            'scheduled_execution_1': f'{scheduled_execution:%H:%M:%S}',
+            "scheduled_execution": scheduled_execution,
+            "scheduled_execution_0": f"{scheduled_execution:%Y-%m-%d}",
+            "scheduled_execution_1": f"{scheduled_execution:%H:%M:%S}",
         }
         rv = self.client.post(url, payload, follow=True)
         self.assertIn(
-            f'The job {job.id} was rescheduled to {scheduled_execution}',
-            rv.content.decode('utf-8'),
+            f"The job {job.id} was rescheduled to {scheduled_execution}",
+            rv.content.decode("utf-8"),
         )
 
         for _job, time in self.scheduler.get_jobs(with_times=True):
             if _job.id == job.id:
-                scheduled = to_unix(
-                    datetime.utcnow() + timedelta(days=1, minutes=15)
-                )
+                scheduled = to_unix(datetime.utcnow() + timedelta(days=1, minutes=15))
                 epochtime = to_unix(time)
                 self.assertAlmostEqual(epochtime, scheduled, delta=60)  # +- 60s

--- a/amy/autoemails/tests/test_askforwebsiteaction.py
+++ b/amy/autoemails/tests/test_askforwebsiteaction.py
@@ -276,9 +276,13 @@ class TestAskForWebsiteAction(TestCase):
             body_template="Sample text.",
         )
         trigger = Trigger.objects.create(
-            action="week-after-workshop-completion", template=template,
+            action="week-after-workshop-completion",
+            template=template,
         )
-        a = AskForWebsiteAction(trigger=trigger, objects=dict(event=e),)
+        a = AskForWebsiteAction(
+            trigger=trigger,
+            objects=dict(event=e),
+        )
         email = a._email()
         self.assertEqual(email.to, [p1.email, p2.email])
 
@@ -339,5 +343,6 @@ class TestAskForWebsiteAction(TestCase):
         )
 
         self.assertEqual(
-            a.all_recipients(), "hg@magic.uk, hp@magic.uk",
+            a.all_recipients(),
+            "hg@magic.uk, hp@magic.uk",
         )

--- a/amy/autoemails/tests/test_emailtemplates.py
+++ b/amy/autoemails/tests/test_emailtemplates.py
@@ -29,13 +29,13 @@ Sincerely,
 {{ admin }}"""
 
         self.template = EmailTemplate.objects.create(
-            slug='sample-template',
-            subject='Welcome to {{ site.name }}',
-            to_header='',
-            from_header='test@address.com',
-            cc_header='copy@example.org',
-            bcc_header='bcc@example.org',
-            reply_to_header='{{ reply_to }}',
+            slug="sample-template",
+            subject="Welcome to {{ site.name }}",
+            to_header="",
+            from_header="test@address.com",
+            cc_header="copy@example.org",
+            bcc_header="bcc@example.org",
+            reply_to_header="{{ reply_to }}",
             body_template=md,
         )
         return self.template
@@ -44,15 +44,15 @@ Sincerely,
         """Create a context dictionary that goes with trigger and email
         template created above."""
         self.objects = {
-            'user': 'Harry',
-            'activities': [
-                'Charms',
-                'Potions',
-                'Astronomy',
+            "user": "Harry",
+            "activities": [
+                "Charms",
+                "Potions",
+                "Astronomy",
             ],
-            'admin': 'Regional Coordinator',
-            'reply_to': 'regional@example.org',
-            'site': Site.objects.get_current(),
+            "admin": "Regional Coordinator",
+            "reply_to": "regional@example.org",
+            "site": Site.objects.get_current(),
         }
         return self.objects
 
@@ -66,37 +66,42 @@ Sincerely,
         # let's keep the hardcoded setting for missing variable in the template
         # system - just in case someone changes it unexpectedly
         expected_output1 = "Hello, XXX-unset-variable-XXX Smith"
-        self.assertEqual(EmailTemplate.render_template(template, data1),
-                         expected_output1)
+        self.assertEqual(
+            EmailTemplate.render_template(template, data1), expected_output1
+        )
 
-        data2 = {'name': 'Harry'}
+        data2 = {"name": "Harry"}
         expected_output2 = "Hello, Harry Smith"
-        self.assertEqual(EmailTemplate.render_template(template, data2),
-                         expected_output2)
+        self.assertEqual(
+            EmailTemplate.render_template(template, data2), expected_output2
+        )
 
-        data3 = {'name': 'Harry', 'last_name': 'Potter'}
+        data3 = {"name": "Harry", "last_name": "Potter"}
         expected_output3 = "Hello, Harry Potter"
-        self.assertEqual(EmailTemplate.render_template(template, data3),
-                         expected_output3)
+        self.assertEqual(
+            EmailTemplate.render_template(template, data3), expected_output3
+        )
 
     def test_rendering_invalid_template(self):
         """Invalid filter or template tag should raise TemplateSyntaxError,
         whereas invalid variable should be changed to
         `XXX-unset-variable-XXX`."""
         template1 = "Hello, {{ name | nonexistentfilter }}!"
-        data1 = dict(name='Harry')
+        data1 = dict(name="Harry")
         with self.assertRaises(TemplateSyntaxError):
             EmailTemplate.render_template(template1, data1)
 
         template2 = "Hello, {% invalidtag name %}!"
-        data2 = dict(name='Harry')
+        data2 = dict(name="Harry")
         with self.assertRaises(TemplateSyntaxError):
             EmailTemplate.render_template(template2, data2)
 
         template3 = "Hello, {{ invalidname }}!"
-        data3 = dict(name='Harry')
-        self.assertEqual(EmailTemplate.render_template(template3, data3),
-                         "Hello, XXX-unset-variable-XXX!")
+        data3 = dict(name="Harry")
+        self.assertEqual(
+            EmailTemplate.render_template(template3, data3),
+            "Hello, XXX-unset-variable-XXX!",
+        )
 
     def test_reading_file_from_disk(self):
         """Non-default database engine backend shouldn't allow to read from
@@ -111,21 +116,18 @@ Sincerely,
             EmailTemplate.render_template(template, data)
 
         # this must work, because we're using Django-main template engine
-        EmailTemplate.render_template(template, data, default_engine='django')
+        EmailTemplate.render_template(template, data, default_engine="django")
 
     def test_get_methods(self):
         tpl = self.prepare_template()
         ctx = self.prepare_context()
 
-        self.assertEqual(tpl.get_subject(context=ctx), 'Welcome to AMY')
-        self.assertEqual(tpl.get_sender(context=ctx), 'test@address.com')
+        self.assertEqual(tpl.get_subject(context=ctx), "Welcome to AMY")
+        self.assertEqual(tpl.get_sender(context=ctx), "test@address.com")
         self.assertEqual(tpl.get_recipients(context=ctx), [])
-        self.assertEqual(tpl.get_cc_recipients(context=ctx),
-                         ['copy@example.org'])
-        self.assertEqual(tpl.get_bcc_recipients(context=ctx),
-                         ['bcc@example.org'])
-        self.assertEqual(tpl.get_reply_to(context=ctx),
-                         ['regional@example.org'])
+        self.assertEqual(tpl.get_cc_recipients(context=ctx), ["copy@example.org"])
+        self.assertEqual(tpl.get_bcc_recipients(context=ctx), ["bcc@example.org"])
+        self.assertEqual(tpl.get_reply_to(context=ctx), ["regional@example.org"])
         body = tpl.get_body(context=ctx)
         self.assertEqual(len(body), 2)
         self.assertTrue(body.text)
@@ -135,7 +137,9 @@ Sincerely,
         tpl = self.prepare_template()
         ctx = self.prepare_context()
         body = tpl.get_body(context=ctx)
-        self.assertEqual(body.text, """Welcome, Harry!
+        self.assertEqual(
+            body.text,
+            """Welcome, Harry!
 
 It's a pleasure to have you here.
 
@@ -151,9 +155,12 @@ Here are some activities you can do:
 
 
 Sincerely,
-Regional Coordinator""")
+Regional Coordinator""",
+        )
 
-        self.assertEqual(body.html, """<p>Welcome, Harry!</p>
+        self.assertEqual(
+            body.html,
+            """<p>Welcome, Harry!</p>
 <p>It's a pleasure to have you here.</p>
 <p>Here are some activities you can do:</p>
 <ul>
@@ -168,65 +175,66 @@ Regional Coordinator""")
 </li>
 </ul>
 <p>Sincerely,
-Regional Coordinator</p>""")
+Regional Coordinator</p>""",
+        )
 
     def test_syntax_check(self):
         """All fields should have Django syntax check validation enabled."""
         # case 1: wrong tag
         tpl1 = EmailTemplate(
-            slug='test-template-1',
-            subject='Wrong tag {% tag %}',
-            to_header='Wrong tag {% tag %}',
-            from_header='Wrong tag {% tag %}',
-            cc_header='Wrong tag {% tag %}',
-            bcc_header='Wrong tag {% tag %}',
-            reply_to_header='Wrong tag {% tag %}',
-            body_template='Wrong tag {% tag %}',
+            slug="test-template-1",
+            subject="Wrong tag {% tag %}",
+            to_header="Wrong tag {% tag %}",
+            from_header="Wrong tag {% tag %}",
+            cc_header="Wrong tag {% tag %}",
+            bcc_header="Wrong tag {% tag %}",
+            reply_to_header="Wrong tag {% tag %}",
+            body_template="Wrong tag {% tag %}",
         )
         with self.assertRaises(ValidationError) as e:
             tpl1.clean()
 
-        self.assertIn('subject', e.exception.error_dict)
-        self.assertIn('to_header', e.exception.error_dict)
-        self.assertIn('from_header', e.exception.error_dict)
-        self.assertIn('cc_header', e.exception.error_dict)
-        self.assertIn('bcc_header', e.exception.error_dict)
-        self.assertIn('reply_to_header', e.exception.error_dict)
-        self.assertIn('body_template', e.exception.error_dict)
-        self.assertIn('Invalid', e.exception.message_dict['subject'][0])
+        self.assertIn("subject", e.exception.error_dict)
+        self.assertIn("to_header", e.exception.error_dict)
+        self.assertIn("from_header", e.exception.error_dict)
+        self.assertIn("cc_header", e.exception.error_dict)
+        self.assertIn("bcc_header", e.exception.error_dict)
+        self.assertIn("reply_to_header", e.exception.error_dict)
+        self.assertIn("body_template", e.exception.error_dict)
+        self.assertIn("Invalid", e.exception.message_dict["subject"][0])
 
         # case 2: missing opening or closing tags
         tpl2 = EmailTemplate(
-            slug='test-template-2',
-            subject='Missing {% url ',
-            to_header='Missing {{ tag',
-            from_header='Missing %}',
-            cc_header='Missing }}',
-            bcc_header='Missing {% tag }',
-            reply_to_header='Missing {{ tag }',
-            body_template='Missing { tag }}',
+            slug="test-template-2",
+            subject="Missing {% url ",
+            to_header="Missing {{ tag",
+            from_header="Missing %}",
+            cc_header="Missing }}",
+            bcc_header="Missing {% tag }",
+            reply_to_header="Missing {{ tag }",
+            body_template="Missing { tag }}",
         )
         with self.assertRaises(ValidationError) as e:
             tpl2.clean()
 
-        self.assertIn('subject', e.exception.error_dict)
-        self.assertIn('to_header', e.exception.error_dict)
-        self.assertIn('from_header', e.exception.error_dict)
-        self.assertIn('cc_header', e.exception.error_dict)
-        self.assertIn('bcc_header', e.exception.error_dict)
-        self.assertIn('reply_to_header', e.exception.error_dict)
-        self.assertIn('body_template', e.exception.error_dict)
-        self.assertIn('Missing', e.exception.message_dict['subject'][0])
+        self.assertIn("subject", e.exception.error_dict)
+        self.assertIn("to_header", e.exception.error_dict)
+        self.assertIn("from_header", e.exception.error_dict)
+        self.assertIn("cc_header", e.exception.error_dict)
+        self.assertIn("bcc_header", e.exception.error_dict)
+        self.assertIn("reply_to_header", e.exception.error_dict)
+        self.assertIn("body_template", e.exception.error_dict)
+        self.assertIn("Missing", e.exception.message_dict["subject"][0])
 
         # case 3: empty values should pass
         tpl3 = EmailTemplate(
-            slug='test-template-3',
-            subject='',
-            to_header='',
-            from_header='',
-            cc_header='',
-            bcc_header='',
-            reply_to_header='',
-            body_template='',
+            slug="test-template-3",
+            subject="",
+            to_header="",
+            from_header="",
+            cc_header="",
+            bcc_header="",
+            reply_to_header="",
+            body_template="",
         )
         tpl3.clean()

--- a/amy/autoemails/tests/test_genericaction.py
+++ b/amy/autoemails/tests/test_genericaction.py
@@ -30,10 +30,16 @@ class TestGenericAction(TestCase):
 
         self.instructor_role = Role.objects.create(name="instructor")
         self.person1 = Person.objects.create(
-            personal="Harry", family="Potter", email="hp@magic.uk", username="hp",
+            personal="Harry",
+            family="Potter",
+            email="hp@magic.uk",
+            username="hp",
         )
         self.person2 = Person.objects.create(
-            personal="Ron", family="Weasley", email="rw@magic.uk", username="rw",
+            personal="Ron",
+            family="Weasley",
+            email="rw@magic.uk",
+            username="rw",
         )
 
     def testLaunchAt(self):
@@ -99,7 +105,8 @@ class TestGenericAction(TestCase):
             body_template="Sample text.",
         )
         trigger = Trigger.objects.create(
-            action="workshop-request-response1", template=template,
+            action="workshop-request-response1",
+            template=template,
         )
         wr = WorkshopRequest(email="test@email.com")
         event = Event.objects.create(
@@ -151,5 +158,6 @@ class TestGenericAction(TestCase):
         )
 
         self.assertEqual(
-            a.all_recipients(), "test@email.com",
+            a.all_recipients(),
+            "test@email.com",
         )

--- a/amy/autoemails/tests/test_instructorshostintroductionaction.py
+++ b/amy/autoemails/tests/test_instructorshostintroductionaction.py
@@ -37,13 +37,22 @@ class TestInstructorsHostIntroductionAction(TestCase):
         self.supporting_instructor = Role.objects.create(name="supporting-instructor")
 
         self.person1 = Person.objects.create(
-            personal="Harry", family="Potter", email="hp@magic.uk", username="hp",
+            personal="Harry",
+            family="Potter",
+            email="hp@magic.uk",
+            username="hp",
         )
         self.person2 = Person.objects.create(
-            personal="Ron", family="Weasley", email="rw@magic.uk", username="rw",
+            personal="Ron",
+            family="Weasley",
+            email="rw@magic.uk",
+            username="rw",
         )
         self.person3 = Person.objects.create(
-            personal="Hermione", family="Granger", email="hg@magic.uk", username="hg",
+            personal="Hermione",
+            family="Granger",
+            email="hg@magic.uk",
+            username="hg",
         )
         self.person4 = Person.objects.create(
             personal="Peter",
@@ -52,7 +61,10 @@ class TestInstructorsHostIntroductionAction(TestCase):
             username="spiderman",
         )
         self.person5 = Person.objects.create(
-            personal="Tony", family="Stark", email="me@stark.com", username="ironman",
+            personal="Tony",
+            family="Stark",
+            email="me@stark.com",
+            username="ironman",
         )
 
     def testLaunchAt(self):
@@ -75,12 +87,20 @@ class TestInstructorsHostIntroductionAction(TestCase):
         e.tags.set(Tag.objects.filter(name__in=["LC", "automated-email"]))
         e2 = Event.objects.create(slug="bogus-event", host=Organization.objects.first())
         # tasks
-        host = Task.objects.create(person=self.person1, role=self.host, event=e,)
+        host = Task.objects.create(
+            person=self.person1,
+            role=self.host,
+            event=e,
+        )
         instructor1 = Task.objects.create(
-            person=self.person2, role=self.instructor, event=e,
+            person=self.person2,
+            role=self.instructor,
+            event=e,
         )
         instructor2 = Task.objects.create(
-            person=self.person3, role=self.instructor, event=e,
+            person=self.person3,
+            role=self.instructor,
+            event=e,
         )
 
         # 1st case: everything is good
@@ -140,7 +160,9 @@ class TestInstructorsHostIntroductionAction(TestCase):
 
         # 7th case: more than 2 instructors - should still work
         Task.objects.create(
-            person=self.person1, role=self.instructor, event=e,
+            person=self.person1,
+            role=self.instructor,
+            event=e,
         )
         self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
 
@@ -148,13 +170,17 @@ class TestInstructorsHostIntroductionAction(TestCase):
         e.tags.add(Tag.objects.get(name="online"))
         self.assertEqual(InstructorsHostIntroductionAction.check(e), False)
         Task.objects.create(
-            person=self.person4, role=self.supporting_instructor, event=e,
+            person=self.person4,
+            role=self.supporting_instructor,
+            event=e,
         )
         self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
 
         # 9th case: for online, more than 1 supporting instructors should still work
         Task.objects.create(
-            person=self.person5, role=self.supporting_instructor, event=e,
+            person=self.person5,
+            role=self.supporting_instructor,
+            event=e,
         )
         self.assertEqual(InstructorsHostIntroductionAction.check(e), True)
 
@@ -186,16 +212,24 @@ class TestInstructorsHostIntroductionAction(TestCase):
         # tasks
         host = Task.objects.create(person=self.person1, role=self.host, event=e)
         instructor1 = Task.objects.create(
-            person=self.person2, role=self.instructor, event=e,
+            person=self.person2,
+            role=self.instructor,
+            event=e,
         )
         instructor2 = Task.objects.create(
-            person=self.person3, role=self.instructor, event=e,
+            person=self.person3,
+            role=self.instructor,
+            event=e,
         )
         supporting_instructor1 = Task.objects.create(
-            person=self.person4, role=self.supporting_instructor, event=e,
+            person=self.person4,
+            role=self.supporting_instructor,
+            event=e,
         )
         supporting_instructor2 = Task.objects.create(
-            person=self.person5, role=self.supporting_instructor, event=e,
+            person=self.person5,
+            role=self.supporting_instructor,
+            event=e,
         )
 
         ctx = a.get_additional_context(objects=dict(event=e))
@@ -250,10 +284,14 @@ class TestInstructorsHostIntroductionAction(TestCase):
         # tasks
         Task.objects.create(person=self.person1, role=self.host, event=e)
         Task.objects.create(
-            person=self.person2, role=self.instructor, event=e,
+            person=self.person2,
+            role=self.instructor,
+            event=e,
         )
         Task.objects.create(
-            person=self.person3, role=self.instructor, event=e,
+            person=self.person3,
+            role=self.instructor,
+            event=e,
         )
 
         template = EmailTemplate.objects.create(
@@ -267,9 +305,13 @@ class TestInstructorsHostIntroductionAction(TestCase):
             body_template="Sample text.",
         )
         trigger = Trigger.objects.create(
-            action="self-organised-request-form", template=template,
+            action="self-organised-request-form",
+            template=template,
         )
-        a = InstructorsHostIntroductionAction(trigger=trigger, objects=dict(event=e),)
+        a = InstructorsHostIntroductionAction(
+            trigger=trigger,
+            objects=dict(event=e),
+        )
         email = a._email()
         self.assertEqual(
             email.to,
@@ -315,10 +357,14 @@ class TestInstructorsHostIntroductionAction(TestCase):
         # tasks
         Task.objects.create(person=self.person1, role=self.host, event=e)
         Task.objects.create(
-            person=self.person2, role=self.instructor, event=e,
+            person=self.person2,
+            role=self.instructor,
+            event=e,
         )
         Task.objects.create(
-            person=self.person3, role=self.instructor, event=e,
+            person=self.person3,
+            role=self.instructor,
+            event=e,
         )
 
         a = InstructorsHostIntroductionAction(
@@ -354,10 +400,14 @@ class TestInstructorsHostIntroductionAction(TestCase):
         self.person1.save()
         Task.objects.create(person=self.person1, role=self.host, event=e)
         Task.objects.create(
-            person=self.person2, role=self.instructor, event=e,
+            person=self.person2,
+            role=self.instructor,
+            event=e,
         )
         Task.objects.create(
-            person=self.person3, role=self.instructor, event=e,
+            person=self.person3,
+            role=self.instructor,
+            event=e,
         )
 
         ctx = a.get_additional_context(objects=dict(event=e))

--- a/amy/autoemails/tests/test_newinstructoraction.py
+++ b/amy/autoemails/tests/test_newinstructoraction.py
@@ -181,7 +181,7 @@ class TestNewInstructorAction(TestCase):
                 role=r,
                 task=t,
                 assignee="Regional Coordinator",
-                tags=['SWC'],
+                tags=["SWC"],
             ),
         )
 

--- a/amy/autoemails/tests/test_postworkshopaction.py
+++ b/amy/autoemails/tests/test_postworkshopaction.py
@@ -32,7 +32,10 @@ class TestPostWorkshopAction(TestCase):
         )
 
     def testLaunchAt(self):
-        e1 = Event(slug="test-event1", host=Organization.objects.first(),)
+        e1 = Event(
+            slug="test-event1",
+            host=Organization.objects.first(),
+        )
         e2 = Event(
             slug="test-event2",
             host=Organization.objects.first(),
@@ -189,7 +192,7 @@ class TestPostWorkshopAction(TestCase):
             country="GB",
             venue="Ministry of Magic",
             # additionally testing the empty email
-            contact=TAG_SEPARATOR.join(["peter@webslinger.net", ""])
+            contact=TAG_SEPARATOR.join(["peter@webslinger.net", ""]),
         )
         e.tags.set(Tag.objects.filter(name__in=["TTT", "SWC"]))
         p1 = Person.objects.create(
@@ -205,8 +208,10 @@ class TestPostWorkshopAction(TestCase):
             personal="Ron", family="Weasley", username="rweasley", email="rw@magic.uk"
         )
         p4 = Person.objects.create(
-            personal="Draco", family="Malfoy", username="dmalfoy",
-            email="draco@malfoy.com"
+            personal="Draco",
+            family="Malfoy",
+            username="dmalfoy",
+            email="draco@malfoy.com",
         )
         host = Role.objects.create(name="host")
         instructor = Role.objects.create(name="instructor")
@@ -243,9 +248,9 @@ class TestPostWorkshopAction(TestCase):
                 ],
                 assignee="Regional Coordinator",
                 reports_link="https://workshop-reports.carpentries.org/"
-                             "?key=e18dd84d093be5cd6c6ccaf63d38a8477ca126f4"
-                             "&slug=test-event",
-                tags=['SWC', 'TTT'],
+                "?key=e18dd84d093be5cd6c6ccaf63d38a8477ca126f4"
+                "&slug=test-event",
+                tags=["SWC", "TTT"],
             ),
         )
 
@@ -276,8 +281,10 @@ class TestPostWorkshopAction(TestCase):
             personal="Ron", family="Weasley", username="rweasley", email="rw@magic.uk"
         )
         p4 = Person.objects.create(
-            personal="Draco", family="Malfoy", username="dmalfoy",
-            email="draco@malfoy.com"
+            personal="Draco",
+            family="Malfoy",
+            username="dmalfoy",
+            email="draco@malfoy.com",
         )
         host = Role.objects.create(name="host")
         instructor = Role.objects.create(name="instructor")
@@ -303,9 +310,13 @@ class TestPostWorkshopAction(TestCase):
             body_template="Sample text.",
         )
         trigger = Trigger.objects.create(
-            action="week-after-workshop-completion", template=template,
+            action="week-after-workshop-completion",
+            template=template,
         )
-        a = PostWorkshopAction(trigger=trigger, objects=dict(event=e),)
+        a = PostWorkshopAction(
+            trigger=trigger,
+            objects=dict(event=e),
+        )
         email = a._email()
         self.assertEqual(email.to, [p2.email, p4.email, p1.email, p3.email])
 
@@ -355,8 +366,10 @@ class TestPostWorkshopAction(TestCase):
             personal="Ron", family="Weasley", username="rweasley", email="rw@magic.uk"
         )
         p4 = Person.objects.create(
-            personal="Draco", family="Malfoy", username="dmalfoy",
-            email="draco@malfoy.com"
+            personal="Draco",
+            family="Malfoy",
+            username="dmalfoy",
+            email="draco@malfoy.com",
         )
         host = Role.objects.create(name="host")
         instructor = Role.objects.create(name="instructor")
@@ -378,5 +391,5 @@ class TestPostWorkshopAction(TestCase):
 
         self.assertEqual(
             a.all_recipients(),
-            "hg@magic.uk, draco@malfoy.com, hp@magic.uk, rw@magic.uk"
+            "hg@magic.uk, draco@malfoy.com, hp@magic.uk, rw@magic.uk",
         )

--- a/amy/autoemails/tests/test_recruithelpersaction.py
+++ b/amy/autoemails/tests/test_recruithelpersaction.py
@@ -35,13 +35,22 @@ class TestRecruitHelpersAction(TestCase):
         self.helper_role = Role.objects.create(name="helper")
 
         self.person1 = Person.objects.create(
-            personal="Harry", family="Potter", email="hp@magic.uk", username="hp",
+            personal="Harry",
+            family="Potter",
+            email="hp@magic.uk",
+            username="hp",
         )
         self.person2 = Person.objects.create(
-            personal="Ron", family="Weasley", email="rw@magic.uk", username="rw",
+            personal="Ron",
+            family="Weasley",
+            email="rw@magic.uk",
+            username="rw",
         )
         self.person3 = Person.objects.create(
-            personal="Hermione", family="Granger", email="hg@magic.uk", username="hg",
+            personal="Hermione",
+            family="Granger",
+            email="hg@magic.uk",
+            username="hg",
         )
 
     def testLaunchAt(self):
@@ -266,7 +275,8 @@ class TestRecruitHelpersAction(TestCase):
             body_template="Sample text.",
         )
         trigger = Trigger.objects.create(
-            action="week-after-workshop-completion", template=template,
+            action="week-after-workshop-completion",
+            template=template,
         )
         a = RecruitHelpersAction(trigger=trigger, objects=dict(event=e))
         email = a._email()
@@ -314,5 +324,6 @@ class TestRecruitHelpersAction(TestCase):
         )
 
         self.assertEqual(
-            a.all_recipients(), "hp@magic.uk, rw@magic.uk",
+            a.all_recipients(),
+            "hp@magic.uk, rw@magic.uk",
         )

--- a/amy/autoemails/tests/test_selforganisedrequestaction.py
+++ b/amy/autoemails/tests/test_selforganisedrequestaction.py
@@ -223,10 +223,12 @@ class TestSelfOrganisedRequestAction(TestCase):
             body_template="Sample text.",
         )
         trigger = Trigger.objects.create(
-            action="self-organised-request-form", template=template,
+            action="self-organised-request-form",
+            template=template,
         )
         a = SelfOrganisedRequestAction(
-            trigger=trigger, objects=dict(event=e, request=r),
+            trigger=trigger,
+            objects=dict(event=e, request=r),
         )
         email = a._email()
         self.assertEqual(email.to, ["harry@hogwarts.edu", "hg@magic.uk", "rw@magic.uk"])

--- a/amy/autoemails/tests/test_utils.py
+++ b/amy/autoemails/tests/test_utils.py
@@ -26,7 +26,10 @@ class TestScheduledExecutionTime(FakeRedisTestCaseMixin, TestCase):
 
     def test_time_for_scheduled_job(self):
         # add job
-        job = self.scheduler.enqueue_in(timedelta(minutes=5), dummy_job,)
+        job = self.scheduler.enqueue_in(
+            timedelta(minutes=5),
+            dummy_job,
+        )
         job_id = job.get_id()
 
         # test
@@ -38,7 +41,10 @@ class TestScheduledExecutionTime(FakeRedisTestCaseMixin, TestCase):
 
     def test_time_for_run_job(self):
         # add job
-        job = self.scheduler.enqueue_in(timedelta(minutes=5), dummy_job,)
+        job = self.scheduler.enqueue_in(
+            timedelta(minutes=5),
+            dummy_job,
+        )
         job_id = job.get_id()
 
         # move the job to queue
@@ -50,7 +56,10 @@ class TestScheduledExecutionTime(FakeRedisTestCaseMixin, TestCase):
 
     def test_time_unaware_aware(self):
         # add job
-        job = self.scheduler.enqueue_in(timedelta(minutes=5), dummy_job,)
+        job = self.scheduler.enqueue_in(
+            timedelta(minutes=5),
+            dummy_job,
+        )
         job_id = job.get_id()
 
         # test
@@ -69,7 +78,10 @@ class TestCheckStatus(FakeRedisTestCaseMixin, TestCase):
 
     def test_status_scheduled_job(self):
         # add job
-        job = self.scheduler.enqueue_in(timedelta(minutes=5), dummy_job,)
+        job = self.scheduler.enqueue_in(
+            timedelta(minutes=5),
+            dummy_job,
+        )
 
         # test
         rv = check_status(job, self.scheduler)
@@ -77,7 +89,10 @@ class TestCheckStatus(FakeRedisTestCaseMixin, TestCase):
 
     def test_status_queued_job(self):
         # add job
-        job = self.scheduler.enqueue_in(timedelta(minutes=5), dummy_job,)
+        job = self.scheduler.enqueue_in(
+            timedelta(minutes=5),
+            dummy_job,
+        )
 
         # move the job to queue
         self.scheduler.enqueue_job(job)
@@ -124,7 +139,10 @@ class TestCheckStatus(FakeRedisTestCaseMixin, TestCase):
 
     def test_status_cancelled_job(self):
         # add job
-        job = self.scheduler.enqueue_in(timedelta(minutes=5), dummy_job,)
+        job = self.scheduler.enqueue_in(
+            timedelta(minutes=5),
+            dummy_job,
+        )
 
         # cancel job
         self.scheduler.cancel(job)

--- a/amy/autoemails/tests/test_utils.py
+++ b/amy/autoemails/tests/test_utils.py
@@ -1,7 +1,6 @@
 from datetime import timedelta, datetime
 
-from django.test import TestCase, override_settings
-from django_rq import get_scheduler
+from django.test import TestCase
 import pytz
 from rq.queue import Queue
 from rq.worker import SimpleWorker

--- a/amy/autoemails/tests/test_views.py
+++ b/amy/autoemails/tests/test_views.py
@@ -129,10 +129,7 @@ class TestGenericScheduleEmail(FakeRedisTestCaseMixin, SuperuserMixin, TestCase)
         self._setUpTemplateTrigger()
         self._setUpWorkshopRequest(create_event=False)
         data = self._formData()
-        data.update({
-            "slug": self.template_slug,
-            "next": "/dashboard"
-        })
+        data.update({"slug": self.template_slug, "next": "/dashboard"})
         url = reverse("autoemails:email_response", args=[self.wr.pk])
 
         # no jobs

--- a/amy/autoemails/views.py
+++ b/amy/autoemails/views.py
@@ -29,9 +29,7 @@ def generic_schedule_email(request, pk):
     Generic view for scheduling an email to be sent.
     """
     template_slug = request.POST.get("slug", "")
-    original_template = get_object_or_404(
-        EmailTemplate, slug=template_slug
-    )
+    original_template = get_object_or_404(EmailTemplate, slug=template_slug)
     # Hardcoded, maybe in future respond to other requests, like
     # SelfOrganizedSubmission or WorkshopInquiry
     trigger = get_object_or_404(
@@ -107,8 +105,7 @@ def generic_schedule_email(request, pk):
         )
 
         return redirect(
-            request.POST.get("next", "")
-            or workshop_request.get_absolute_url()
+            request.POST.get("next", "") or workshop_request.get_absolute_url()
         )
 
     else:
@@ -119,6 +116,5 @@ def generic_schedule_email(request, pk):
         )
 
         return redirect(
-            request.POST.get("next", "")
-            or workshop_request.get_absolute_url()
+            request.POST.get("next", "") or workshop_request.get_absolute_url()
         )

--- a/amy/dashboard/admin.py
+++ b/amy/dashboard/admin.py
@@ -4,7 +4,7 @@ from .models import Criterium, Continent
 
 
 class CriteriumAdmin(admin.ModelAdmin):
-    list_display = ('name', 'email', 'get_countries')
+    list_display = ("name", "email", "get_countries")
 
     def get_countries(self, obj):
         if len(obj.countries) > 10:
@@ -12,12 +12,12 @@ class CriteriumAdmin(admin.ModelAdmin):
         else:
             return ", ".join([x.name for x in obj.countries])
 
-    get_countries.short_description = 'Matching countries'
-    get_countries.admin_order_field = 'countries'
+    get_countries.short_description = "Matching countries"
+    get_countries.admin_order_field = "countries"
 
 
 class ContinentAdmin(admin.ModelAdmin):
-    list_display = ('name', 'get_countries')
+    list_display = ("name", "get_countries")
 
     def get_countries(self, obj):
         if len(obj.countries) > 10:
@@ -25,8 +25,8 @@ class ContinentAdmin(admin.ModelAdmin):
         else:
             return ", ".join([x.name for x in obj.countries])
 
-    get_countries.short_description = 'Matching countries'
-    get_countries.admin_order_field = 'countries'
+    get_countries.short_description = "Matching countries"
+    get_countries.admin_order_field = "countries"
 
 
 admin.site.register(Criterium, CriteriumAdmin)

--- a/amy/dashboard/apps.py
+++ b/amy/dashboard/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class DashboardConfig(AppConfig):
-    name = 'dashboard'
+    name = "dashboard"

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -12,6 +12,7 @@ from workshops.models import (
 )
 
 from workshops.forms import BootstrapHelper
+
 # this is used instead of Django Autocomplete Light widgets
 # see issue #1330: https://github.com/swcarpentry/amy/issues/1330
 from workshops.fields import (
@@ -35,34 +36,37 @@ class AssignmentForm(forms.Form):
         add_cancel_button=False,
         wider_labels=True,
         use_get_method=True,
-        form_id="assignment-form"
+        form_id="assignment-form",
     )
 
 
 class AutoUpdateProfileForm(forms.ModelForm):
     username = forms.CharField(disabled=True, required=False)
     email = forms.CharField(
-        disabled=True, required=False,
-        label=Person._meta.get_field('email').verbose_name,
-        help_text=Person._meta.get_field('email').help_text,
+        disabled=True,
+        required=False,
+        label=Person._meta.get_field("email").verbose_name,
+        help_text=Person._meta.get_field("email").help_text,
     )
     github = forms.CharField(
-        disabled=True, required=False,
-        help_text='If you want to change your github username, please email '
-                  'us at <a href="mailto:team@carpentries.org">'
-                  'team@carpentries.org</a>.')
+        disabled=True,
+        required=False,
+        help_text="If you want to change your github username, please email "
+        'us at <a href="mailto:team@carpentries.org">'
+        "team@carpentries.org</a>.",
+    )
 
     country = CountryField().formfield(
         required=False,
-        help_text='Your country of residence.',
+        help_text="Your country of residence.",
         widget=Select2Widget,
     )
 
     languages = forms.ModelMultipleChoiceField(
-        label='Languages',
+        label="Languages",
         required=False,
         queryset=Language.objects.all(),
-        widget=ModelSelect2MultipleWidget(data_view='language-lookup')
+        widget=ModelSelect2MultipleWidget(data_view="language-lookup"),
     )
 
     helper = BootstrapHelper(add_cancel_button=False)
@@ -70,38 +74,38 @@ class AutoUpdateProfileForm(forms.ModelForm):
     class Meta:
         model = Person
         fields = [
-            'personal',
-            'middle',
-            'family',
-            'email',
-            'secondary_email',
-            'gender',
-            'gender_other',
-            'may_contact',
-            'publish_profile',
-            'lesson_publication_consent',
-            'country',
-            'airport',
-            'github',
-            'twitter',
-            'url',
-            'username',
-            'affiliation',
-            'domains',
-            'lessons',
-            'languages',
-            'occupation',
-            'orcid',
+            "personal",
+            "middle",
+            "family",
+            "email",
+            "secondary_email",
+            "gender",
+            "gender_other",
+            "may_contact",
+            "publish_profile",
+            "lesson_publication_consent",
+            "country",
+            "airport",
+            "github",
+            "twitter",
+            "url",
+            "username",
+            "affiliation",
+            "domains",
+            "lessons",
+            "languages",
+            "occupation",
+            "orcid",
         ]
         readonly_fields = (
-            'username',
-            'github',
+            "username",
+            "github",
         )
         widgets = {
-            'gender': RadioSelectWithOther('gender_other'),
-            'domains': forms.CheckboxSelectMultiple(),
-            'lessons': forms.CheckboxSelectMultiple(),
-            'airport': Select2Widget,
+            "gender": RadioSelectWithOther("gender_other"),
+            "domains": forms.CheckboxSelectMultiple(),
+            "lessons": forms.CheckboxSelectMultiple(),
+            "airport": Select2Widget,
         }
 
     def __init__(self, *args, **kwargs):
@@ -112,10 +116,10 @@ class AutoUpdateProfileForm(forms.ModelForm):
 
         # set up `*WithOther` widgets so that they can display additional
         # fields inline
-        self['gender'].field.widget.other_field = self['gender_other']
+        self["gender"].field.widget.other_field = self["gender_other"]
 
         # remove additional fields
-        self.helper.layout.fields.remove('gender_other')
+        self.helper.layout.fields.remove("gender_other")
 
     def clean(self):
         super().clean()
@@ -123,14 +127,14 @@ class AutoUpdateProfileForm(forms.ModelForm):
 
         # 1: require "other gender" field if "other" was selected in
         # "gender" field
-        gender = self.cleaned_data.get('gender', '')
-        gender_other = self.cleaned_data.get('gender_other', '')
+        gender = self.cleaned_data.get("gender", "")
+        gender_other = self.cleaned_data.get("gender_other", "")
         if gender == GenderMixin.OTHER and not gender_other:
-            errors['gender'] = ValidationError("This field is required.")
+            errors["gender"] = ValidationError("This field is required.")
         elif gender != GenderMixin.OTHER and gender_other:
-            errors['gender'] = ValidationError(
-                'If you entered data in "Other" field, please select that '
-                "option.")
+            errors["gender"] = ValidationError(
+                'If you entered data in "Other" field, please select that ' "option."
+            )
 
         # raise errors if any present
         if errors:
@@ -138,10 +142,11 @@ class AutoUpdateProfileForm(forms.ModelForm):
 
 
 class SendHomeworkForm(forms.ModelForm):
-    url = forms.URLField(label='URL')
+    url = forms.URLField(label="URL")
     requirement = forms.ModelChoiceField(
         queryset=TrainingRequirement.objects.filter(name__endswith="Homework"),
-        label="Type", required=True,
+        label="Type",
+        required=True,
     )
 
     helper = BootstrapHelper(add_cancel_button=False)
@@ -149,8 +154,8 @@ class SendHomeworkForm(forms.ModelForm):
     class Meta:
         model = TrainingProgress
         fields = [
-            'requirement',
-            'url',
+            "requirement",
+            "url",
         ]
 
 
@@ -158,5 +163,7 @@ class SearchForm(forms.Form):
     """Represent general searching form."""
 
     term = forms.CharField(label="Term", max_length=100)
-    no_redirect = forms.BooleanField(required=False, initial=False, widget=forms.HiddenInput)
+    no_redirect = forms.BooleanField(
+        required=False, initial=False, widget=forms.HiddenInput
+    )
     helper = BootstrapHelper(add_cancel_button=False, use_get_method=True)

--- a/amy/dashboard/models.py
+++ b/amy/dashboard/models.py
@@ -10,22 +10,20 @@ class Criterium(models.Model):
         unique=True,
     )
     countries = CountryField(
-        multiple=True,
-        verbose_name="Countries to match this criterium"
+        multiple=True, verbose_name="Countries to match this criterium"
     )
     email = models.EmailField(
-        verbose_name='Notification email address',
+        verbose_name="Notification email address",
         blank=False,
     )
 
     class Meta:
-        ordering = ['name', 'email']
-        verbose_name = 'Notification Criterium'
-        verbose_name_plural = 'Notification Criteria'
+        ordering = ["name", "email"]
+        verbose_name = "Notification Criterium"
+        verbose_name_plural = "Notification Criteria"
 
     def __str__(self):
-        return "Criterium {name} ({email})".format(name=self.name,
-                                                   email=self.email)
+        return "Criterium {name} ({email})".format(name=self.name, email=self.email)
 
 
 class Continent(models.Model):
@@ -35,15 +33,12 @@ class Continent(models.Model):
         blank=False,
         unique=True,
     )
-    countries = CountryField(
-        multiple=True,
-        verbose_name="Countries in this continent"
-    )
+    countries = CountryField(multiple=True, verbose_name="Countries in this continent")
 
     class Meta:
-        ordering = ['name']
-        verbose_name = 'Continent'
-        verbose_name_plural = 'Continents'
+        ordering = ["name"]
+        verbose_name = "Continent"
+        verbose_name_plural = "Continents"
 
     def __str__(self):
         return "Continent {name}".format(name=self.name)

--- a/amy/dashboard/tests/test_assignment_form.py
+++ b/amy/dashboard/tests/test_assignment_form.py
@@ -33,8 +33,8 @@ class TestAssignmentForm(TestCase):
 
         This is a regression test for https://github.com/carpentries/amy/issues/1792.
         """
-        admins = Group.objects.get(name='administrators')
-        committee = Group.objects.get(name='steering committee')
+        admins = Group.objects.get(name="administrators")
+        committee = Group.objects.get(name="steering committee")
         self.administrator.groups.add(admins)
         # user has to be in 2 groups to yield duplicate
         # results in the queryset
@@ -42,6 +42,6 @@ class TestAssignmentForm(TestCase):
         self.both.groups.add(admins)
 
         field = AssignmentForm().fields["assigned_to"]
-        self.assertEqual(list(field.queryset), [
-            self.both, self.superuser, self.administrator
-        ])
+        self.assertEqual(
+            list(field.queryset), [self.both, self.superuser, self.administrator]
+        )

--- a/amy/dashboard/tests/test_autoupdate_profile.py
+++ b/amy/dashboard/tests/test_autoupdate_profile.py
@@ -15,8 +15,12 @@ class TestAutoUpdateProfile(TestBase):
         self._setUpLanguages()
 
         self.user = Person.objects.create_user(
-            username='user', personal='', family='',
-            email='user@example.org', password='pass')
+            username="user",
+            personal="",
+            family="",
+            email="user@example.org",
+            password="pass",
+        )
 
         self.user.data_privacy_agreement = True
         self.user.save()
@@ -24,50 +28,48 @@ class TestAutoUpdateProfile(TestBase):
         Qualification.objects.create(person=self.user, lesson=self.git)
         Qualification.objects.create(person=self.user, lesson=self.sql)
 
-        self.physics = KnowledgeDomain.objects.create(name='physics')
-        self.chemistry = KnowledgeDomain.objects.create(name='chemistry')
+        self.physics = KnowledgeDomain.objects.create(name="physics")
+        self.chemistry = KnowledgeDomain.objects.create(name="chemistry")
         self.user.domains.add(self.physics)
 
         self.user.languages.add(self.english)
         self.user.languages.add(self.french)
 
-        self.client.login(username='user', password='pass')
+        self.client.login(username="user", password="pass")
 
     def test_load_form(self):
-        rv = self.client.get(reverse('autoupdate_profile'))
+        rv = self.client.get(reverse("autoupdate_profile"))
         self.assertEqual(rv.status_code, 200)
 
     def test_update_profile(self):
         data = {
-            'personal': 'admin',
-            'middle': '',
-            'family': 'Smith',
-            'email': 'admin@example.org',
-            'gender': Person.UNDISCLOSED,
-            'may_contact': True,
-            'airport': self.airport_0_0.pk,
-            'github': 'changed',
-            'twitter': '',
-            'url': '',
-            'username': 'changed',
-            'affiliation': '',
-            'languages': [self.latin.pk, self.french.pk],
-            'domains': [self.chemistry.pk],
-            'lessons': [self.git.pk, self.matlab.pk],
-            'privacy_consent': True,
+            "personal": "admin",
+            "middle": "",
+            "family": "Smith",
+            "email": "admin@example.org",
+            "gender": Person.UNDISCLOSED,
+            "may_contact": True,
+            "airport": self.airport_0_0.pk,
+            "github": "changed",
+            "twitter": "",
+            "url": "",
+            "username": "changed",
+            "affiliation": "",
+            "languages": [self.latin.pk, self.french.pk],
+            "domains": [self.chemistry.pk],
+            "lessons": [self.git.pk, self.matlab.pk],
+            "privacy_consent": True,
         }
 
-        rv = self.client.post(reverse('autoupdate_profile'), data, follow=True)
+        rv = self.client.post(reverse("autoupdate_profile"), data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        content = rv.content.decode('utf-8')
-        self.assertNotIn('Fix errors below', content)
+        content = rv.content.decode("utf-8")
+        self.assertNotIn("Fix errors below", content)
         self.user.refresh_from_db()
 
-        self.assertEqual(self.user.username, 'user')  # username is read-only
+        self.assertEqual(self.user.username, "user")  # username is read-only
         self.assertEqual(self.user.github, None)  # github is read-only
-        self.assertEqual(self.user.family, 'Smith')
-        self.assertEqual(set(self.user.lessons.all()),
-                         {self.git, self.matlab})
+        self.assertEqual(self.user.family, "Smith")
+        self.assertEqual(set(self.user.lessons.all()), {self.git, self.matlab})
         self.assertEqual(list(self.user.domains.all()), [self.chemistry])
-        self.assertEqual(set(self.user.languages.all()),
-                         {self.french, self.latin})
+        self.assertEqual(set(self.user.languages.all()), {self.french, self.latin})

--- a/amy/dashboard/tests/test_trainee_dashboard.py
+++ b/amy/dashboard/tests/test_trainee_dashboard.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from django.urls import reverse
 
-from workshops.models import Person, Award, Badge, TrainingProgress, TrainingRequirement
+from workshops.models import Person, Award, TrainingProgress, TrainingRequirement
 from workshops.tests.base import TestBase
 
 
@@ -224,7 +224,7 @@ class TestSWCHomeworkStatus(TestBase):
         rv = self.client.get(self.progress_url)
         self.assertContains(rv, "SWC Homework not submitted yet")
 
-    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(
+    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(  # noqa: line too long
         self,
     ):
         TrainingProgress.objects.create(trainee=self.admin, requirement=self.homework)
@@ -291,7 +291,7 @@ class TestDCHomeworkStatus(TestBase):
         rv = self.client.get(self.progress_url)
         self.assertContains(rv, "DC Homework not submitted yet")
 
-    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(
+    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(  # noqa: line too long
         self,
     ):
         TrainingProgress.objects.create(trainee=self.admin, requirement=self.homework)
@@ -358,7 +358,7 @@ class TestLCHomeworkStatus(TestBase):
         rv = self.client.get(self.progress_url)
         self.assertContains(rv, "LC Homework not submitted yet")
 
-    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(
+    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(  # noqa: line too long
         self,
     ):
         TrainingProgress.objects.create(trainee=self.admin, requirement=self.homework)

--- a/amy/dashboard/tests/test_trainee_dashboard.py
+++ b/amy/dashboard/tests/test_trainee_dashboard.py
@@ -2,25 +2,29 @@ from datetime import datetime
 
 from django.urls import reverse
 
-from workshops.models import Person, Award, Badge, TrainingProgress, \
-    TrainingRequirement
+from workshops.models import Person, Award, Badge, TrainingProgress, TrainingRequirement
 from workshops.tests.base import TestBase
 
 
 class TestTraineeDashboard(TestBase):
     """Tests for trainee dashboard."""
+
     def setUp(self):
         self.user = Person.objects.create_user(
-            username='user', personal='', family='',
-            email='user@example.org', password='pass')
+            username="user",
+            personal="",
+            family="",
+            email="user@example.org",
+            password="pass",
+        )
         self.user.data_privacy_agreement = True
         self.user.save()
-        self.client.login(username='user', password='pass')
+        self.client.login(username="user", password="pass")
 
     def test_dashboard_loads(self):
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(reverse("trainee-dashboard"))
         self.assertEqual(rv.status_code, 200)
-        content = rv.content.decode('utf-8')
+        content = rv.content.decode("utf-8")
         self.assertIn("Log out", content)
         self.assertIn("Update your profile", content)
 
@@ -32,85 +36,119 @@ class TestInstructorStatus(TestBase):
     def setUp(self):
         self._setUpUsersAndLogin()
         self._setUpBadges()
-        self.progress_url = reverse('training-progress')
+        self.progress_url = reverse("training-progress")
 
     def test_swc_dc_lc_instructor_badges(self):
         """When the trainee is awarded both Carpentry Instructor badge,
         we want to display that info in the dashboard."""
 
-        Award.objects.create(person=self.admin, badge=self.swc_instructor,
-                             awarded=datetime(2016, 6, 1, 15, 0))
-        Award.objects.create(person=self.admin, badge=self.dc_instructor,
-                             awarded=datetime(2016, 6, 1, 15, 0))
-        Award.objects.create(person=self.admin, badge=self.lc_instructor,
-                             awarded=datetime(2018, 12, 25, 20, 16))
+        Award.objects.create(
+            person=self.admin,
+            badge=self.swc_instructor,
+            awarded=datetime(2016, 6, 1, 15, 0),
+        )
+        Award.objects.create(
+            person=self.admin,
+            badge=self.dc_instructor,
+            awarded=datetime(2016, 6, 1, 15, 0),
+        )
+        Award.objects.create(
+            person=self.admin,
+            badge=self.lc_instructor,
+            awarded=datetime(2018, 12, 25, 20, 16),
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Software Carpentry Instructor')
-        self.assertContains(rv, 'Data Carpentry Instructor')
-        self.assertContains(rv, 'Library Carpentry Instructor')
-        self.assertIn(self.swc_instructor,
-                      rv.context['user'].instructor_badges)
-        self.assertIn(self.dc_instructor, rv.context['user'].instructor_badges)
-        self.assertIn(self.lc_instructor, rv.context['user'].instructor_badges)
+        self.assertContains(rv, "Software Carpentry Instructor")
+        self.assertContains(rv, "Data Carpentry Instructor")
+        self.assertContains(rv, "Library Carpentry Instructor")
+        self.assertIn(self.swc_instructor, rv.context["user"].instructor_badges)
+        self.assertIn(self.dc_instructor, rv.context["user"].instructor_badges)
+        self.assertIn(self.lc_instructor, rv.context["user"].instructor_badges)
 
     def test_swc_instructor(self):
-        Award.objects.create(person=self.admin, badge=self.swc_instructor,
-                             awarded=datetime(2016, 6, 1, 15, 0))
+        Award.objects.create(
+            person=self.admin,
+            badge=self.swc_instructor,
+            awarded=datetime(2016, 6, 1, 15, 0),
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Software Carpentry Instructor')
-        self.assertIn(self.swc_instructor,
-                      rv.context['user'].instructor_badges)
+        self.assertContains(rv, "Software Carpentry Instructor")
+        self.assertIn(self.swc_instructor, rv.context["user"].instructor_badges)
 
     def test_dc_instructor(self):
-        Award.objects.create(person=self.admin, badge=self.dc_instructor,
-                             awarded=datetime(2016, 6, 1, 15, 0))
+        Award.objects.create(
+            person=self.admin,
+            badge=self.dc_instructor,
+            awarded=datetime(2016, 6, 1, 15, 0),
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Data Carpentry Instructor')
-        self.assertIn(self.dc_instructor, rv.context['user'].instructor_badges)
+        self.assertContains(rv, "Data Carpentry Instructor")
+        self.assertIn(self.dc_instructor, rv.context["user"].instructor_badges)
 
     def test_lc_instructor(self):
-        Award.objects.create(person=self.admin, badge=self.lc_instructor,
-                             awarded=datetime(2018, 12, 25, 20, 16))
+        Award.objects.create(
+            person=self.admin,
+            badge=self.lc_instructor,
+            awarded=datetime(2018, 12, 25, 20, 16),
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Library Carpentry Instructor')
-        self.assertIn(self.lc_instructor, rv.context['user'].instructor_badges)
+        self.assertContains(rv, "Library Carpentry Instructor")
+        self.assertIn(self.lc_instructor, rv.context["user"].instructor_badges)
 
     def test_neither_swc_nor_dc_instructor(self):
         """Check that we don't display that the trainee is an instructor if
         they don't have appropriate badge."""
         rv = self.client.get(self.progress_url)
-        self.assertNotContains(rv, 'Congratulations, you\'re certified both '
-                                   'Software Carpentry and Data Carpentry '
-                                   'Instructor!')
-        self.assertNotContains(rv, 'Congratulations, you\'re certified '
-                                   'Software Carpentry Instructor!')
-        self.assertNotContains(rv, 'Congratulations, you\'re certified '
-                                   'Data Carpentry Instructor!')
+        self.assertNotContains(
+            rv,
+            "Congratulations, you're certified both "
+            "Software Carpentry and Data Carpentry "
+            "Instructor!",
+        )
+        self.assertNotContains(
+            rv, "Congratulations, you're certified " "Software Carpentry Instructor!"
+        )
+        self.assertNotContains(
+            rv, "Congratulations, you're certified " "Data Carpentry Instructor!"
+        )
 
     def test_eligible_but_not_awarded(self):
         """Test what is dispslayed when a trainee is eligible to be certified
         as an SWC/DC Instructor, but doesn't have appropriate badge awarded
         yet."""
-        requirements = ['Training', 'SWC Homework', 'DC Homework',
-                        'Discussion', 'SWC Demo', 'DC Demo']
+        requirements = [
+            "Training",
+            "SWC Homework",
+            "DC Homework",
+            "Discussion",
+            "SWC Demo",
+            "DC Demo",
+        ]
         for requirement in requirements:
             TrainingProgress.objects.create(
                 trainee=self.admin,
-                requirement=TrainingRequirement.objects.get(name=requirement))
+                requirement=TrainingRequirement.objects.get(name=requirement),
+            )
 
-        admin = Person.objects.annotate_with_instructor_eligibility() \
-                              .get(username='admin')
+        admin = Person.objects.annotate_with_instructor_eligibility().get(
+            username="admin"
+        )
         assert admin.get_missing_instructor_requirements() == []
 
         rv = self.client.get(self.progress_url)
 
-        self.assertNotContains(rv, 'Congratulations, you\'re certified both '
-                                   'Software Carpentry and Data Carpentry '
-                                   'Instructor!')
-        self.assertNotContains(rv, 'Congratulations, you\'re certified '
-                                   'Software Carpentry Instructor!')
-        self.assertNotContains(rv, 'Congratulations, you\'re certified '
-                                   'Data Carpentry Instructor!')
+        self.assertNotContains(
+            rv,
+            "Congratulations, you're certified both "
+            "Software Carpentry and Data Carpentry "
+            "Instructor!",
+        )
+        self.assertNotContains(
+            rv, "Congratulations, you're certified " "Software Carpentry Instructor!"
+        )
+        self.assertNotContains(
+            rv, "Congratulations, you're certified " "Data Carpentry Instructor!"
+        )
 
 
 class TestInstructorTrainingStatus(TestBase):
@@ -119,38 +157,39 @@ class TestInstructorTrainingStatus(TestBase):
 
     def setUp(self):
         self._setUpUsersAndLogin()
-        self.training = TrainingRequirement.objects.get(name='Training')
-        self.progress_url = reverse('training-progress')
+        self.training = TrainingRequirement.objects.get(name="Training")
+        self.progress_url = reverse("training-progress")
 
     def test_training_passed(self):
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.training)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.training)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Training passed')
+        self.assertContains(rv, "Training passed")
 
     def test_training_passed_but_discarded(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.training, discarded=True)
+            trainee=self.admin, requirement=self.training, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Training not passed yet')
+        self.assertContains(rv, "Training not passed yet")
 
     def test_last_training_discarded_but_another_is_passed(self):
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.training)
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.training)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.training, discarded=True)
+            trainee=self.admin, requirement=self.training, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Training passed')
+        self.assertContains(rv, "Training passed")
 
     def test_training_failed(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.training, state='f')
+            trainee=self.admin, requirement=self.training, state="f"
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Training not passed yet')
+        self.assertContains(rv, "Training not passed yet")
 
     def test_training_not_finished(self):
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Training not passed yet')
+        self.assertContains(rv, "Training not passed yet")
 
 
 class TestSWCHomeworkStatus(TestBase):
@@ -159,57 +198,64 @@ class TestSWCHomeworkStatus(TestBase):
 
     def setUp(self):
         self._setUpUsersAndLogin()
-        self.homework = TrainingRequirement.objects.get(name='SWC Homework')
-        self.progress_url = reverse('training-progress')
+        self.homework = TrainingRequirement.objects.get(name="SWC Homework")
+        self.progress_url = reverse("training-progress")
 
     def test_homework_not_submitted(self):
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Homework not submitted yet')
+        self.assertContains(rv, "SWC Homework not submitted yet")
 
     def test_homework_waiting_to_be_evaluated(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework, state='n')
+            trainee=self.admin, requirement=self.homework, state="n"
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Homework evaluation pending')
+        self.assertContains(rv, "SWC Homework evaluation pending")
 
     def test_homework_passed(self):
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.homework)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Homework accepted')
+        self.assertContains(rv, "SWC Homework accepted")
 
     def test_homework_not_accepted_when_homework_passed_but_discarded(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework, discarded=True)
+            trainee=self.admin, requirement=self.homework, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Homework not submitted yet')
+        self.assertContains(rv, "SWC Homework not submitted yet")
 
-    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(self):
+    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(
+        self,
+    ):
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.homework)
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework, discarded=True)
+            trainee=self.admin, requirement=self.homework, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Homework accepted')
+        self.assertContains(rv, "SWC Homework accepted")
 
     def test_submission_form(self):
         data = {
-            'url': 'http://example.com',
-            'requirement': self.homework.pk,
+            "url": "http://example.com",
+            "requirement": self.homework.pk,
         }
         rv = self.client.post(self.progress_url, data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'training-progress')
-        self.assertContains(rv, 'Your homework submission will be evaluated '
-                                'soon.')
-        got = list(TrainingProgress.objects.values_list(
-            'state', 'trainee', 'url', 'requirement'))
-        expected = [(
-            'n',
-            self.admin.pk,
-            'http://example.com',
-            TrainingRequirement.objects.get(name='SWC Homework').pk,
-        )]
+        self.assertEqual(rv.resolver_match.view_name, "training-progress")
+        self.assertContains(rv, "Your homework submission will be evaluated " "soon.")
+        got = list(
+            TrainingProgress.objects.values_list(
+                "state", "trainee", "url", "requirement"
+            )
+        )
+        expected = [
+            (
+                "n",
+                self.admin.pk,
+                "http://example.com",
+                TrainingRequirement.objects.get(name="SWC Homework").pk,
+            )
+        ]
         self.assertEqual(got, expected)
 
 
@@ -219,57 +265,64 @@ class TestDCHomeworkStatus(TestBase):
 
     def setUp(self):
         self._setUpUsersAndLogin()
-        self.homework = TrainingRequirement.objects.get(name='DC Homework')
-        self.progress_url = reverse('training-progress')
+        self.homework = TrainingRequirement.objects.get(name="DC Homework")
+        self.progress_url = reverse("training-progress")
 
     def test_homework_not_submitted(self):
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Homework not submitted yet')
+        self.assertContains(rv, "DC Homework not submitted yet")
 
     def test_homework_waiting_to_be_evaluated(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework, state='n')
+            trainee=self.admin, requirement=self.homework, state="n"
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Homework evaluation pending')
+        self.assertContains(rv, "DC Homework evaluation pending")
 
     def test_homework_passed(self):
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.homework)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Homework accepted')
+        self.assertContains(rv, "DC Homework accepted")
 
     def test_homework_not_accepted_when_homework_passed_but_discarded(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework, discarded=True)
+            trainee=self.admin, requirement=self.homework, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Homework not submitted yet')
+        self.assertContains(rv, "DC Homework not submitted yet")
 
-    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(self):
+    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(
+        self,
+    ):
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.homework)
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework, discarded=True)
+            trainee=self.admin, requirement=self.homework, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Homework accepted')
+        self.assertContains(rv, "DC Homework accepted")
 
     def test_submission_form(self):
         data = {
-            'url': 'http://example.com',
-            'requirement': self.homework.pk,
+            "url": "http://example.com",
+            "requirement": self.homework.pk,
         }
         rv = self.client.post(self.progress_url, data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'training-progress')
-        self.assertContains(rv, 'Your homework submission will be evaluated '
-                                'soon.')
-        got = list(TrainingProgress.objects.values_list(
-            'state', 'trainee', 'url', 'requirement'))
-        expected = [(
-            'n',
-            self.admin.pk,
-            'http://example.com',
-            TrainingRequirement.objects.get(name='DC Homework').pk,
-        )]
+        self.assertEqual(rv.resolver_match.view_name, "training-progress")
+        self.assertContains(rv, "Your homework submission will be evaluated " "soon.")
+        got = list(
+            TrainingProgress.objects.values_list(
+                "state", "trainee", "url", "requirement"
+            )
+        )
+        expected = [
+            (
+                "n",
+                self.admin.pk,
+                "http://example.com",
+                TrainingRequirement.objects.get(name="DC Homework").pk,
+            )
+        ]
         self.assertEqual(got, expected)
 
 
@@ -279,99 +332,107 @@ class TestLCHomeworkStatus(TestBase):
 
     def setUp(self):
         self._setUpUsersAndLogin()
-        self.homework = TrainingRequirement.objects.get(name='LC Homework')
-        self.progress_url = reverse('training-progress')
+        self.homework = TrainingRequirement.objects.get(name="LC Homework")
+        self.progress_url = reverse("training-progress")
 
     def test_homework_not_submitted(self):
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Homework not submitted yet')
+        self.assertContains(rv, "LC Homework not submitted yet")
 
     def test_homework_waiting_to_be_evaluated(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework, state='n')
+            trainee=self.admin, requirement=self.homework, state="n"
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Homework evaluation pending')
+        self.assertContains(rv, "LC Homework evaluation pending")
 
     def test_homework_passed(self):
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.homework)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Homework accepted')
+        self.assertContains(rv, "LC Homework accepted")
 
     def test_homework_not_accepted_when_homework_passed_but_discarded(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework, discarded=True)
+            trainee=self.admin, requirement=self.homework, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Homework not submitted yet')
+        self.assertContains(rv, "LC Homework not submitted yet")
 
-    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(self):
+    def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(
+        self,
+    ):
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.homework)
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.homework, discarded=True)
+            trainee=self.admin, requirement=self.homework, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Homework accepted')
+        self.assertContains(rv, "LC Homework accepted")
 
     def test_submission_form(self):
         data = {
-            'url': 'http://example.com',
-            'requirement': self.homework.pk,
+            "url": "http://example.com",
+            "requirement": self.homework.pk,
         }
         rv = self.client.post(self.progress_url, data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'training-progress')
-        self.assertContains(rv, 'Your homework submission will be evaluated '
-                                'soon.')
-        got = list(TrainingProgress.objects.values_list(
-            'state', 'trainee', 'url', 'requirement'))
-        expected = [(
-            'n',
-            self.admin.pk,
-            'http://example.com',
-            TrainingRequirement.objects.get(name='LC Homework').pk,
-        )]
+        self.assertEqual(rv.resolver_match.view_name, "training-progress")
+        self.assertContains(rv, "Your homework submission will be evaluated " "soon.")
+        got = list(
+            TrainingProgress.objects.values_list(
+                "state", "trainee", "url", "requirement"
+            )
+        )
+        expected = [
+            (
+                "n",
+                self.admin.pk,
+                "http://example.com",
+                TrainingRequirement.objects.get(name="LC Homework").pk,
+            )
+        ]
         self.assertEqual(got, expected)
 
 
 class TestDiscussionSessionStatus(TestBase):
     """Test that trainee dashboard displays status of passing Discussion
     Session. Test whether we display instructions for registering for a
-    session. """
+    session."""
 
     def setUp(self):
         self._setUpUsersAndLogin()
-        self.discussion = TrainingRequirement.objects.get(name='Discussion')
-        self.progress_url = reverse('training-progress')
+        self.discussion = TrainingRequirement.objects.get(name="Discussion")
+        self.progress_url = reverse("training-progress")
 
     def test_session_passed(self):
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.discussion)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.discussion)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Discussion Session passed')
+        self.assertContains(rv, "Discussion Session passed")
 
     def test_session_passed_but_discarded(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.discussion, discarded=True)
+            trainee=self.admin, requirement=self.discussion, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Discussion Session not passed yet')
+        self.assertContains(rv, "Discussion Session not passed yet")
 
     def test_last_session_discarded_but_another_is_passed(self):
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.discussion)
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.discussion)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.discussion, discarded=True)
+            trainee=self.admin, requirement=self.discussion, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Discussion Session passed')
+        self.assertContains(rv, "Discussion Session passed")
 
     def test_session_failed(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.discussion, state='f')
+            trainee=self.admin, requirement=self.discussion, state="f"
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Discussion Session not passed yet')
+        self.assertContains(rv, "Discussion Session not passed yet")
 
     def test_no_participation_in_a_session_yet(self):
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'Discussion Session not passed yet')
+        self.assertContains(rv, "Discussion Session not passed yet")
 
 
 class TestDemoSessionStatus(TestBase):
@@ -381,125 +442,125 @@ class TestDemoSessionStatus(TestBase):
 
     def setUp(self):
         self._setUpUsersAndLogin()
-        self.swc_demo = TrainingRequirement.objects.get(name='SWC Demo')
-        self.dc_demo = TrainingRequirement.objects.get(name='DC Demo')
-        self.lc_demo = TrainingRequirement.objects.get(name='LC Demo')
-        self.progress_url = reverse('training-progress')
+        self.swc_demo = TrainingRequirement.objects.get(name="SWC Demo")
+        self.dc_demo = TrainingRequirement.objects.get(name="DC Demo")
+        self.lc_demo = TrainingRequirement.objects.get(name="LC Demo")
+        self.progress_url = reverse("training-progress")
 
     def test_swc_session_passed(self):
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.swc_demo)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.swc_demo)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Demo Session passed')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "SWC Demo Session passed")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_swc_session_passed_but_discarded(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.swc_demo, discarded=True)
+            trainee=self.admin, requirement=self.swc_demo, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Demo Session not passed yet')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "SWC Demo Session not passed yet")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_swc_last_session_discarded_but_another_is_passed(self):
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.swc_demo)
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.swc_demo)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.swc_demo, discarded=True)
+            trainee=self.admin, requirement=self.swc_demo, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Demo Session passed')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "SWC Demo Session passed")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_swc_session_failed(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.swc_demo, state='f')
+            trainee=self.admin, requirement=self.swc_demo, state="f"
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Demo Session not passed yet')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "SWC Demo Session not passed yet")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_no_participation_in_a_swc_session_yet(self):
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Demo Session not passed yet')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "SWC Demo Session not passed yet")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_dc_session_passed(self):
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.dc_demo)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.dc_demo)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Demo Session passed')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "DC Demo Session passed")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_dc_session_passed_but_discarded(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.dc_demo, discarded=True)
+            trainee=self.admin, requirement=self.dc_demo, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Demo Session not passed yet')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "DC Demo Session not passed yet")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_dc_last_session_discarded_but_another_is_passed(self):
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.dc_demo)
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.dc_demo)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.dc_demo, discarded=True)
+            trainee=self.admin, requirement=self.dc_demo, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Demo Session passed')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "DC Demo Session passed")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_dc_session_failed(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.dc_demo, state='f')
+            trainee=self.admin, requirement=self.dc_demo, state="f"
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Demo Session not passed yet')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "DC Demo Session not passed yet")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_no_participation_in_a_dc_session_yet(self):
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'DC Demo Session not passed yet')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "DC Demo Session not passed yet")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_lc_session_passed(self):
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.lc_demo)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.lc_demo)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Demo Session passed')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "LC Demo Session passed")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_lc_session_passed_but_discarded(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.lc_demo, discarded=True)
+            trainee=self.admin, requirement=self.lc_demo, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Demo Session not passed yet')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "LC Demo Session not passed yet")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_lc_last_session_discarded_but_another_is_passed(self):
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.lc_demo)
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.lc_demo)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.lc_demo, discarded=True)
+            trainee=self.admin, requirement=self.lc_demo, discarded=True
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Demo Session passed')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "LC Demo Session passed")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_lc_session_failed(self):
         TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.lc_demo, state='f')
+            trainee=self.admin, requirement=self.lc_demo, state="f"
+        )
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Demo Session not passed yet')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "LC Demo Session not passed yet")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_no_participation_in_a_lc_session_yet(self):
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'LC Demo Session not passed yet')
-        self.assertContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "LC Demo Session not passed yet")
+        self.assertContains(rv, "You can register for Demo Session on")
 
     def test_no_registration_instruction_when_trainee_passed_both_all_sessions(self):
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.swc_demo)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.dc_demo)
-        TrainingProgress.objects.create(
-            trainee=self.admin, requirement=self.lc_demo)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.swc_demo)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.dc_demo)
+        TrainingProgress.objects.create(trainee=self.admin, requirement=self.lc_demo)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, 'SWC Demo Session passed')
-        self.assertContains(rv, 'DC Demo Session passed')
-        self.assertContains(rv, 'LC Demo Session passed')
-        self.assertNotContains(rv, 'You can register for Demo Session on')
+        self.assertContains(rv, "SWC Demo Session passed")
+        self.assertContains(rv, "DC Demo Session passed")
+        self.assertContains(rv, "LC Demo Session passed")
+        self.assertNotContains(rv, "You can register for Demo Session on")

--- a/amy/extcomments/__init__.py
+++ b/amy/extcomments/__init__.py
@@ -1,8 +1,10 @@
 def get_model():
     from django_comments.models import Comment
+
     return Comment
 
 
 def get_form():
     from extcomments.forms import CommentForm
+
     return CommentForm

--- a/amy/extcomments/apps.py
+++ b/amy/extcomments/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class ExtcommentsConfig(AppConfig):
-    name = 'extcomments'
+    name = "extcomments"

--- a/amy/extcomments/forms.py
+++ b/amy/extcomments/forms.py
@@ -5,7 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 
 class CommentForm(DjCF):
-    comment = MarkdownxFormField(
-        label=_("Comment"),
-        max_length=COMMENT_MAX_LENGTH
-    )
+    comment = MarkdownxFormField(label=_("Comment"), max_length=COMMENT_MAX_LENGTH)

--- a/amy/extcomments/tests.py
+++ b/amy/extcomments/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/amy/extforms/apps.py
+++ b/amy/extforms/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class ExtformsConfig(AppConfig):
-    name = 'extforms'
+    name = "extforms"

--- a/amy/extforms/forms.py
+++ b/amy/extforms/forms.py
@@ -27,59 +27,59 @@ class TrainingRequestForm(forms.ModelForm):
     class Meta:
         model = TrainingRequest
         fields = (
-            'review_process',
-            'group_name',
-            'personal',
-            'family',
-            'email',
-            'secondary_email',
-            'github',
-            'occupation',
-            'occupation_other',
-            'affiliation',
-            'location',
-            'country',
-            'underresourced',
-            'domains',
-            'domains_other',
-            'underrepresented',
-            'underrepresented_details',
-            'nonprofit_teaching_experience',
-            'previous_involvement',
-            'previous_training',
-            'previous_training_other',
-            'previous_training_explanation',
-            'previous_experience',
-            'previous_experience_other',
-            'previous_experience_explanation',
-            'programming_language_usage_frequency',
-            'teaching_frequency_expectation',
-            'teaching_frequency_expectation_other',
-            'max_travelling_frequency',
-            'max_travelling_frequency_other',
-            'reason',
-            'user_notes',
-            'data_privacy_agreement',
-            'code_of_conduct_agreement',
-            'training_completion_agreement',
-            'workshop_teaching_agreement',
+            "review_process",
+            "group_name",
+            "personal",
+            "family",
+            "email",
+            "secondary_email",
+            "github",
+            "occupation",
+            "occupation_other",
+            "affiliation",
+            "location",
+            "country",
+            "underresourced",
+            "domains",
+            "domains_other",
+            "underrepresented",
+            "underrepresented_details",
+            "nonprofit_teaching_experience",
+            "previous_involvement",
+            "previous_training",
+            "previous_training_other",
+            "previous_training_explanation",
+            "previous_experience",
+            "previous_experience_other",
+            "previous_experience_explanation",
+            "programming_language_usage_frequency",
+            "teaching_frequency_expectation",
+            "teaching_frequency_expectation_other",
+            "max_travelling_frequency",
+            "max_travelling_frequency_other",
+            "reason",
+            "user_notes",
+            "data_privacy_agreement",
+            "code_of_conduct_agreement",
+            "training_completion_agreement",
+            "workshop_teaching_agreement",
         )
         widgets = {
-            'review_process': forms.RadioSelect(),
-            'occupation': RadioSelectWithOther('occupation_other'),
-            'domains': CheckboxSelectMultipleWithOthers('domains_other'),
-            'underrepresented': forms.RadioSelect(),
-            'previous_involvement': forms.CheckboxSelectMultiple(),
-            'previous_training': RadioSelectWithOther(
-                'previous_training_other'),
-            'previous_experience': RadioSelectWithOther(
-                'previous_experience_other'),
-            'programming_language_usage_frequency': forms.RadioSelect(),
-            'teaching_frequency_expectation': RadioSelectWithOther(
-                'teaching_frequency_expectation_other'),
-            'max_travelling_frequency': RadioSelectWithOther(
-                'max_travelling_frequency_other'),
-            'country': Select2Widget,
+            "review_process": forms.RadioSelect(),
+            "occupation": RadioSelectWithOther("occupation_other"),
+            "domains": CheckboxSelectMultipleWithOthers("domains_other"),
+            "underrepresented": forms.RadioSelect(),
+            "previous_involvement": forms.CheckboxSelectMultiple(),
+            "previous_training": RadioSelectWithOther("previous_training_other"),
+            "previous_experience": RadioSelectWithOther("previous_experience_other"),
+            "programming_language_usage_frequency": forms.RadioSelect(),
+            "teaching_frequency_expectation": RadioSelectWithOther(
+                "teaching_frequency_expectation_other"
+            ),
+            "max_travelling_frequency": RadioSelectWithOther(
+                "max_travelling_frequency_other"
+            ),
+            "country": Select2Widget,
         }
 
     def __init__(self, *args, **kwargs):
@@ -90,85 +90,85 @@ class TrainingRequestForm(forms.ModelForm):
 
         # set up RadioSelectWithOther widget so that it can display additional
         # field inline
-        self['occupation'].field.widget.other_field = self['occupation_other']
-        self['domains'].field.widget.other_field = self['domains_other']
-        self['previous_training'].field.widget.other_field = (
-            self['previous_training_other'])
-        self['previous_experience'].field.widget.other_field = (
-            self['previous_experience_other'])
-        self['teaching_frequency_expectation'].field.widget.other_field = (
-            self['teaching_frequency_expectation_other'])
-        self['max_travelling_frequency'].field.widget.other_field = (
-            self['max_travelling_frequency_other'])
+        self["occupation"].field.widget.other_field = self["occupation_other"]
+        self["domains"].field.widget.other_field = self["domains_other"]
+        self["previous_training"].field.widget.other_field = self[
+            "previous_training_other"
+        ]
+        self["previous_experience"].field.widget.other_field = self[
+            "previous_experience_other"
+        ]
+        self["teaching_frequency_expectation"].field.widget.other_field = self[
+            "teaching_frequency_expectation_other"
+        ]
+        self["max_travelling_frequency"].field.widget.other_field = self[
+            "max_travelling_frequency_other"
+        ]
 
         # remove that additional field
-        self.helper.layout.fields.remove('occupation_other')
-        self.helper.layout.fields.remove('domains_other')
-        self.helper.layout.fields.remove('previous_training_other')
-        self.helper.layout.fields.remove('previous_experience_other')
-        self.helper.layout.fields.remove(
-            'teaching_frequency_expectation_other')
-        self.helper.layout.fields.remove('max_travelling_frequency_other')
+        self.helper.layout.fields.remove("occupation_other")
+        self.helper.layout.fields.remove("domains_other")
+        self.helper.layout.fields.remove("previous_training_other")
+        self.helper.layout.fields.remove("previous_experience_other")
+        self.helper.layout.fields.remove("teaching_frequency_expectation_other")
+        self.helper.layout.fields.remove("max_travelling_frequency_other")
 
         # fake requiredness of the registration code / group name
-        self['group_name'].field.widget.fake_required = True
+        self["group_name"].field.widget.fake_required = True
 
         # special accordion display for the review process
-        self['review_process'].field.widget.subfields = {
-            'preapproved': [
-                self['group_name'],
+        self["review_process"].field.widget.subfields = {
+            "preapproved": [
+                self["group_name"],
             ],
-            'open': [],  # this option doesn't require any additional fields
+            "open": [],  # this option doesn't require any additional fields
         }
-        self['review_process'].field.widget.notes = \
-            TrainingRequest.REVIEW_CHOICES_NOTES
+        self["review_process"].field.widget.notes = TrainingRequest.REVIEW_CHOICES_NOTES
 
         # get current position of `review_process` field
-        pos_index = self.helper.layout.fields.index('review_process')
+        pos_index = self.helper.layout.fields.index("review_process")
 
-        self.helper.layout.fields.remove('review_process')
-        self.helper.layout.fields.remove('group_name')
+        self.helper.layout.fields.remove("review_process")
+        self.helper.layout.fields.remove("group_name")
 
         # insert div+field at previously saved position
         self.helper.layout.insert(
             pos_index,
             Div(
-                Field('review_process',
-                      template="bootstrap4/layout/radio-accordion.html"),
-                css_class='form-group row',
+                Field(
+                    "review_process", template="bootstrap4/layout/radio-accordion.html"
+                ),
+                css_class="form-group row",
             ),
         )
 
         # add <HR> around "underrepresented*" fields
-        index = self.helper.layout.fields.index('underrepresented')
-        self.helper.layout.insert(
-            index, HTML(self.helper.hr()))
+        index = self.helper.layout.fields.index("underrepresented")
+        self.helper.layout.insert(index, HTML(self.helper.hr()))
 
-        index = self.helper.layout.fields.index('underrepresented_details')
-        self.helper.layout.insert(
-            index + 1, HTML(self.helper.hr()))
+        index = self.helper.layout.fields.index("underrepresented_details")
+        self.helper.layout.insert(index + 1, HTML(self.helper.hr()))
 
     def clean(self):
         super().clean()
         errors = dict()
 
         # 1: validate registration code / group name
-        review_process = self.cleaned_data.get('review_process', '')
-        group_name = self.cleaned_data.get('group_name', '').split()
+        review_process = self.cleaned_data.get("review_process", "")
+        group_name = self.cleaned_data.get("group_name", "").split()
 
         # it's required when review_process is 'preapproved', but not when
         # 'open'
-        if review_process == 'preapproved' and not group_name:
-            errors['review_process'] = ValidationError(
+        if review_process == "preapproved" and not group_name:
+            errors["review_process"] = ValidationError(
                 "Registration code is required for pre-approved training "
                 "review process."
             )
 
         # it's required to be empty when review_process is 'open'
-        if review_process == 'open' and group_name:
-            errors['review_process'] = ValidationError(
-                "Registration code must be empty for open training review "
-                "process."
+        if review_process == "open" and group_name:
+            errors["review_process"] = ValidationError(
+                "Registration code must be empty for open training review " "process."
             )
 
         if errors:
@@ -179,18 +179,18 @@ class WorkshopRequestExternalForm(WorkshopRequestBaseForm):
     captcha = ReCaptchaField()
 
     class Meta(WorkshopRequestBaseForm.Meta):
-        fields = WorkshopRequestBaseForm.Meta.fields + ("captcha", )
+        fields = WorkshopRequestBaseForm.Meta.fields + ("captcha",)
 
 
 class WorkshopInquiryRequestExternalForm(WorkshopInquiryRequestBaseForm):
     captcha = ReCaptchaField()
 
     class Meta(WorkshopInquiryRequestBaseForm.Meta):
-        fields = WorkshopInquiryRequestBaseForm.Meta.fields + ("captcha", )
+        fields = WorkshopInquiryRequestBaseForm.Meta.fields + ("captcha",)
 
 
 class SelfOrganisedSubmissionExternalForm(SelfOrganisedSubmissionBaseForm):
     captcha = ReCaptchaField()
 
     class Meta(SelfOrganisedSubmissionBaseForm.Meta):
-        fields = SelfOrganisedSubmissionBaseForm.Meta.fields + ("captcha", )
+        fields = SelfOrganisedSubmissionBaseForm.Meta.fields + ("captcha",)

--- a/amy/extforms/models.py
+++ b/amy/extforms/models.py
@@ -1,3 +1,1 @@
-from django.db import models
-
 # Create your models here.

--- a/amy/extforms/tests/test_selforganised_submission_form.py
+++ b/amy/extforms/tests/test_selforganised_submission_form.py
@@ -119,7 +119,8 @@ class TestSelfOrganisedSubmissionExternalForm(TestBase):
         # test email for admins
         msg = mail.outbox[1]
         self.assertEqual(
-            msg.subject, "New self-organised submission: Ministry of Magic",
+            msg.subject,
+            "New self-organised submission: Ministry of Magic",
         )
         self.assertEqual(msg.recipients(), ["admin-uk@carpentries.org"])
         self.assertNotIn(

--- a/amy/extforms/tests/test_training_request_form.py
+++ b/amy/extforms/tests/test_training_request_form.py
@@ -12,83 +12,79 @@ class TestTrainingRequestForm(TestBase):
         self._setUpUsersAndLogin()
         self._setUpRoles()
         self.data = {
-            'review_process': 'preapproved',
-            'group_name': 'coolprogrammers',
-            'personal': 'John',
-            'family': 'Smith',
-            'email': 'john@smith.com',
-            'github': '',
-            'occupation': '',
-            'occupation_other': 'unemployed',
-            'affiliation': 'AGH University of Science and Technology',
-            'location': 'Cracow',
-            'country': 'PL',
-            'domains': [1, 2],
-            'domains_other': '',
-            'underrepresented': 'undisclosed',
-            'previous_involvement': [Role.objects.get(name='host').id],
-            'previous_training': 'none',
-            'previous_training_other': '',
-            'previous_training_explanation': '',
-            'previous_experience': 'none',
-            'previous_experience_other': '',
-            'previous_experience_explanation': '',
-            'programming_language_usage_frequency': 'daily',
-            'reason': 'Just for fun.',
-            'teaching_frequency_expectation': 'monthly',
-            'teaching_frequency_expectation_other': '',
-            'max_travelling_frequency': 'yearly',
-            'max_travelling_frequency_other': '',
-            'addition_skills': '',
-            'user_notes': '',
-            'agreed_to_code_of_conduct': 'on',
-            'agreed_to_complete_training': 'on',
-            'agreed_to_teach_workshops': 'on',
-            'privacy_consent': True,
+            "review_process": "preapproved",
+            "group_name": "coolprogrammers",
+            "personal": "John",
+            "family": "Smith",
+            "email": "john@smith.com",
+            "github": "",
+            "occupation": "",
+            "occupation_other": "unemployed",
+            "affiliation": "AGH University of Science and Technology",
+            "location": "Cracow",
+            "country": "PL",
+            "domains": [1, 2],
+            "domains_other": "",
+            "underrepresented": "undisclosed",
+            "previous_involvement": [Role.objects.get(name="host").id],
+            "previous_training": "none",
+            "previous_training_other": "",
+            "previous_training_explanation": "",
+            "previous_experience": "none",
+            "previous_experience_other": "",
+            "previous_experience_explanation": "",
+            "programming_language_usage_frequency": "daily",
+            "reason": "Just for fun.",
+            "teaching_frequency_expectation": "monthly",
+            "teaching_frequency_expectation_other": "",
+            "max_travelling_frequency": "yearly",
+            "max_travelling_frequency_other": "",
+            "addition_skills": "",
+            "user_notes": "",
+            "agreed_to_code_of_conduct": "on",
+            "agreed_to_complete_training": "on",
+            "agreed_to_teach_workshops": "on",
+            "privacy_consent": True,
         }
 
     def test_request_added(self):
-        email = 'john@smith.com'
+        email = "john@smith.com"
         self.passCaptcha(self.data)
 
-        rv = self.client.post(reverse('training_request'), self.data,
-                              follow=True)
+        rv = self.client.post(reverse("training_request"), self.data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        content = rv.content.decode('utf-8')
-        self.assertNotIn('fix errors in the form below', content)
+        content = rv.content.decode("utf-8")
+        self.assertNotIn("fix errors in the form below", content)
         self.assertEqual(TrainingRequest.objects.all().count(), 1)
 
         # Test that the sender was emailed
         self.assertEqual(len(mail.outbox), 1)
         msg = mail.outbox[0]
         self.assertEqual(msg.to, [email])
-        self.assertEqual(msg.subject,
-                         TrainingRequestCreate.autoresponder_subject)
-        self.assertIn('A copy of your request', msg.body)
+        self.assertEqual(msg.subject, TrainingRequestCreate.autoresponder_subject)
+        self.assertIn("A copy of your request", msg.body)
         # with open('email.eml', 'wb') as f:
         #     f.write(msg.message().as_bytes())
 
     def test_review_process_validation(self):
         # 1: shouldn't pass when review_process requires group_name
-        self.data['review_process'] = 'preapproved'
-        self.data['group_name'] = ''
+        self.data["review_process"] = "preapproved"
+        self.data["group_name"] = ""
         self.passCaptcha(self.data)
 
-        rv = self.client.post(reverse('training_request'), self.data,
-                              follow=True)
+        rv = self.client.post(reverse("training_request"), self.data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        content = rv.content.decode('utf-8')
-        self.assertIn('fix errors in the form below', content)
+        content = rv.content.decode("utf-8")
+        self.assertIn("fix errors in the form below", content)
         self.assertEqual(TrainingRequest.objects.all().count(), 0)
 
         # 2: shouldn't pass when review_process requires *NO* group_name
-        self.data['review_process'] = 'open'
-        self.data['group_name'] = 'some_code'
+        self.data["review_process"] = "open"
+        self.data["group_name"] = "some_code"
         self.passCaptcha(self.data)
 
-        rv = self.client.post(reverse('training_request'), self.data,
-                              follow=True)
+        rv = self.client.post(reverse("training_request"), self.data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        content = rv.content.decode('utf-8')
-        self.assertIn('fix errors in the form below', content)
+        content = rv.content.decode("utf-8")
+        self.assertIn("fix errors in the form below", content)
         self.assertEqual(TrainingRequest.objects.all().count(), 0)

--- a/amy/extforms/tests/test_training_request_form.py
+++ b/amy/extforms/tests/test_training_request_form.py
@@ -1,6 +1,5 @@
 from django.core import mail
 from django.urls import reverse
-from webtest import forms
 
 from extforms.views import TrainingRequestCreate
 from workshops.models import Role, TrainingRequest

--- a/amy/extforms/views.py
+++ b/amy/extforms/views.py
@@ -1,7 +1,7 @@
 from django.contrib.sites.shortcuts import get_current_site
 from django.template.loader import get_template
 from django.urls import reverse_lazy
-from django.views.generic import TemplateView, RedirectView
+from django.views.generic import TemplateView
 
 from extforms.forms import (
     TrainingRequestForm,

--- a/amy/extforms/views.py
+++ b/amy/extforms/views.py
@@ -31,6 +31,7 @@ from workshops.base_views import (
 # ------------------------------------------------------------
 # TrainingRequest views
 
+
 class TrainingRequestCreate(
     LoginNotRequiredMixin,
     AutoresponderMixin,
@@ -38,39 +39,41 @@ class TrainingRequestCreate(
 ):
     model = TrainingRequest
     form_class = TrainingRequestForm
-    template_name = 'forms/trainingrequest.html'
-    success_url = reverse_lazy('training_request_confirm')
-    autoresponder_subject = 'Thank you for your application'
-    autoresponder_body_template_txt = 'mailing/training_request.txt'
-    autoresponder_body_template_html = 'mailing/training_request.html'
-    autoresponder_form_field = 'email'
+    template_name = "forms/trainingrequest.html"
+    success_url = reverse_lazy("training_request_confirm")
+    autoresponder_subject = "Thank you for your application"
+    autoresponder_body_template_txt = "mailing/training_request.txt"
+    autoresponder_body_template_html = "mailing/training_request.html"
+    autoresponder_form_field = "email"
 
     def autoresponder_email_context(self, form):
         return dict(object=self.object)
 
     def get_success_message(self, *args, **kwargs):
         """Don't display a success message."""
-        return ''
+        return ""
 
 
 class TrainingRequestConfirm(LoginNotRequiredMixin, TemplateView):
-    template_name = 'forms/trainingrequest_confirm.html'
+    template_name = "forms/trainingrequest_confirm.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['title'] = 'Thank you for applying for an instructor training'
+        context["title"] = "Thank you for applying for an instructor training"
         return context
 
 
 # ------------------------------------------------------------
 # Workshop landing page view
 
+
 class WorkshopLanding(LoginNotRequiredMixin, TemplateView):
-    template_name = 'forms/workshop_landing.html'
+    template_name = "forms/workshop_landing.html"
 
 
 # ------------------------------------------------------------
 # WorkshopRequest views
+
 
 class WorkshopRequestCreate(
     LoginNotRequiredMixin,
@@ -80,32 +83,32 @@ class WorkshopRequestCreate(
 ):
     model = WorkshopRequest
     form_class = WorkshopRequestExternalForm
-    page_title = 'Request a Carpentries Workshop'
-    template_name = 'forms/workshoprequest.html'
-    success_url = reverse_lazy('workshop_request_confirm')
+    page_title = "Request a Carpentries Workshop"
+    template_name = "forms/workshoprequest.html"
+    success_url = reverse_lazy("workshop_request_confirm")
     email_fail_silently = False
 
-    autoresponder_subject = 'Workshop request confirmation'
-    autoresponder_body_template_txt = 'mailing/workshoprequest.txt'
-    autoresponder_body_template_html = 'mailing/workshoprequest.html'
-    autoresponder_form_field = 'email'
+    autoresponder_subject = "Workshop request confirmation"
+    autoresponder_body_template_txt = "mailing/workshoprequest.txt"
+    autoresponder_body_template_html = "mailing/workshoprequest.html"
+    autoresponder_form_field = "email"
 
     def autoresponder_email_context(self, form):
         return dict(object=self.object)
 
     def get_success_message(self, *args, **kwargs):
         """Don't display a success message."""
-        return ''
+        return ""
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['title'] = self.page_title
+        context["title"] = self.page_title
         return context
 
     def get_email_kwargs(self):
         return {
-            'to': match_notification_email(self.object),
-            'reply_to': [self.object.email],
+            "to": match_notification_email(self.object),
+            "reply_to": [self.object.email],
         }
 
     def get_subject(self):
@@ -114,9 +117,7 @@ class WorkshopRequestCreate(
             if self.object.institution
             else self.object.institution_other_name
         )
-        subject = (
-            'New workshop request: {affiliation}, {dates}'
-        ).format(
+        subject = ("New workshop request: {affiliation}, {dates}").format(
             affiliation=affiliation,
             dates=self.object.dates(),
         )
@@ -124,23 +125,23 @@ class WorkshopRequestCreate(
 
     def get_body(self):
         link = self.object.get_absolute_url()
-        link_domain = 'https://{}'.format(get_current_site(self.request))
+        link_domain = "https://{}".format(get_current_site(self.request))
 
-        body_txt = get_template(
-            'mailing/workshoprequest_admin.txt'
-        ).render({
-            'object': self.object,
-            'link': link,
-            'link_domain': link_domain,
-        })
+        body_txt = get_template("mailing/workshoprequest_admin.txt").render(
+            {
+                "object": self.object,
+                "link": link,
+                "link_domain": link_domain,
+            }
+        )
 
-        body_html = get_template(
-            'mailing/workshoprequest_admin.html'
-        ).render({
-            'object': self.object,
-            'link': link,
-            'link_domain': link_domain,
-        })
+        body_html = get_template("mailing/workshoprequest_admin.html").render(
+            {
+                "object": self.object,
+                "link": link,
+                "link_domain": link_domain,
+            }
+        )
         return body_txt, body_html
 
     def form_valid(self, form):
@@ -150,16 +151,17 @@ class WorkshopRequestCreate(
 
 
 class WorkshopRequestConfirm(LoginNotRequiredMixin, TemplateView):
-    template_name = 'forms/workshoprequest_confirm.html'
+    template_name = "forms/workshoprequest_confirm.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['title'] = 'Thank you for requesting a workshop'
+        context["title"] = "Thank you for requesting a workshop"
         return context
 
 
 # ------------------------------------------------------------
 # WorkshopInquiryRequest views
+
 
 class WorkshopInquiryRequestCreate(
     LoginNotRequiredMixin,
@@ -169,32 +171,32 @@ class WorkshopInquiryRequestCreate(
 ):
     model = WorkshopInquiryRequest
     form_class = WorkshopInquiryRequestExternalForm
-    page_title = 'Inquiry about Carpentries Workshop'
-    template_name = 'forms/workshopinquiry.html'
-    success_url = reverse_lazy('workshop_inquiry_confirm')
+    page_title = "Inquiry about Carpentries Workshop"
+    template_name = "forms/workshopinquiry.html"
+    success_url = reverse_lazy("workshop_inquiry_confirm")
     email_fail_silently = False
 
-    autoresponder_subject = 'Workshop inquiry confirmation'
-    autoresponder_body_template_txt = 'mailing/workshopinquiry.txt'
-    autoresponder_body_template_html = 'mailing/workshopinquiry.html'
-    autoresponder_form_field = 'email'
+    autoresponder_subject = "Workshop inquiry confirmation"
+    autoresponder_body_template_txt = "mailing/workshopinquiry.txt"
+    autoresponder_body_template_html = "mailing/workshopinquiry.html"
+    autoresponder_form_field = "email"
 
     def autoresponder_email_context(self, form):
         return dict(object=self.object)
 
     def get_success_message(self, *args, **kwargs):
         """Don't display a success message."""
-        return ''
+        return ""
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['title'] = self.page_title
+        context["title"] = self.page_title
         return context
 
     def get_email_kwargs(self):
         return {
-            'to': match_notification_email(self.object),
-            'reply_to': [self.object.email],
+            "to": match_notification_email(self.object),
+            "reply_to": [self.object.email],
         }
 
     def get_subject(self):
@@ -203,9 +205,7 @@ class WorkshopInquiryRequestCreate(
             if self.object.institution
             else self.object.institution_other_name
         )
-        subject = (
-            'New workshop inquiry: {affiliation}, {dates}'
-        ).format(
+        subject = ("New workshop inquiry: {affiliation}, {dates}").format(
             affiliation=affiliation,
             dates=self.object.dates(),
         )
@@ -213,23 +213,23 @@ class WorkshopInquiryRequestCreate(
 
     def get_body(self):
         link = self.object.get_absolute_url()
-        link_domain = 'https://{}'.format(get_current_site(self.request))
+        link_domain = "https://{}".format(get_current_site(self.request))
 
-        body_txt = get_template(
-            'mailing/workshopinquiry_admin.txt'
-        ).render({
-            'object': self.object,
-            'link': link,
-            'link_domain': link_domain,
-        })
+        body_txt = get_template("mailing/workshopinquiry_admin.txt").render(
+            {
+                "object": self.object,
+                "link": link,
+                "link_domain": link_domain,
+            }
+        )
 
-        body_html = get_template(
-            'mailing/workshopinquiry_admin.html'
-        ).render({
-            'object': self.object,
-            'link': link,
-            'link_domain': link_domain,
-        })
+        body_html = get_template("mailing/workshopinquiry_admin.html").render(
+            {
+                "object": self.object,
+                "link": link,
+                "link_domain": link_domain,
+            }
+        )
         return body_txt, body_html
 
     def form_valid(self, form):
@@ -239,16 +239,17 @@ class WorkshopInquiryRequestCreate(
 
 
 class WorkshopInquiryRequestConfirm(LoginNotRequiredMixin, TemplateView):
-    template_name = 'forms/workshopinquiry_confirm.html'
+    template_name = "forms/workshopinquiry_confirm.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['title'] = 'Thank you for inquiring about The Carpentries'
+        context["title"] = "Thank you for inquiring about The Carpentries"
         return context
 
 
 # ------------------------------------------------------------
 # SelfOrganisedSubmission views
+
 
 class SelfOrganisedSubmissionCreate(
     LoginNotRequiredMixin,
@@ -258,32 +259,32 @@ class SelfOrganisedSubmissionCreate(
 ):
     model = SelfOrganisedSubmission
     form_class = SelfOrganisedSubmissionExternalForm
-    page_title = 'Submit a self-organised workshop'
-    template_name = 'forms/selforganised_submission.html'
-    success_url = reverse_lazy('selforganised_submission_confirm')
+    page_title = "Submit a self-organised workshop"
+    template_name = "forms/selforganised_submission.html"
+    success_url = reverse_lazy("selforganised_submission_confirm")
     email_fail_silently = False
 
-    autoresponder_subject = 'Self-organised submission confirmation'
-    autoresponder_body_template_txt = 'mailing/selforganisedsubmission.txt'
-    autoresponder_body_template_html = 'mailing/selforganisedsubmission.html'
-    autoresponder_form_field = 'email'
+    autoresponder_subject = "Self-organised submission confirmation"
+    autoresponder_body_template_txt = "mailing/selforganisedsubmission.txt"
+    autoresponder_body_template_html = "mailing/selforganisedsubmission.html"
+    autoresponder_form_field = "email"
 
     def autoresponder_email_context(self, form):
         return dict(object=self.object)
 
     def get_success_message(self, *args, **kwargs):
         """Don't display a success message."""
-        return ''
+        return ""
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['title'] = self.page_title
+        context["title"] = self.page_title
         return context
 
     def get_email_kwargs(self):
         return {
-            'to': match_notification_email(self.object),
-            'reply_to': [self.object.email],
+            "to": match_notification_email(self.object),
+            "reply_to": [self.object.email],
         }
 
     def get_subject(self):
@@ -292,32 +293,30 @@ class SelfOrganisedSubmissionCreate(
             if self.object.institution
             else self.object.institution_other_name
         )
-        subject = (
-            'New self-organised submission: {affiliation}'
-        ).format(
+        subject = ("New self-organised submission: {affiliation}").format(
             affiliation=affiliation,
         )
         return subject
 
     def get_body(self):
         link = self.object.get_absolute_url()
-        link_domain = 'https://{}'.format(get_current_site(self.request))
+        link_domain = "https://{}".format(get_current_site(self.request))
 
-        body_txt = get_template(
-            'mailing/selforganisedsubmission_admin.txt'
-        ).render({
-            'object': self.object,
-            'link': link,
-            'link_domain': link_domain,
-        })
+        body_txt = get_template("mailing/selforganisedsubmission_admin.txt").render(
+            {
+                "object": self.object,
+                "link": link,
+                "link_domain": link_domain,
+            }
+        )
 
-        body_html = get_template(
-            'mailing/selforganisedsubmission_admin.html'
-        ).render({
-            'object': self.object,
-            'link': link,
-            'link_domain': link_domain,
-        })
+        body_html = get_template("mailing/selforganisedsubmission_admin.html").render(
+            {
+                "object": self.object,
+                "link": link,
+                "link_domain": link_domain,
+            }
+        )
         return body_txt, body_html
 
     def form_valid(self, form):
@@ -327,9 +326,9 @@ class SelfOrganisedSubmissionCreate(
 
 
 class SelfOrganisedSubmissionConfirm(LoginNotRequiredMixin, TemplateView):
-    template_name = 'forms/selforganisedsubmission_confirm.html'
+    template_name = "forms/selforganisedsubmission_confirm.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['title'] = 'Thank you for submitting self-organised workshop'
+        context["title"] = "Thank you for submitting self-organised workshop"
         return context

--- a/amy/extrequests/apps.py
+++ b/amy/extrequests/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class ExtrequestsConfig(AppConfig):
-    name = 'extrequests'
+    name = "extrequests"

--- a/amy/extrequests/filters.py
+++ b/amy/extrequests/filters.py
@@ -29,115 +29,117 @@ from workshops.models import (
 # TrainingRequest related filter and filter methods
 # ------------------------------------------------------------
 
+
 class TrainingRequestFilter(AMYFilterSet):
     search = django_filters.CharFilter(
-        label='Name or Email',
-        method='filter_by_person',
+        label="Name or Email",
+        method="filter_by_person",
     )
 
     group_name = django_filters.CharFilter(
-        field_name='group_name',
-        lookup_expr='icontains',
-        label='Group')
+        field_name="group_name", lookup_expr="icontains", label="Group"
+    )
 
     state = django_filters.ChoiceFilter(
-        label='State',
-        choices=(
-            ('no_d', 'Pending or accepted'),
-        ) + TrainingRequest.STATE_CHOICES,
-        method='filter_training_requests_by_state',
+        label="State",
+        choices=(("no_d", "Pending or accepted"),) + TrainingRequest.STATE_CHOICES,
+        method="filter_training_requests_by_state",
     )
 
     matched = django_filters.ChoiceFilter(
-        label='Is Matched?',
+        label="Is Matched?",
         choices=(
-            ('', 'Unknown'),
-            ('u', 'Unmatched'),
-            ('p', 'Matched trainee, unmatched training'),
-            ('t', 'Matched trainee and training'),
+            ("", "Unknown"),
+            ("u", "Unmatched"),
+            ("p", "Matched trainee, unmatched training"),
+            ("t", "Matched trainee and training"),
         ),
-        method='filter_matched',
+        method="filter_matched",
     )
 
     nonnull_manual_score = django_filters.BooleanFilter(
-        label='Manual score applied',
-        method='filter_non_null_manual_score',
+        label="Manual score applied",
+        method="filter_non_null_manual_score",
         widget=widgets.CheckboxInput,
     )
 
     affiliation = django_filters.CharFilter(
-        method='filter_affiliation',
+        method="filter_affiliation",
     )
 
-    location = django_filters.CharFilter(lookup_expr='icontains')
+    location = django_filters.CharFilter(lookup_expr="icontains")
 
     order_by = NamesOrderingFilter(
         fields=(
-            'created_at',
-            'score_total',
+            "created_at",
+            "score_total",
         ),
     )
 
     class Meta:
         model = TrainingRequest
         fields = [
-            'search',
-            'group_name',
-            'state',
-            'matched',
-            'affiliation',
-            'location',
+            "search",
+            "group_name",
+            "state",
+            "matched",
+            "affiliation",
+            "location",
         ]
 
     def filter_matched(self, queryset, name, choice):
-        if choice == '':
+        if choice == "":
             return queryset
-        elif choice == 'u':  # unmatched
+        elif choice == "u":  # unmatched
             return queryset.filter(person=None)
-        elif choice == 'p':  # matched trainee, unmatched training
-            return queryset.filter(person__isnull=False)\
-                           .exclude(person__task__role__name='learner',
-                                    person__task__event__tags__name='TTT')\
-                           .distinct()
+        elif choice == "p":  # matched trainee, unmatched training
+            return (
+                queryset.filter(person__isnull=False)
+                .exclude(
+                    person__task__role__name="learner",
+                    person__task__event__tags__name="TTT",
+                )
+                .distinct()
+            )
         else:  # choice == 't' <==> matched trainee and training
-            return queryset.filter(person__task__role__name='learner',
-                                   person__task__event__tags__name='TTT')\
-                           .distinct()
+            return queryset.filter(
+                person__task__role__name="learner",
+                person__task__event__tags__name="TTT",
+            ).distinct()
 
     def filter_by_person(self, queryset, name, value):
-        if value == '':
+        if value == "":
             return queryset
         else:
             # 'Harry Potter' -> ['Harry', 'Potter']
-            tokens = re.split(r'\s+', value)
+            tokens = re.split(r"\s+", value)
             # Each token must match email address or github username or
             # personal, or family name.
             for token in tokens:
                 queryset = queryset.filter(
-                    Q(personal__icontains=token) |
-                    Q(middle__icontains=token) |
-                    Q(family__icontains=token) |
-                    Q(email__icontains=token) |
-                    Q(person__personal__icontains=token) |
-                    Q(person__middle__icontains=token) |
-                    Q(person__family__icontains=token) |
-                    Q(person__email__icontains=token)
+                    Q(personal__icontains=token)
+                    | Q(middle__icontains=token)
+                    | Q(family__icontains=token)
+                    | Q(email__icontains=token)
+                    | Q(person__personal__icontains=token)
+                    | Q(person__middle__icontains=token)
+                    | Q(person__family__icontains=token)
+                    | Q(person__email__icontains=token)
                 )
             return queryset
 
     def filter_affiliation(self, queryset, name, affiliation):
-        if affiliation == '':
+        if affiliation == "":
             return queryset
         else:
-            q = (
-                Q(affiliation__icontains=affiliation) |
-                Q(person__affiliation__icontains=affiliation)
+            q = Q(affiliation__icontains=affiliation) | Q(
+                person__affiliation__icontains=affiliation
             )
             return queryset.filter(q).distinct()
 
     def filter_training_requests_by_state(self, queryset, name, choice):
-        if choice == 'no_d':
-            return queryset.exclude(state='d')
+        if choice == "no_d":
+            return queryset.exclude(state="d")
         else:
             return queryset.filter(state=choice)
 
@@ -151,29 +153,28 @@ class TrainingRequestFilter(AMYFilterSet):
 # WorkshopRequest related filter and filter methods
 # ------------------------------------------------------------
 
+
 class WorkshopRequestFilter(AMYFilterSet, StateFilterSet):
     assigned_to = ForeignKeyAllValuesFilter(Person, widget=Select2Widget)
     country = AllCountriesFilter(widget=Select2Widget)
     continent = ContinentFilter(widget=Select2Widget, label="Continent")
     requested_workshop_types = django_filters.ModelMultipleChoiceFilter(
-        label='Requested workshop types',
+        label="Requested workshop types",
         queryset=Curriculum.objects.all(),
         widget=widgets.CheckboxSelectMultiple(),
     )
 
     order_by = django_filters.OrderingFilter(
-        fields=(
-            'created_at',
-        ),
+        fields=("created_at",),
     )
 
     class Meta:
         model = WorkshopRequest
         fields = [
-            'state',
-            'assigned_to',
-            'requested_workshop_types',
-            'country',
+            "state",
+            "assigned_to",
+            "requested_workshop_types",
+            "country",
         ]
 
 
@@ -181,58 +182,55 @@ class WorkshopRequestFilter(AMYFilterSet, StateFilterSet):
 # WorkshopInquiryRequest related filter and filter methods
 # ------------------------------------------------------------
 
+
 class WorkshopInquiryFilter(AMYFilterSet, StateFilterSet):
     assigned_to = ForeignKeyAllValuesFilter(Person, widget=Select2Widget)
     country = AllCountriesFilter(widget=Select2Widget)
     continent = ContinentFilter(widget=Select2Widget, label="Continent")
     requested_workshop_types = django_filters.ModelMultipleChoiceFilter(
-        label='Requested workshop types',
+        label="Requested workshop types",
         queryset=Curriculum.objects.all(),
         widget=widgets.CheckboxSelectMultiple(),
     )
 
     order_by = django_filters.OrderingFilter(
-        fields=(
-            'created_at',
-        ),
+        fields=("created_at",),
     )
 
     class Meta:
         model = WorkshopInquiryRequest
         fields = [
-            'state',
-            'assigned_to',
-            'requested_workshop_types',
-            'country',
+            "state",
+            "assigned_to",
+            "requested_workshop_types",
+            "country",
         ]
-
 
 
 # ------------------------------------------------------------
 # SelfOrganisedSubmission related filter and filter methods
 # ------------------------------------------------------------
 
+
 class SelfOrganisedSubmissionFilter(AMYFilterSet, StateFilterSet):
     assigned_to = ForeignKeyAllValuesFilter(Person, widget=Select2Widget)
     country = AllCountriesFilter(widget=Select2Widget)
     continent = ContinentFilter(widget=Select2Widget, label="Continent")
     workshop_types = django_filters.ModelMultipleChoiceFilter(
-        label='Requested workshop types',
+        label="Requested workshop types",
         queryset=Curriculum.objects.all(),
         widget=widgets.CheckboxSelectMultiple(),
     )
 
     order_by = django_filters.OrderingFilter(
-        fields=(
-            'created_at',
-        ),
+        fields=("created_at",),
     )
 
     class Meta:
         model = SelfOrganisedSubmission
         fields = [
-            'state',
-            'assigned_to',
-            'workshop_types',
-            'workshop_format',
+            "state",
+            "assigned_to",
+            "workshop_types",
+            "workshop_format",
         ]

--- a/amy/extrequests/forms.py
+++ b/amy/extrequests/forms.py
@@ -127,7 +127,11 @@ class BulkMatchTrainingRequestForm(forms.Form):
     helper = BootstrapHelper(
         add_submit_button=False, form_tag=False, add_cancel_button=False
     )
-    helper.layout = Layout("event", "seat_membership", "seat_open_training",)
+    helper.layout = Layout(
+        "event",
+        "seat_membership",
+        "seat_open_training",
+    )
     helper.add_input(
         Submit(
             "match",
@@ -409,11 +413,13 @@ class WorkshopRequestBaseForm(forms.ModelForm):
         hr_fields_before = ("carpentries_info_source",)
         for field in hr_fields_after:
             self.helper.layout.insert(
-                self.helper.layout.fields.index(field) + 1, HTML(self.helper.hr()),
+                self.helper.layout.fields.index(field) + 1,
+                HTML(self.helper.hr()),
             )
         for field in hr_fields_before:
             self.helper.layout.insert(
-                self.helper.layout.fields.index(field), HTML(self.helper.hr()),
+                self.helper.layout.fields.index(field),
+                HTML(self.helper.hr()),
             )
 
     @staticmethod
@@ -830,11 +836,13 @@ class WorkshopInquiryRequestBaseForm(forms.ModelForm):
         )
         for field in hr_fields_after:
             self.helper.layout.insert(
-                self.helper.layout.fields.index(field) + 1, HTML(self.helper.hr()),
+                self.helper.layout.fields.index(field) + 1,
+                HTML(self.helper.hr()),
             )
         for field in hr_fields_before:
             self.helper.layout.insert(
-                self.helper.layout.fields.index(field), HTML(self.helper.hr()),
+                self.helper.layout.fields.index(field),
+                HTML(self.helper.hr()),
             )
 
         AGREEMENTS_TEXT = (
@@ -895,7 +903,8 @@ class WorkshopInquiryRequestBaseForm(forms.ModelForm):
         academic_levels = self.cleaned_data.get("academic_levels", None)
         computing_levels = self.cleaned_data.get("computing_levels", None)
         requested_workshop_types = self.cleaned_data.get(
-            "requested_workshop_types", None,
+            "requested_workshop_types",
+            None,
         )
 
         if routine_data and routine_data.filter(unknown=True):
@@ -1002,7 +1011,10 @@ class WorkshopInquiryRequestAdminForm(WorkshopInquiryRequestBaseForm):
     helper = BootstrapHelper(add_cancel_button=False, duplicate_buttons_on_top=True)
 
     class Meta(WorkshopInquiryRequestBaseForm.Meta):
-        fields = ("state", "event",) + WorkshopInquiryRequestBaseForm.Meta.fields
+        fields = (
+            "state",
+            "event",
+        ) + WorkshopInquiryRequestBaseForm.Meta.fields
 
         widgets = WorkshopInquiryRequestBaseForm.Meta.widgets.copy()
         widgets.update({"event": Select2Widget})
@@ -1145,11 +1157,13 @@ class SelfOrganisedSubmissionBaseForm(forms.ModelForm):
         hr_fields_before = []
         for field in hr_fields_after:
             self.helper.layout.insert(
-                self.helper.layout.fields.index(field) + 1, HTML(self.helper.hr()),
+                self.helper.layout.fields.index(field) + 1,
+                HTML(self.helper.hr()),
             )
         for field in hr_fields_before:
             self.helper.layout.insert(
-                self.helper.layout.fields.index(field), HTML(self.helper.hr()),
+                self.helper.layout.fields.index(field),
+                HTML(self.helper.hr()),
             )
 
     def clean(self):
@@ -1242,7 +1256,10 @@ class SelfOrganisedSubmissionAdminForm(SelfOrganisedSubmissionBaseForm):
     helper = BootstrapHelper(add_cancel_button=False, duplicate_buttons_on_top=True)
 
     class Meta(SelfOrganisedSubmissionBaseForm.Meta):
-        fields = ("state", "event",) + SelfOrganisedSubmissionBaseForm.Meta.fields
+        fields = (
+            "state",
+            "event",
+        ) + SelfOrganisedSubmissionBaseForm.Meta.fields
 
         widgets = SelfOrganisedSubmissionBaseForm.Meta.widgets.copy()
         widgets.update({"event": Select2Widget})
@@ -1322,106 +1339,172 @@ class TrainingRequestsMergeForm(forms.Form):
     state = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     person = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     group_name = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     personal = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     middle = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     family = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     email = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     secondary_email = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     github = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     occupation = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     occupation_other = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     affiliation = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     location = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     country = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     underresourced = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     domains = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     domains_other = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     underrepresented = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     underrepresented_details = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     nonprofit_teaching_experience = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     previous_involvement = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     previous_training = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     previous_training_other = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     previous_training_explanation = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     previous_experience = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     previous_experience_other = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     previous_experience_explanation = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     programming_language_usage_frequency = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     teaching_frequency_expectation = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     teaching_frequency_expectation_other = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     max_travelling_frequency = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     max_travelling_frequency_other = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     reason = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     user_notes = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     training_completion_agreement = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     workshop_teaching_agreement = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     data_privacy_agreement = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     code_of_conduct_agreement = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     created_at = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     comments = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )

--- a/amy/extrequests/models.py
+++ b/amy/extrequests/models.py
@@ -96,7 +96,11 @@ class WorkshopInquiryRequest(
         verbose_name="Workshop location",
         help_text="City, state, or province.",
     )
-    country = CountryField(null=False, blank=False, verbose_name="Country",)
+    country = CountryField(
+        null=False,
+        blank=False,
+        verbose_name="Country",
+    )
     # Here starts "Your Audience" part with this description:
     # The Carpentries offers several different workshops intended for audiences
     # from different domain backgrounds, with different computational
@@ -124,7 +128,10 @@ class WorkshopInquiryRequest(
         "all that apply.",
     )
     domains_other = models.CharField(
-        max_length=STR_LONGEST, blank=True, default="", verbose_name="Other domains",
+        max_length=STR_LONGEST,
+        blank=True,
+        default="",
+        verbose_name="Other domains",
     )
     academic_levels = models.ManyToManyField(
         AcademicLevel,
@@ -435,10 +442,7 @@ class SelfOrganisedSubmission(
         help_text="Please provide the dates that your Self-Organised workshop will"
         " run.",
     )
-    end = models.DateField(
-        null=True,
-        verbose_name="Workshop end date"
-    )
+    end = models.DateField(null=True, verbose_name="Workshop end date")
     workshop_url = models.URLField(
         max_length=STR_LONGEST,
         blank=True,
@@ -496,7 +500,11 @@ class SelfOrganisedSubmission(
         'lesson only" or "We are teaching Data Carpentry\'s Ecology '
         'workshop, but not teaching a programming language."',
     )
-    country = CountryField(null=True, blank=False, verbose_name="Country",)
+    country = CountryField(
+        null=True,
+        blank=False,
+        verbose_name="Country",
+    )
     language = models.ForeignKey(
         Language,
         on_delete=models.PROTECT,

--- a/amy/extrequests/tests/test_bulk_manual_score.py
+++ b/amy/extrequests/tests/test_bulk_manual_score.py
@@ -32,7 +32,7 @@ class UploadTrainingRequestManualScoreCSVTestCase(TestBase):
         # ensure data has correct format
         self.assertEqual(
             set(data[0].keys()),
-            set(TrainingRequest.MANUAL_SCORE_UPLOAD_FIELDS + ("errors", ))
+            set(TrainingRequest.MANUAL_SCORE_UPLOAD_FIELDS + ("errors",)),
         )
 
     def test_csv_without_required_field(self):
@@ -42,8 +42,8 @@ class UploadTrainingRequestManualScoreCSVTestCase(TestBase):
 1,123,"This person exceeded at receiving big manual score."
 2,-321,They did bad at our survey"""
         data = self.compute_from_string(bad_csv)
-        self.assertTrue(data[0]['score_manual'] is None)
-        self.assertTrue(data[1]['score_manual'] is None)
+        self.assertTrue(data[0]["score_manual"] is None)
+        self.assertTrue(data[1]["score_manual"] is None)
 
     def test_csv_with_empty_lines(self):
         csv = """request_id,score_manual,score_notes
@@ -58,7 +58,7 @@ class UploadTrainingRequestManualScoreCSVTestCase(TestBase):
 1,,'This person exceeded at receiving big manual score.'"""
         data = self.compute_from_string(csv)
         entry = data[0]
-        self.assertEqual(entry['score_manual'], '')
+        self.assertEqual(entry["score_manual"], "")
 
     def test_serializability_of_parsed(self):
         csv = """request_id,score_manual,score_notes
@@ -70,17 +70,19 @@ class UploadTrainingRequestManualScoreCSVTestCase(TestBase):
             serializer = JSONSerializer()
             serializer.dumps(data)
         except TypeError:
-            self.fail('Dumping manual scores for Training Requests into JSON '
-                      'unexpectedly failed!')
+            self.fail(
+                "Dumping manual scores for Training Requests into JSON "
+                "unexpectedly failed!"
+            )
 
     def test_malformed_CSV_with_proper_header_row(self):
         csv = """request_id,score_manual,score_notes
 This is a malformed CSV"""
         data = self.compute_from_string(csv)
         self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['request_id'], 'This is a malformed CSV')
-        self.assertEqual(data[0]['score_manual'], None)
-        self.assertEqual(data[0]['score_notes'], None)
+        self.assertEqual(data[0]["request_id"], "This is a malformed CSV")
+        self.assertEqual(data[0]["score_manual"], None)
+        self.assertEqual(data[0]["score_notes"], None)
 
 
 class CSVBulkUploadTestBase(TestBase):
@@ -88,22 +90,22 @@ class CSVBulkUploadTestBase(TestBase):
 
     def setUp(self):
         """Prepare some existing Training Requests."""
-        self.tr1 = create_training_request(state='p', person=None)
+        self.tr1 = create_training_request(state="p", person=None)
         self.tr1.score_manual = 10
         self.tr1.score_notes = "This request received positive manual score"
         self.tr1.save()
 
-        self.tr2 = create_training_request(state='p', person=None)
+        self.tr2 = create_training_request(state="p", person=None)
         self.tr2.score_manual = -10
         self.tr2.score_notes = "This request received negative manual score"
         self.tr2.save()
 
-        self.tr3 = create_training_request(state='p', person=None)
+        self.tr3 = create_training_request(state="p", person=None)
         self.tr3.score_manual = 0
         self.tr3.score_notes = "This request was manually scored to zero"
         self.tr3.save()
 
-        self.tr4 = create_training_request(state='p', person=None)
+        self.tr4 = create_training_request(state="p", person=None)
         self.tr4.score_manual = None
         self.tr4.score_notes = "This request hasn't been scored manually"
         self.tr4.save()
@@ -137,92 +139,93 @@ class CleanUploadTrainingRequestManualScore(CSVBulkUploadTestBase):
         has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
         self.assertFalse(has_errors)
         # empty list evaluates to False
-        self.assertFalse(cleaned[0]['errors'])
-        self.assertFalse(cleaned[1]['errors'])
-        self.assertFalse(cleaned[2]['errors'])
-        self.assertFalse(cleaned[3]['errors'])
+        self.assertFalse(cleaned[0]["errors"])
+        self.assertFalse(cleaned[1]["errors"])
+        self.assertFalse(cleaned[2]["errors"])
+        self.assertFalse(cleaned[3]["errors"])
 
     def test_missing_request_ID(self):
         data = self.make_data()
-        data[1]['request_id'] = ''
+        data[1]["request_id"] = ""
 
         has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
         self.assertTrue(has_errors)
-        self.assertFalse(cleaned[0]['errors'])
-        self.assertTrue(cleaned[1]['errors'])
-        self.assertFalse(cleaned[2]['errors'])
-        self.assertFalse(cleaned[3]['errors'])
+        self.assertFalse(cleaned[0]["errors"])
+        self.assertTrue(cleaned[1]["errors"])
+        self.assertFalse(cleaned[2]["errors"])
+        self.assertFalse(cleaned[3]["errors"])
 
-        self.assertIn('Request ID is missing.', cleaned[1]['errors'])
+        self.assertIn("Request ID is missing.", cleaned[1]["errors"])
 
     def test_missing_score_manual(self):
         data = self.make_data()
-        data[1]['score_manual'] = ''
+        data[1]["score_manual"] = ""
 
         has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
         self.assertTrue(has_errors)
-        self.assertFalse(cleaned[0]['errors'])
-        self.assertTrue(cleaned[1]['errors'])
-        self.assertFalse(cleaned[2]['errors'])
-        self.assertFalse(cleaned[3]['errors'])
+        self.assertFalse(cleaned[0]["errors"])
+        self.assertTrue(cleaned[1]["errors"])
+        self.assertFalse(cleaned[2]["errors"])
+        self.assertFalse(cleaned[3]["errors"])
 
-        self.assertIn('Manual score is missing.', cleaned[1]['errors'])
+        self.assertIn("Manual score is missing.", cleaned[1]["errors"])
 
     def test_missing_score_notes(self):
         """Missing notes should not trigger any errors."""
         data = self.make_data()
-        data[1]['score_notes'] = ''
+        data[1]["score_notes"] = ""
 
         has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
         self.assertFalse(has_errors)
-        self.assertFalse(cleaned[0]['errors'])
-        self.assertFalse(cleaned[1]['errors'])
-        self.assertFalse(cleaned[2]['errors'])
-        self.assertFalse(cleaned[3]['errors'])
+        self.assertFalse(cleaned[0]["errors"])
+        self.assertFalse(cleaned[1]["errors"])
+        self.assertFalse(cleaned[2]["errors"])
+        self.assertFalse(cleaned[3]["errors"])
 
     def test_request_ID_wrong_format(self):
         data = self.make_data()
-        data[0]['request_id'] = '1.23.4'
-        data[1]['request_id'] = ' '
-        data[2]['request_id'] = '-123'
-        data[3]['request_id'] = '.0'
+        data[0]["request_id"] = "1.23.4"
+        data[1]["request_id"] = " "
+        data[2]["request_id"] = "-123"
+        data[3]["request_id"] = ".0"
 
         has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
         self.assertTrue(has_errors)
         for i in range(4):
-            self.assertTrue(cleaned[i]['errors'])
-            self.assertIn('Request ID is not an integer value.',
-                          cleaned[i]['errors'], i)
+            self.assertTrue(cleaned[i]["errors"])
+            self.assertIn(
+                "Request ID is not an integer value.", cleaned[i]["errors"], i
+            )
 
     def test_score_manual_wrong_format(self):
         data = self.make_data()
-        data[0]['score_manual'] = '1.23.4'
-        data[1]['score_manual'] = ' '
-        data[2]['score_manual'] = '.0'
-        data[3]['score_manual'] = '-123'
+        data[0]["score_manual"] = "1.23.4"
+        data[1]["score_manual"] = " "
+        data[2]["score_manual"] = ".0"
+        data[3]["score_manual"] = "-123"
 
         has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
         self.assertTrue(has_errors)
         for i in range(3):
-            self.assertTrue(cleaned[i]['errors'])
-            self.assertIn('Manual score is not an integer value.',
-                          cleaned[i]['errors'], i)
+            self.assertTrue(cleaned[i]["errors"])
+            self.assertIn(
+                "Manual score is not an integer value.", cleaned[i]["errors"], i
+            )
 
         # last entry should be valid
-        self.assertFalse(cleaned[3]['errors'])
+        self.assertFalse(cleaned[3]["errors"])
 
     def test_request_ID_not_matching(self):
         data = self.make_data()
-        data[0]['request_id'] = '3333'
+        data[0]["request_id"] = "3333"
 
         has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
         self.assertTrue(has_errors)
-        self.assertTrue(cleaned[0]['errors'])
-        self.assertIn('Request ID doesn\'t match any request.',
-                      cleaned[0]['errors'])
-        self.assertFalse(cleaned[1]['errors'])
-        self.assertFalse(cleaned[2]['errors'])
-        self.assertFalse(cleaned[3]['errors'])
+        self.assertTrue(cleaned[0]["errors"])
+        self.assertIn("Request ID doesn't match any request.", cleaned[0]["errors"])
+        self.assertFalse(cleaned[1]["errors"])
+        self.assertFalse(cleaned[2]["errors"])
+        self.assertFalse(cleaned[3]["errors"])
 
 
 class UpdateTrainingRequestManualScore(CSVBulkUploadTestBase):

--- a/amy/extrequests/tests/test_selforganised_submissions.py
+++ b/amy/extrequests/tests/test_selforganised_submissions.py
@@ -617,7 +617,9 @@ class TestAcceptingSelfOrgSubmPrefilledform(TestBase):
         """
         # setup mock to "fake" the response from non-existing URL
         mock.get(
-            self.sos1.workshop_url, text=html, status_code=200,
+            self.sos1.workshop_url,
+            text=html,
+            status_code=200,
         )
 
         view_url = reverse("selforganisedsubmission_accept_event", args=[self.sos1.pk])
@@ -716,10 +718,12 @@ class TestAcceptSelfOrganisedSubmissionAddsEmailActions(
             body_template="Sample text.",
         )
         self.trigger1 = Trigger.objects.create(
-            action="self-organised-request-form", template=template1,
+            action="self-organised-request-form",
+            template=template1,
         )
         self.trigger2 = Trigger.objects.create(
-            action="week-after-workshop-completion", template=template2,
+            action="week-after-workshop-completion",
+            template=template2,
         )
 
         self.url = reverse("selforganisedsubmission_accept_event", args=[self.sos.pk])

--- a/amy/extrequests/tests/test_training_request.py
+++ b/amy/extrequests/tests/test_training_request.py
@@ -27,23 +27,23 @@ from workshops.models import (
 )
 
 
-def create_training_request(state, person, open_review=True, reg_code=''):
+def create_training_request(state, person, open_review=True, reg_code=""):
     return TrainingRequest.objects.create(
-        review_process='open' if open_review else 'preapproved',
+        review_process="open" if open_review else "preapproved",
         group_name=reg_code,
-        personal='John',
-        family='Smith',
-        email='john@smith.com',
-        occupation='',
-        affiliation='AGH University of Science and Technology',
-        location='Cracow',
-        country='PL',
-        previous_training='none',
-        previous_experience='none',
-        programming_language_usage_frequency='daily',
-        reason='Just for fun.',
-        teaching_frequency_expectation='monthly',
-        max_travelling_frequency='yearly',
+        personal="John",
+        family="Smith",
+        email="john@smith.com",
+        occupation="",
+        affiliation="AGH University of Science and Technology",
+        location="Cracow",
+        country="PL",
+        previous_training="none",
+        previous_experience="none",
+        programming_language_usage_frequency="daily",
+        reason="Just for fun.",
+        teaching_frequency_expectation="monthly",
+        max_travelling_frequency="yearly",
         state=state,
         person=person,
     )
@@ -59,36 +59,37 @@ class TestTrainingRequestModel(TestBase):
         self._setUpTags()
 
         self.trainee = Person.objects.create_user(
-            username='trainee', personal='Bob',
-            family='Smith', email='bob@smith.com')
-        org = Organization.objects.create(domain='example.com',
-                                          fullname='Test Organization')
-        training = Event.objects.create(slug='training', host=org)
-        training.tags.add(Tag.objects.get(name='TTT'))
-        learner = Role.objects.get(name='learner')
+            username="trainee", personal="Bob", family="Smith", email="bob@smith.com"
+        )
+        org = Organization.objects.create(
+            domain="example.com", fullname="Test Organization"
+        )
+        training = Event.objects.create(slug="training", host=org)
+        training.tags.add(Tag.objects.get(name="TTT"))
+        learner = Role.objects.get(name="learner")
         Task.objects.create(person=self.trainee, event=training, role=learner)
 
     def test_accepted_request_are_always_valid(self):
         """Accepted training requests are valid regardless of whether they
         are matched to a training."""
-        req = create_training_request(state='a', person=None)
+        req = create_training_request(state="a", person=None)
         req.full_clean()
 
-        req = create_training_request(state='a', person=self.admin)
+        req = create_training_request(state="a", person=self.admin)
         req.full_clean()
 
-        req = create_training_request(state='a', person=self.trainee)
+        req = create_training_request(state="a", person=self.trainee)
         req.full_clean()
 
     def test_valid_pending_request(self):
-        req = create_training_request(state='p', person=None)
+        req = create_training_request(state="p", person=None)
         req.full_clean()
 
-        req = create_training_request(state='p', person=self.admin)
+        req = create_training_request(state="p", person=self.admin)
         req.full_clean()
 
     def test_pending_request_must_not_be_matched(self):
-        req = create_training_request(state='p', person=self.trainee)
+        req = create_training_request(state="p", person=self.trainee)
         with self.assertRaises(ValidationError):
             req.full_clean()
 
@@ -98,20 +99,20 @@ class TestTrainingRequestModelScoring(TestBase):
         self._setUpRoles()
 
         self.tr = TrainingRequest.objects.create(
-            personal='John',
-            family='Smith',
-            email='john@smith.com',
-            occupation='',
-            affiliation='',
-            location='Washington',
-            country='US',
-            previous_training='none',
-            previous_experience='none',
-            programming_language_usage_frequency='never',
-            reason='Just for fun.',
-            teaching_frequency_expectation='monthly',
-            max_travelling_frequency='yearly',
-            state='p',
+            personal="John",
+            family="Smith",
+            email="john@smith.com",
+            occupation="",
+            affiliation="",
+            location="Washington",
+            country="US",
+            previous_training="none",
+            previous_experience="none",
+            programming_language_usage_frequency="never",
+            reason="Just for fun.",
+            teaching_frequency_expectation="monthly",
+            max_travelling_frequency="yearly",
+            state="p",
         )
 
     def test_minimal_response_no_score(self):
@@ -119,7 +120,7 @@ class TestTrainingRequestModelScoring(TestBase):
 
     def test_country(self):
         # a sample country that scores a point
-        self.tr.country = 'W3'
+        self.tr.country = "W3"
         self.tr.save()
         self.assertEqual(self.tr.score_auto, 1)
 
@@ -131,7 +132,7 @@ class TestTrainingRequestModelScoring(TestBase):
 
     def test_country_and_underresourced_institution(self):
         # a sample country that scores a point
-        self.tr.country = 'W3'
+        self.tr.country = "W3"
         self.tr.underresourced = True
         self.tr.save()
         self.assertEqual(self.tr.score_auto, 2)
@@ -140,7 +141,7 @@ class TestTrainingRequestModelScoring(TestBase):
         """Ensure m2m_changed signals work correctly on
         `TrainingRequest.domains` field."""
         # test adding a domain
-        domain = KnowledgeDomain.objects.get(name='Humanities')
+        domain = KnowledgeDomain.objects.get(name="Humanities")
         self.tr.domains.add(domain)
         self.assertEqual(self.tr.score_auto, 1)
 
@@ -151,22 +152,26 @@ class TestTrainingRequestModelScoring(TestBase):
         self.assertEqual(self.tr.score_auto, 0)
 
         # test setting domains
-        domains = KnowledgeDomain.objects.filter(name__in=[
-            'Humanities', 'Library and information science',
-            'Economics/business', 'Social sciences',
-            'Chemistry',
-        ])
+        domains = KnowledgeDomain.objects.filter(
+            name__in=[
+                "Humanities",
+                "Library and information science",
+                "Economics/business",
+                "Social sciences",
+                "Chemistry",
+            ]
+        )
         self.tr.domains.set(domains)
         self.assertEqual(self.tr.score_auto, 1)
 
     def test_each_domain(self):
         "Ensure each domain from the list counts for +1 score_auto."
         domain_names = [
-            'Humanities',
-            'Library and information science',
-            'Economics/business',
-            'Social sciences',
-            'Chemistry',
+            "Humanities",
+            "Library and information science",
+            "Economics/business",
+            "Social sciences",
+            "Chemistry",
         ]
 
         last_domain = None
@@ -186,10 +191,10 @@ class TestTrainingRequestModelScoring(TestBase):
         """With change in https://github.com/swcarpentry/amy/issues/1468,
         we start automatically scoring underrepresented field."""
         data = {
-            'yes': 1,
-            'no': 0,
-            'undisclosed': 0,
-            '???': 0,
+            "yes": 1,
+            "no": 0,
+            "undisclosed": 0,
+            "???": 0,
         }
         for value, score in data.items():
             self.tr.underrepresented = value
@@ -217,7 +222,7 @@ class TestTrainingRequestModelScoring(TestBase):
         for choice, desc in choices:
             self.tr.previous_training = choice
             self.tr.save()
-            if choice in ['course', 'full']:
+            if choice in ["course", "full"]:
                 self.assertEqual(self.tr.score_auto, 1)
             else:
                 self.assertEqual(self.tr.score_auto, 0)
@@ -229,7 +234,7 @@ class TestTrainingRequestModelScoring(TestBase):
         for choice, desc in choices:
             self.tr.previous_experience = choice
             self.tr.save()
-            if choice in ['ta', 'courses']:
+            if choice in ["ta", "courses"]:
                 self.assertEqual(self.tr.score_auto, 1)
             else:
                 self.assertEqual(self.tr.score_auto, 0)
@@ -241,7 +246,7 @@ class TestTrainingRequestModelScoring(TestBase):
         for choice, desc in choices:
             self.tr.programming_language_usage_frequency = choice
             self.tr.save()
-            if choice in ['daily', 'weekly']:
+            if choice in ["daily", "weekly"]:
                 self.assertEqual(self.tr.score_auto, 1)
             else:
                 self.assertEqual(self.tr.score_auto, 0)
@@ -255,196 +260,220 @@ class TestTrainingRequestsListView(TestBase):
         self._setUpTags()
         self._setUpUsersAndLogin()
 
-        self.first_req = create_training_request(state='d',
-                                                 person=self.spiderman)
-        self.second_req = create_training_request(state='p', person=None)
-        self.third_req = create_training_request(state='a',
-                                                 person=self.ironman)
-        org = Organization.objects.create(domain='example.com',
-                                          fullname='Test Organization')
-        self.learner = Role.objects.get(name='learner')
-        self.ttt = Tag.objects.get(name='TTT')
+        self.first_req = create_training_request(state="d", person=self.spiderman)
+        self.second_req = create_training_request(state="p", person=None)
+        self.third_req = create_training_request(state="a", person=self.ironman)
+        org = Organization.objects.create(
+            domain="example.com", fullname="Test Organization"
+        )
+        self.learner = Role.objects.get(name="learner")
+        self.ttt = Tag.objects.get(name="TTT")
 
-        self.first_training = Event.objects.create(slug='ttt-event', host=org)
+        self.first_training = Event.objects.create(slug="ttt-event", host=org)
         self.first_training.tags.add(self.ttt)
-        Task.objects.create(person=self.spiderman, role=self.learner,
-                            event=self.first_training)
-        self.second_training = Event.objects.create(slug='second-ttt-event',
-                                                    host=org)
+        Task.objects.create(
+            person=self.spiderman, role=self.learner, event=self.first_training
+        )
+        self.second_training = Event.objects.create(slug="second-ttt-event", host=org)
         self.second_training.tags.add(self.ttt)
 
     def test_view_loads(self):
-        rv = self.client.get(reverse('all_trainingrequests'))
+        rv = self.client.get(reverse("all_trainingrequests"))
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(set(rv.context['requests']),
-                         {self.first_req, self.second_req, self.third_req})
+        self.assertEqual(
+            set(rv.context["requests"]),
+            {self.first_req, self.second_req, self.third_req},
+        )
 
     def test_successful_bulk_discard(self):
         data = {
-            'discard': '',
-            'requests': [self.first_req.pk, self.second_req.pk],
+            "discard": "",
+            "requests": [self.first_req.pk, self.second_req.pk],
         }
-        rv = self.client.post(reverse('all_trainingrequests'), data,
-                              follow=True)
+        rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 
         self.assertTrue(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Successfully discarded selected requests.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainingrequests")
+        msg = "Successfully discarded selected requests."
         self.assertContains(rv, msg)
         self.first_req.refresh_from_db()
-        self.assertEqual(self.first_req.state, 'd')
+        self.assertEqual(self.first_req.state, "d")
         self.second_req.refresh_from_db()
-        self.assertEqual(self.second_req.state, 'd')
+        self.assertEqual(self.second_req.state, "d")
         self.third_req.refresh_from_db()
-        self.assertEqual(self.third_req.state, 'a')
+        self.assertEqual(self.third_req.state, "a")
 
     def test_successful_bulk_accept(self):
         data = {
-            'accept': '',
-            'requests': [self.first_req.pk, self.second_req.pk],
+            "accept": "",
+            "requests": [self.first_req.pk, self.second_req.pk],
         }
-        rv = self.client.post(reverse('all_trainingrequests'), data,
-                              follow=True)
+        rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 
         self.assertTrue(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Successfully accepted selected requests.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainingrequests")
+        msg = "Successfully accepted selected requests."
         self.assertContains(rv, msg)
         self.first_req.refresh_from_db()
-        self.assertEqual(self.first_req.state, 'a')
+        self.assertEqual(self.first_req.state, "a")
         self.second_req.refresh_from_db()
-        self.assertEqual(self.second_req.state, 'a')
+        self.assertEqual(self.second_req.state, "a")
         self.third_req.refresh_from_db()
-        self.assertEqual(self.third_req.state, 'a')
+        self.assertEqual(self.third_req.state, "a")
 
     def test_successful_matching_to_training(self):
         data = {
-            'match': '',
-            'event': self.second_training.pk,
-            'requests': [self.first_req.pk],
+            "match": "",
+            "event": self.second_training.pk,
+            "requests": [self.first_req.pk],
         }
-        rv = self.client.post(reverse('all_trainingrequests'), data,
-                              follow=True)
+        rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Successfully accepted and matched selected people to training.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainingrequests")
+        msg = "Successfully accepted and matched selected people to training."
         self.assertContains(rv, msg)
-        self.assertEqual(set(Event.objects.filter(task__person=self.spiderman,
-                                                  task__role__name='learner')),
-                         {self.first_training, self.second_training})
-        self.assertEqual(set(Event.objects.filter(task__person=self.ironman,
-                                                  task__role__name='learner')),
-                         set())
+        self.assertEqual(
+            set(
+                Event.objects.filter(
+                    task__person=self.spiderman, task__role__name="learner"
+                )
+            ),
+            {self.first_training, self.second_training},
+        )
+        self.assertEqual(
+            set(
+                Event.objects.filter(
+                    task__person=self.ironman, task__role__name="learner"
+                )
+            ),
+            set(),
+        )
 
     def test_successful_matching_twice_to_the_same_training(self):
         data = {
-            'match': '',
-            'event': self.first_training.pk,
-            'requests': [self.first_req.pk],
+            "match": "",
+            "event": self.first_training.pk,
+            "requests": [self.first_req.pk],
         }
         # Spiderman is already matched with first_training
         assert self.spiderman.get_training_tasks()[0].event == self.first_training
 
-        rv = self.client.post(reverse('all_trainingrequests'), data,
-                              follow=True)
+        rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Successfully accepted and matched selected people to training.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainingrequests")
+        msg = "Successfully accepted and matched selected people to training."
         self.assertContains(rv, msg)
-        self.assertEqual(set(Event.objects.filter(task__person=self.spiderman,
-                                                  task__role__name='learner')),
-                         {self.first_training})
+        self.assertEqual(
+            set(
+                Event.objects.filter(
+                    task__person=self.spiderman, task__role__name="learner"
+                )
+            ),
+            {self.first_training},
+        )
 
     def test_trainee_accepted_during_matching(self):
         # this request is set up without matched person
         self.second_req.person = self.spiderman
         self.second_req.save()
-        self.assertEqual(self.second_req.state, 'p')
+        self.assertEqual(self.second_req.state, "p")
 
         data = {
-            'match': '',
-            'event': self.second_training.pk,
-            'requests': [self.second_req.pk],
+            "match": "",
+            "event": self.second_training.pk,
+            "requests": [self.second_req.pk],
         }
-        rv = self.client.post(reverse('all_trainingrequests'), data,
-                              follow=True)
+        rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Successfully accepted and matched selected people to training.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainingrequests")
+        msg = "Successfully accepted and matched selected people to training."
         self.assertContains(rv, msg)
         self.second_req.refresh_from_db()
-        self.assertEqual(self.second_req.state, 'a')
+        self.assertEqual(self.second_req.state, "a")
 
     def test_matching_to_training_fails_in_the_case_of_unmatched_persons(self):
         """Requests that are not matched with any trainee account cannot be
-        matched with a training. """
+        matched with a training."""
 
         data = {
-            'match': '',
-            'event': self.second_training.pk,
-            'requests': [self.first_req.pk, self.second_req.pk],
+            "match": "",
+            "event": self.second_training.pk,
+            "requests": [self.first_req.pk, self.second_req.pk],
         }
         # Spiderman is already matched with first_training
-        assert (self.spiderman.get_training_tasks()[0].event ==
-                self.first_training)
+        assert self.spiderman.get_training_tasks()[0].event == self.first_training
 
-        rv = self.client.post(reverse('all_trainingrequests'), data,
-                              follow=True)
+        rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Fix errors in the form below and try again.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainingrequests")
+        msg = "Fix errors in the form below and try again."
         self.assertContains(rv, msg)
-        msg = ('Some of the requests are not matched to a trainee yet. Before '
-               'matching them to a training, you need to accept them '
-               'and match with a trainee.')
+        msg = (
+            "Some of the requests are not matched to a trainee yet. Before "
+            "matching them to a training, you need to accept them "
+            "and match with a trainee."
+        )
         self.assertContains(rv, msg)
         # Check that Spiderman is not matched to second_training even though
         # he was selected.
-        self.assertEqual(set(Event.objects.filter(task__person=self.spiderman,
-                                                  task__role__name='learner')),
-                         {self.first_training})
+        self.assertEqual(
+            set(
+                Event.objects.filter(
+                    task__person=self.spiderman, task__role__name="learner"
+                )
+            ),
+            {self.first_training},
+        )
 
     def test_successful_unmatching(self):
         data = {
-            'unmatch': '',
-            'requests': [self.first_req.pk],
+            "unmatch": "",
+            "requests": [self.first_req.pk],
         }
-        rv = self.client.post(reverse('all_trainingrequests'), data,
-                              follow=True)
+        rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Successfully unmatched selected people from trainings.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainingrequests")
+        msg = "Successfully unmatched selected people from trainings."
         self.assertContains(rv, msg)
 
-        self.assertEqual(set(Event.objects.filter(task__person=self.spiderman,
-                                                  task__role__name='learner')),
-                         set())
+        self.assertEqual(
+            set(
+                Event.objects.filter(
+                    task__person=self.spiderman, task__role__name="learner"
+                )
+            ),
+            set(),
+        )
 
     def test_unmatching_fails_when_no_matched_trainee(self):
         """Requests that are not matched with any trainee cannot be
         unmatched from a training."""
 
         data = {
-            'unmatch': '',
-            'requests': [self.first_req.pk, self.second_req.pk],
+            "unmatch": "",
+            "requests": [self.first_req.pk, self.second_req.pk],
         }
-        rv = self.client.post(reverse('all_trainingrequests'), data,
-                              follow=True)
+        rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Fix errors in the form below and try again.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainingrequests")
+        msg = "Fix errors in the form below and try again."
         self.assertContains(rv, msg)
 
         # Check that Spiderman is still matched to first_training even though
         # he was selected.
-        self.assertEqual(set(Event.objects.filter(task__person=self.spiderman,
-                                                  task__role__name='learner')),
-                         {self.first_training})
+        self.assertEqual(
+            set(
+                Event.objects.filter(
+                    task__person=self.spiderman, task__role__name="learner"
+                )
+            ),
+            {self.first_training},
+        )
 
 
 class TestMatchingTrainingRequestAndDetailedView(TestBase):
@@ -456,113 +485,124 @@ class TestMatchingTrainingRequestAndDetailedView(TestBase):
 
     def test_detailed_view_of_pending_request(self):
         """Match Request form should be displayed only when no account is
-        matched. """
-        req = create_training_request(state='p', person=None)
-        rv = self.client.get(reverse('trainingrequest_details', args=[req.pk]))
+        matched."""
+        req = create_training_request(state="p", person=None)
+        rv = self.client.get(reverse("trainingrequest_details", args=[req.pk]))
         self.assertEqual(rv.status_code, 200)
-        self.assertContains(rv, 'Match Request to AMY account')
+        self.assertContains(rv, "Match Request to AMY account")
 
     def test_detailed_view_of_accepted_request(self):
         """Match Request form should be displayed only when no account is
-        matched. """
-        req = create_training_request(state='p', person=self.admin)
-        rv = self.client.get(reverse('trainingrequest_details', args=[req.pk]))
+        matched."""
+        req = create_training_request(state="p", person=self.admin)
+        rv = self.client.get(reverse("trainingrequest_details", args=[req.pk]))
         self.assertEqual(rv.status_code, 200)
-        self.assertNotContains(rv, 'Match Request to AMY account')
+        self.assertNotContains(rv, "Match Request to AMY account")
 
     def test_person_is_suggested(self):
-        req = create_training_request(state='p', person=None)
-        p = Person.objects.create_user(username='john_smith', personal='john',
-                                       family='smith', email='asdf@gmail.com')
-        rv = self.client.get(reverse('trainingrequest_details', args=[req.pk]))
+        req = create_training_request(state="p", person=None)
+        p = Person.objects.create_user(
+            username="john_smith",
+            personal="john",
+            family="smith",
+            email="asdf@gmail.com",
+        )
+        rv = self.client.get(reverse("trainingrequest_details", args=[req.pk]))
 
-        self.assertEqual(rv.context['form'].initial['person'], p)
+        self.assertEqual(rv.context["form"].initial["person"], p)
 
     def test_person_is_suggested_based_on_secondary_email(self):
         """Having just secondary email matching should show the person
         in results."""
-        req = create_training_request(state='p', person=None)
-        p = Person.objects.create(username='john_kowalsky',
-                                  personal='Johnny',
-                                  family='Kowalsky',
-                                  email='asdf@gmail.com',
-                                  secondary_email='john@smith.com')
-        rv = self.client.get(reverse('trainingrequest_details', args=[req.pk]))
+        req = create_training_request(state="p", person=None)
+        p = Person.objects.create(
+            username="john_kowalsky",
+            personal="Johnny",
+            family="Kowalsky",
+            email="asdf@gmail.com",
+            secondary_email="john@smith.com",
+        )
+        rv = self.client.get(reverse("trainingrequest_details", args=[req.pk]))
 
-        self.assertEqual(rv.context['form'].initial['person'], p)
+        self.assertEqual(rv.context["form"].initial["person"], p)
 
     def test_new_person(self):
-        req = create_training_request(state='p', person=None)
-        rv = self.client.get(reverse('trainingrequest_details', args=[req.pk]))
+        req = create_training_request(state="p", person=None)
+        rv = self.client.get(reverse("trainingrequest_details", args=[req.pk]))
 
-        self.assertEqual(rv.context['form'].initial['person'], None)
+        self.assertEqual(rv.context["form"].initial["person"], None)
 
     def test_matching_with_existing_account_works(self):
         """Regression test for [#949].
 
         [#949] https://github.com/swcarpentry/amy/pull/949/"""
 
-        req = create_training_request(state='p', person=None)
-        rv = self.client.post(reverse('trainingrequest_details',
-                                      args=[req.pk]),
-                              data={'person': self.ironman.pk,
-                                    'match-selected-person': ''},
-                              follow=True)
+        req = create_training_request(state="p", person=None)
+        rv = self.client.post(
+            reverse("trainingrequest_details", args=[req.pk]),
+            data={"person": self.ironman.pk, "match-selected-person": ""},
+            follow=True,
+        )
         self.assertEqual(rv.status_code, 200)
         req.refresh_from_db()
-        self.assertEqual(req.state, 'p')
+        self.assertEqual(req.state, "p")
         self.assertEqual(req.person, self.ironman)
 
         self.ironman.refresh_from_db()
 
         # in response to #1270, check if person record was updated
         data_expected = {
-            'personal': req.personal,
-            'middle': req.middle,
-            'family': req.family,
-            'email': req.email,
-            'country': req.country,
-            'github': req.github or None,
-            'affiliation': req.affiliation,
-            'occupation': req.get_occupation_display() if req.occupation
-                else req.occupation_other,
-            'data_privacy_agreement': req.data_privacy_agreement,
-            'may_contact': True,
-            'is_active': True,
+            "personal": req.personal,
+            "middle": req.middle,
+            "family": req.family,
+            "email": req.email,
+            "country": req.country,
+            "github": req.github or None,
+            "affiliation": req.affiliation,
+            "occupation": req.get_occupation_display()
+            if req.occupation
+            else req.occupation_other,
+            "data_privacy_agreement": req.data_privacy_agreement,
+            "may_contact": True,
+            "is_active": True,
         }
         for key, value in data_expected.items():
-            self.assertEqual(getattr(self.ironman, key), value,
-                             'Attribute: {}'.format(key))
-        self.assertEqual(set(self.ironman.domains.all()),
-                         set(req.domains.all()))
+            self.assertEqual(
+                getattr(self.ironman, key), value, "Attribute: {}".format(key)
+            )
+        self.assertEqual(set(self.ironman.domains.all()), set(req.domains.all()))
 
     def test_matching_with_new_account_works(self):
-        req = create_training_request(state='p', person=None)
-        rv = self.client.post(reverse('trainingrequest_details', args=[req.pk]),
-                              data={'create-new-person': ''},
-                              follow=True)
+        req = create_training_request(state="p", person=None)
+        rv = self.client.post(
+            reverse("trainingrequest_details", args=[req.pk]),
+            data={"create-new-person": ""},
+            follow=True,
+        )
         self.assertEqual(rv.status_code, 200)
         req.refresh_from_db()
-        self.assertEqual(req.state, 'p')
+        self.assertEqual(req.state, "p")
 
         # in response to #1270, check if person record was updated
         data_expected = {
-            'personal': req.personal,
-            'middle': req.middle,
-            'family': req.family,
-            'email': req.email,
-            'country': req.country,
-            'github': req.github or None,
-            'affiliation': req.affiliation,
-            'occupation': req.get_occupation_display() if req.occupation
-                else req.occupation_other,
-            'data_privacy_agreement': req.data_privacy_agreement,
-            'may_contact': True,
-            'is_active': True,
+            "personal": req.personal,
+            "middle": req.middle,
+            "family": req.family,
+            "email": req.email,
+            "country": req.country,
+            "github": req.github or None,
+            "affiliation": req.affiliation,
+            "occupation": req.get_occupation_display()
+            if req.occupation
+            else req.occupation_other,
+            "data_privacy_agreement": req.data_privacy_agreement,
+            "may_contact": True,
+            "is_active": True,
         }
         for key, value in data_expected.items():
-            self.assertEqual(getattr(req.person, key), value,
-                             'Attribute: {}'.format(key))
+            self.assertEqual(
+                getattr(req.person, key), value, "Attribute: {}".format(key)
+            )
         self.assertEqual(set(req.person.domains.all()), set(req.domains.all()))
 
     def test_matching_in_transaction(self):
@@ -573,10 +613,10 @@ class TestMatchingTrainingRequestAndDetailedView(TestBase):
         scenario AMY must inform correctly about the issue, not throw 500
         error."""
         # this email conflicts with `duplicate` person below
-        tr = create_training_request(state='p', person=None)
-        tr.personal = 'John'
-        tr.family = 'Smith'
-        tr.email = 'john@corporate.edu'
+        tr = create_training_request(state="p", person=None)
+        tr.personal = "John"
+        tr.family = "Smith"
+        tr.email = "john@corporate.edu"
         tr.save()
 
         # a fake request
@@ -592,17 +632,22 @@ class TestMatchingTrainingRequestAndDetailedView(TestBase):
         messages_middleware.process_request(request)
 
         create = False
-        person = Person.objects.create(username='john_smith', personal='john',
-                                       family='smith', email='john@smith.com')
-        duplicate = Person.objects.create(username='jonny_smith',
-                                          personal='jonny', family='smith',
-                                          email='john@corporate.edu')
+        person = Person.objects.create(
+            username="john_smith",
+            personal="john",
+            family="smith",
+            email="john@smith.com",
+        )
+        duplicate = Person.objects.create(
+            username="jonny_smith",
+            personal="jonny",
+            family="smith",
+            email="john@corporate.edu",
+        )
 
         # matching fails because it can't rewrite email address due to
         # uniqueness constraint
-        self.assertFalse(
-            _match_training_request_to_person(request, tr, create, person)
-        )
+        self.assertFalse(_match_training_request_to_person(request, tr, create, person))
         messages = request._messages._queued_messages
         self.assertEqual(len(messages), 1)
         self.assertEqual(messages[0].level, WARNING)
@@ -610,21 +655,18 @@ class TestMatchingTrainingRequestAndDetailedView(TestBase):
 
 class TestTrainingRequestTemplateTags(TestBase):
     def test_pending_request(self):
-        self._test(state='p', expected='badge badge-warning')
+        self._test(state="p", expected="badge badge-warning")
 
     def test_accepted_request(self):
-        self._test(state='a', expected='badge badge-success')
+        self._test(state="a", expected="badge badge-success")
 
     def test_discarded_request(self):
-        self._test(state='d', expected='badge badge-danger')
+        self._test(state="d", expected="badge badge-danger")
 
     def _test(self, state, expected):
-        template = Template(
-            '{% load state %}'
-            '{% state_label req %}'
-        )
+        template = Template("{% load state %}" "{% state_label req %}")
         training_request = TrainingRequest(state=state)
-        context = Context({'req': training_request})
+        context = Context({"req": training_request})
         got = template.render(context)
         self.assertEqual(got, expected)
 
@@ -642,13 +684,11 @@ class TestTrainingRequestMerging(TestBase):
         self._setUpTags()
         self._setUpUsersAndLogin()
 
-        self.first_req = create_training_request(state='d',
-                                                 person=self.spiderman)
-        self.first_req.secondary_email = 'notused@example.org'
-        self.second_req = create_training_request(state='p', person=None)
-        self.third_req = create_training_request(state='a',
-                                                 person=self.ironman)
-        self.third_req.secondary_email = 'notused@amy.org'
+        self.first_req = create_training_request(state="d", person=self.spiderman)
+        self.first_req.secondary_email = "notused@example.org"
+        self.second_req = create_training_request(state="p", person=None)
+        self.third_req = create_training_request(state="a", person=self.ironman)
+        self.third_req.secondary_email = "notused@amy.org"
 
         # comments regarding first request
         self.ca = Comment.objects.create(
@@ -669,180 +709,183 @@ class TestTrainingRequestMerging(TestBase):
 
         # assign roles (previous involvement with The Carpentries) and
         # knowledge domains - those are the hardest to merge successfully
-        self.chemistry = KnowledgeDomain.objects.get(name='Chemistry')
-        self.physics = KnowledgeDomain.objects.get(name='Physics')
-        self.humanities = KnowledgeDomain.objects.get(name='Humanities')
-        self.education = KnowledgeDomain.objects.get(name='Education')
-        self.social = KnowledgeDomain.objects.get(name='Social sciences')
+        self.chemistry = KnowledgeDomain.objects.get(name="Chemistry")
+        self.physics = KnowledgeDomain.objects.get(name="Physics")
+        self.humanities = KnowledgeDomain.objects.get(name="Humanities")
+        self.education = KnowledgeDomain.objects.get(name="Education")
+        self.social = KnowledgeDomain.objects.get(name="Social sciences")
         self.first_req.domains.set([self.chemistry, self.physics])
         self.second_req.domains.set([self.humanities, self.social])
         self.third_req.domains.set([self.education])
 
-        self.learner = Role.objects.get(name='learner')
-        self.helper = Role.objects.get(name='helper')
-        self.instructor = Role.objects.get(name='instructor')
-        self.contributor = Role.objects.get(name='contributor')
+        self.learner = Role.objects.get(name="learner")
+        self.helper = Role.objects.get(name="helper")
+        self.instructor = Role.objects.get(name="instructor")
+        self.contributor = Role.objects.get(name="contributor")
         self.first_req.previous_involvement.set([self.learner])
         self.second_req.previous_involvement.set([self.helper])
-        self.third_req.previous_involvement.set([self.instructor,
-                                                 self.contributor])
+        self.third_req.previous_involvement.set([self.instructor, self.contributor])
 
         # prepare merge strategies (POST data to be sent to the merging view)
         self.strategy_1 = {
-            'trainingrequest_a': self.first_req.pk,
-            'trainingrequest_b': self.second_req.pk,
-            'id': 'obj_a',
-            'state': 'obj_b',
-            'person': 'obj_a',
-            'group_name': 'obj_a',
-            'personal': 'obj_a',
-            'middle': 'obj_a',
-            'family': 'obj_a',
-            'email': 'obj_a',
-            'secondary_email': 'obj_a',
-            'github': 'obj_a',
-            'occupation': 'obj_a',
-            'occupation_other': 'obj_a',
-            'affiliation': 'obj_a',
-            'location': 'obj_a',
-            'country': 'obj_a',
-            'underresourced': 'obj_a',
-            'domains': 'obj_a',
-            'domains_other': 'obj_a',
-            'underrepresented': 'obj_a',
-            'underrepresented_details': 'obj_a',
-            'nonprofit_teaching_experience': 'obj_a',
-            'previous_involvement': 'obj_b',
-            'previous_training': 'obj_a',
-            'previous_training_other': 'obj_a',
-            'previous_training_explanation': 'obj_a',
-            'previous_experience': 'obj_a',
-            'previous_experience_other': 'obj_a',
-            'previous_experience_explanation': 'obj_a',
-            'programming_language_usage_frequency': 'obj_a',
-            'teaching_frequency_expectation': 'obj_a',
-            'teaching_frequency_expectation_other': 'obj_a',
-            'max_travelling_frequency': 'obj_a',
-            'max_travelling_frequency_other': 'obj_a',
-            'reason': 'obj_a',
-            'user_notes': 'obj_a',
-            'training_completion_agreement': 'obj_a',
-            'workshop_teaching_agreement': 'obj_a',
-            'data_privacy_agreement': 'obj_a',
-            'code_of_conduct_agreement': 'obj_a',
-            'created_at': 'obj_a',
-            'comments': 'combine',
+            "trainingrequest_a": self.first_req.pk,
+            "trainingrequest_b": self.second_req.pk,
+            "id": "obj_a",
+            "state": "obj_b",
+            "person": "obj_a",
+            "group_name": "obj_a",
+            "personal": "obj_a",
+            "middle": "obj_a",
+            "family": "obj_a",
+            "email": "obj_a",
+            "secondary_email": "obj_a",
+            "github": "obj_a",
+            "occupation": "obj_a",
+            "occupation_other": "obj_a",
+            "affiliation": "obj_a",
+            "location": "obj_a",
+            "country": "obj_a",
+            "underresourced": "obj_a",
+            "domains": "obj_a",
+            "domains_other": "obj_a",
+            "underrepresented": "obj_a",
+            "underrepresented_details": "obj_a",
+            "nonprofit_teaching_experience": "obj_a",
+            "previous_involvement": "obj_b",
+            "previous_training": "obj_a",
+            "previous_training_other": "obj_a",
+            "previous_training_explanation": "obj_a",
+            "previous_experience": "obj_a",
+            "previous_experience_other": "obj_a",
+            "previous_experience_explanation": "obj_a",
+            "programming_language_usage_frequency": "obj_a",
+            "teaching_frequency_expectation": "obj_a",
+            "teaching_frequency_expectation_other": "obj_a",
+            "max_travelling_frequency": "obj_a",
+            "max_travelling_frequency_other": "obj_a",
+            "reason": "obj_a",
+            "user_notes": "obj_a",
+            "training_completion_agreement": "obj_a",
+            "workshop_teaching_agreement": "obj_a",
+            "data_privacy_agreement": "obj_a",
+            "code_of_conduct_agreement": "obj_a",
+            "created_at": "obj_a",
+            "comments": "combine",
         }
         self.strategy_2 = {
-            'trainingrequest_a': self.first_req.pk,
-            'trainingrequest_b': self.third_req.pk,
-            'id': 'obj_b',
-            'state': 'obj_a',
-            'person': 'obj_a',
-            'group_name': 'obj_b',
-            'personal': 'obj_b',
-            'middle': 'obj_b',
-            'family': 'obj_b',
-            'email': 'obj_b',
-            'secondary_email': 'obj_b',
-            'github': 'obj_b',
-            'occupation': 'obj_b',
-            'occupation_other': 'obj_b',
-            'affiliation': 'obj_b',
-            'location': 'obj_b',
-            'country': 'obj_b',
-            'underresourced': 'obj_b',
-            'domains': 'combine',
-            'domains_other': 'obj_b',
-            'underrepresented': 'obj_b',
-            'underrepresented_details': 'obj_b',
-            'nonprofit_teaching_experience': 'obj_b',
-            'previous_involvement': 'combine',
-            'previous_training': 'obj_a',
-            'previous_training_other': 'obj_a',
-            'previous_training_explanation': 'obj_a',
-            'previous_experience': 'obj_a',
-            'previous_experience_other': 'obj_a',
-            'previous_experience_explanation': 'obj_a',
-            'programming_language_usage_frequency': 'obj_a',
-            'teaching_frequency_expectation': 'obj_a',
-            'teaching_frequency_expectation_other': 'obj_a',
-            'max_travelling_frequency': 'obj_a',
-            'max_travelling_frequency_other': 'obj_a',
-            'reason': 'obj_a',
-            'user_notes': 'obj_a',
-            'training_completion_agreement': 'obj_a',
-            'workshop_teaching_agreement': 'obj_a',
-            'data_privacy_agreement': 'obj_a',
-            'code_of_conduct_agreement': 'obj_a',
-            'created_at': 'obj_a',
-            'comments': 'combine',
+            "trainingrequest_a": self.first_req.pk,
+            "trainingrequest_b": self.third_req.pk,
+            "id": "obj_b",
+            "state": "obj_a",
+            "person": "obj_a",
+            "group_name": "obj_b",
+            "personal": "obj_b",
+            "middle": "obj_b",
+            "family": "obj_b",
+            "email": "obj_b",
+            "secondary_email": "obj_b",
+            "github": "obj_b",
+            "occupation": "obj_b",
+            "occupation_other": "obj_b",
+            "affiliation": "obj_b",
+            "location": "obj_b",
+            "country": "obj_b",
+            "underresourced": "obj_b",
+            "domains": "combine",
+            "domains_other": "obj_b",
+            "underrepresented": "obj_b",
+            "underrepresented_details": "obj_b",
+            "nonprofit_teaching_experience": "obj_b",
+            "previous_involvement": "combine",
+            "previous_training": "obj_a",
+            "previous_training_other": "obj_a",
+            "previous_training_explanation": "obj_a",
+            "previous_experience": "obj_a",
+            "previous_experience_other": "obj_a",
+            "previous_experience_explanation": "obj_a",
+            "programming_language_usage_frequency": "obj_a",
+            "teaching_frequency_expectation": "obj_a",
+            "teaching_frequency_expectation_other": "obj_a",
+            "max_travelling_frequency": "obj_a",
+            "max_travelling_frequency_other": "obj_a",
+            "reason": "obj_a",
+            "user_notes": "obj_a",
+            "training_completion_agreement": "obj_a",
+            "workshop_teaching_agreement": "obj_a",
+            "data_privacy_agreement": "obj_a",
+            "code_of_conduct_agreement": "obj_a",
+            "created_at": "obj_a",
+            "comments": "combine",
         }
 
-        base_url = reverse('trainingrequests_merge')
-        query_1 = urlencode({
-            'trainingrequest_a': self.first_req.pk,
-            'trainingrequest_b': self.second_req.pk,
-        })
-        query_2 = urlencode({
-            'trainingrequest_a': self.first_req.pk,
-            'trainingrequest_b': self.third_req.pk,
-        })
-        self.url_1 = '{}?{}'.format(base_url, query_1)
-        self.url_2 = '{}?{}'.format(base_url, query_2)
+        base_url = reverse("trainingrequests_merge")
+        query_1 = urlencode(
+            {
+                "trainingrequest_a": self.first_req.pk,
+                "trainingrequest_b": self.second_req.pk,
+            }
+        )
+        query_2 = urlencode(
+            {
+                "trainingrequest_a": self.first_req.pk,
+                "trainingrequest_b": self.third_req.pk,
+            }
+        )
+        self.url_1 = "{}?{}".format(base_url, query_1)
+        self.url_2 = "{}?{}".format(base_url, query_2)
 
     def test_form_invalid_values(self):
         """Make sure only a few fields accept third option ("combine")."""
         hidden = {
-            'trainingrequest_a': self.first_req.pk,
-            'trainingrequest_b': self.second_req.pk,
+            "trainingrequest_a": self.first_req.pk,
+            "trainingrequest_b": self.second_req.pk,
         }
         # fields accepting only 2 options: "obj_a" and "obj_b"
         failing = {
-            'id': 'combine',
-            'state': 'combine',
-            'person': 'combine',
-            'group_name': 'combine',
-            'personal': 'combine',
-            'middle': 'combine',
-            'family': 'combine',
-            'email': 'combine',
-            'secondary_email': 'combine',
-            'github': 'combine',
-            'occupation': 'combine',
-            'occupation_other': 'combine',
-            'affiliation': 'combine',
-            'location': 'combine',
-            'country': 'combine',
-            'underresourced': 'combine',
-            'domains_other': 'combine',
-            'underrepresented': 'combine',
-            'underrepresented_details': 'combine',
-            'nonprofit_teaching_experience': 'combine',
-            'previous_training': 'combine',
-            'previous_training_other': 'combine',
-            'previous_training_explanation': 'combine',
-            'previous_experience': 'combine',
-            'previous_experience_other': 'combine',
-            'previous_experience_explanation': 'combine',
-            'programming_language_usage_frequency': 'combine',
-            'teaching_frequency_expectation': 'combine',
-            'teaching_frequency_expectation_other': 'combine',
-            'max_travelling_frequency': 'combine',
-            'max_travelling_frequency_other': 'combine',
-            'training_completion_agreement': 'combine',
-            'workshop_teaching_agreement': 'combine',
-            'data_privacy_agreement': 'combine',
-            'code_of_conduct_agreement': 'combine',
-            'created_at': 'combine',
+            "id": "combine",
+            "state": "combine",
+            "person": "combine",
+            "group_name": "combine",
+            "personal": "combine",
+            "middle": "combine",
+            "family": "combine",
+            "email": "combine",
+            "secondary_email": "combine",
+            "github": "combine",
+            "occupation": "combine",
+            "occupation_other": "combine",
+            "affiliation": "combine",
+            "location": "combine",
+            "country": "combine",
+            "underresourced": "combine",
+            "domains_other": "combine",
+            "underrepresented": "combine",
+            "underrepresented_details": "combine",
+            "nonprofit_teaching_experience": "combine",
+            "previous_training": "combine",
+            "previous_training_other": "combine",
+            "previous_training_explanation": "combine",
+            "previous_experience": "combine",
+            "previous_experience_other": "combine",
+            "previous_experience_explanation": "combine",
+            "programming_language_usage_frequency": "combine",
+            "teaching_frequency_expectation": "combine",
+            "teaching_frequency_expectation_other": "combine",
+            "max_travelling_frequency": "combine",
+            "max_travelling_frequency_other": "combine",
+            "training_completion_agreement": "combine",
+            "workshop_teaching_agreement": "combine",
+            "data_privacy_agreement": "combine",
+            "code_of_conduct_agreement": "combine",
+            "created_at": "combine",
         }
         # fields additionally accepting "combine"
         passing = {
-            'domains': 'combine',
-            'previous_involvement': 'combine',
-            'reason': 'combine',
-            'user_notes': 'combine',
-            'comments': 'combine',
+            "domains": "combine",
+            "previous_involvement": "combine",
+            "reason": "combine",
+            "user_notes": "combine",
+            "comments": "combine",
         }
         data = hidden.copy()
         data.update(failing)
@@ -877,54 +920,42 @@ class TestTrainingRequestMerging(TestBase):
         """Merging: ensure basic (non-relationships) attributes are properly
         saved."""
         assertions = {
-            'id': self.first_req.id,
-            'state': self.second_req.state,
-            'person': self.first_req.person,
-            'group_name': self.first_req.group_name,
-            'personal': self.first_req.personal,
-            'middle': self.first_req.middle,
-            'family': self.first_req.family,
-            'email': self.first_req.email,
-            'github': self.first_req.github,
-            'occupation': self.first_req.occupation,
-            'occupation_other': self.first_req.occupation_other,
-            'affiliation': self.first_req.affiliation,
-            'location': self.first_req.location,
-            'country': self.first_req.country,
-            'underresourced': self.first_req.underresourced,
-            'domains_other': self.first_req.domains_other,
-            'underrepresented': self.first_req.underrepresented,
-            'nonprofit_teaching_experience':
-                self.first_req.nonprofit_teaching_experience,
-            'previous_training': self.first_req.previous_training,
-            'previous_training_other': self.first_req.previous_training_other,
-            'previous_training_explanation':
-                self.first_req.previous_training_explanation,
-            'previous_experience': self.first_req.previous_experience,
-            'previous_experience_other':
-                self.first_req.previous_experience_other,
-            'previous_experience_explanation':
-                self.first_req.previous_experience_explanation,
-            'programming_language_usage_frequency':
-                self.first_req.programming_language_usage_frequency,
-            'teaching_frequency_expectation':
-                self.first_req.teaching_frequency_expectation,
-            'teaching_frequency_expectation_other':
-                self.first_req.teaching_frequency_expectation_other,
-            'max_travelling_frequency':
-                self.first_req.max_travelling_frequency,
-            'max_travelling_frequency_other':
-                self.first_req.max_travelling_frequency_other,
-            'reason': self.first_req.reason,
-            'user_notes': self.first_req.user_notes,
-            'training_completion_agreement':
-                self.first_req.training_completion_agreement,
-            'workshop_teaching_agreement':
-                self.first_req.workshop_teaching_agreement,
-            'data_privacy_agreement': self.first_req.data_privacy_agreement,
-            'code_of_conduct_agreement':
-                self.first_req.code_of_conduct_agreement,
-            'created_at': self.first_req.created_at,
+            "id": self.first_req.id,
+            "state": self.second_req.state,
+            "person": self.first_req.person,
+            "group_name": self.first_req.group_name,
+            "personal": self.first_req.personal,
+            "middle": self.first_req.middle,
+            "family": self.first_req.family,
+            "email": self.first_req.email,
+            "github": self.first_req.github,
+            "occupation": self.first_req.occupation,
+            "occupation_other": self.first_req.occupation_other,
+            "affiliation": self.first_req.affiliation,
+            "location": self.first_req.location,
+            "country": self.first_req.country,
+            "underresourced": self.first_req.underresourced,
+            "domains_other": self.first_req.domains_other,
+            "underrepresented": self.first_req.underrepresented,
+            "nonprofit_teaching_experience": self.first_req.nonprofit_teaching_experience,
+            "previous_training": self.first_req.previous_training,
+            "previous_training_other": self.first_req.previous_training_other,
+            "previous_training_explanation": self.first_req.previous_training_explanation,
+            "previous_experience": self.first_req.previous_experience,
+            "previous_experience_other": self.first_req.previous_experience_other,
+            "previous_experience_explanation": self.first_req.previous_experience_explanation,
+            "programming_language_usage_frequency": self.first_req.programming_language_usage_frequency,
+            "teaching_frequency_expectation": self.first_req.teaching_frequency_expectation,
+            "teaching_frequency_expectation_other": self.first_req.teaching_frequency_expectation_other,
+            "max_travelling_frequency": self.first_req.max_travelling_frequency,
+            "max_travelling_frequency_other": self.first_req.max_travelling_frequency_other,
+            "reason": self.first_req.reason,
+            "user_notes": self.first_req.user_notes,
+            "training_completion_agreement": self.first_req.training_completion_agreement,
+            "workshop_teaching_agreement": self.first_req.workshop_teaching_agreement,
+            "data_privacy_agreement": self.first_req.data_privacy_agreement,
+            "code_of_conduct_agreement": self.first_req.code_of_conduct_agreement,
+            "created_at": self.first_req.created_at,
         }
         rv = self.client.post(self.url_1, data=self.strategy_1)
         self.assertEqual(rv.status_code, 302)
@@ -936,8 +967,8 @@ class TestTrainingRequestMerging(TestBase):
     def test_merging_relational_attributes(self):
         """Merging: ensure relational fields are properly saved/combined."""
         assertions = {
-            'domains': set([self.chemistry, self.physics]),
-            'previous_involvement': set([self.helper]),
+            "domains": set([self.chemistry, self.physics]),
+            "previous_involvement": set([self.helper]),
             # comments are not relational, they're related via generic FKs,
             # so they won't appear here
         }
@@ -947,18 +978,14 @@ class TestTrainingRequestMerging(TestBase):
         self.first_req.refresh_from_db()
 
         for key, value in assertions.items():
-            self.assertEqual(
-                set(getattr(self.first_req, key).all()),
-                value,
-                key)
+            self.assertEqual(set(getattr(self.first_req, key).all()), value, key)
 
     def test_merging(self):
         rv = self.client.post(self.url_1, self.strategy_1, follow=True)
         self.assertTrue(rv.status_code, 200)
         # after successful merge, we should end up redirected to the details
         # page of the base object
-        self.assertEqual(rv.resolver_match.view_name,
-                         'trainingrequest_details')
+        self.assertEqual(rv.resolver_match.view_name, "trainingrequest_details")
 
         # check if objects merged
         self.first_req.refresh_from_db()
@@ -969,8 +996,7 @@ class TestTrainingRequestMerging(TestBase):
         # try second strategy
         rv = self.client.post(self.url_2, self.strategy_2, follow=True)
         self.assertTrue(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name,
-                         'trainingrequest_details')
+        self.assertEqual(rv.resolver_match.view_name, "trainingrequest_details")
 
         # check if objects merged
         with self.assertRaises(TrainingRequest.DoesNotExist):
@@ -980,16 +1006,14 @@ class TestTrainingRequestMerging(TestBase):
         self.third_req.refresh_from_db()
 
         # check if third request properties changed accordingly
-        self.assertEqual(self.third_req.personal, 'John')
-        self.assertEqual(self.third_req.family, 'Smith')
-        self.assertEqual(self.third_req.state, 'p')
+        self.assertEqual(self.third_req.personal, "John")
+        self.assertEqual(self.third_req.family, "Smith")
+        self.assertEqual(self.third_req.state, "p")
         self.assertEqual(self.third_req.person, self.spiderman)
         domains_set = set([self.chemistry, self.physics, self.education])
         roles_set = set([self.helper, self.instructor, self.contributor])
-        self.assertEqual(domains_set,
-                         set(self.third_req.domains.all()))
-        self.assertEqual(roles_set,
-                         set(self.third_req.previous_involvement.all()))
+        self.assertEqual(domains_set, set(self.third_req.domains.all()))
+        self.assertEqual(roles_set, set(self.third_req.previous_involvement.all()))
 
         # make sure no M2M related objects were removed from DB
         self.chemistry.refresh_from_db()
@@ -1011,14 +1035,13 @@ class TestTrainingRequestMerging(TestBase):
         """Ensure comments regarding persons are correctly merged using
         `merge_objects`.
         This test uses strategy 1 (combine)."""
-        self.strategy_1['comments'] = 'combine'
+        self.strategy_1["comments"] = "combine"
         comments = [self.ca, self.cb]
         rv = self.client.post(self.url_1, data=self.strategy_1)
         self.assertEqual(rv.status_code, 302)
         self.first_req.refresh_from_db()
         self.assertEqual(
-            set(Comment.objects.for_model(self.first_req)
-                               .filter(is_removed=False)),
+            set(Comment.objects.for_model(self.first_req).filter(is_removed=False)),
             set(comments),
         )
 
@@ -1026,14 +1049,13 @@ class TestTrainingRequestMerging(TestBase):
         """Ensure comments regarding persons are correctly merged using
         `merge_objects`.
         This test uses strategy 2 (object a)."""
-        self.strategy_1['comments'] = 'obj_a'
+        self.strategy_1["comments"] = "obj_a"
         comments = [self.ca]
         rv = self.client.post(self.url_1, data=self.strategy_1)
         self.assertEqual(rv.status_code, 302)
         self.first_req.refresh_from_db()
         self.assertEqual(
-            set(Comment.objects.for_model(self.first_req)
-                               .filter(is_removed=False)),
+            set(Comment.objects.for_model(self.first_req).filter(is_removed=False)),
             set(comments),
         )
 
@@ -1041,13 +1063,12 @@ class TestTrainingRequestMerging(TestBase):
         """Ensure comments regarding persons are correctly merged using
         `merge_objects`.
         This test uses strategy 3 (object b)."""
-        self.strategy_1['comments'] = 'obj_b'
+        self.strategy_1["comments"] = "obj_b"
         comments = [self.cb]
         rv = self.client.post(self.url_1, data=self.strategy_1)
         self.assertEqual(rv.status_code, 302)
         self.first_req.refresh_from_db()
         self.assertEqual(
-            set(Comment.objects.for_model(self.first_req)
-                               .filter(is_removed=False)),
+            set(Comment.objects.for_model(self.first_req).filter(is_removed=False)),
             set(comments),
         )

--- a/amy/extrequests/tests/test_training_request.py
+++ b/amy/extrequests/tests/test_training_request.py
@@ -638,7 +638,8 @@ class TestMatchingTrainingRequestAndDetailedView(TestBase):
             family="smith",
             email="john@smith.com",
         )
-        duplicate = Person.objects.create(
+        # duplicate
+        Person.objects.create(
             username="jonny_smith",
             personal="jonny",
             family="smith",
@@ -937,21 +938,21 @@ class TestTrainingRequestMerging(TestBase):
             "underresourced": self.first_req.underresourced,
             "domains_other": self.first_req.domains_other,
             "underrepresented": self.first_req.underrepresented,
-            "nonprofit_teaching_experience": self.first_req.nonprofit_teaching_experience,
+            "nonprofit_teaching_experience": self.first_req.nonprofit_teaching_experience,  # noqa: line too long
             "previous_training": self.first_req.previous_training,
             "previous_training_other": self.first_req.previous_training_other,
-            "previous_training_explanation": self.first_req.previous_training_explanation,
+            "previous_training_explanation": self.first_req.previous_training_explanation,  # noqa: line too long
             "previous_experience": self.first_req.previous_experience,
             "previous_experience_other": self.first_req.previous_experience_other,
-            "previous_experience_explanation": self.first_req.previous_experience_explanation,
-            "programming_language_usage_frequency": self.first_req.programming_language_usage_frequency,
-            "teaching_frequency_expectation": self.first_req.teaching_frequency_expectation,
-            "teaching_frequency_expectation_other": self.first_req.teaching_frequency_expectation_other,
+            "previous_experience_explanation": self.first_req.previous_experience_explanation,  # noqa: line too long
+            "programming_language_usage_frequency": self.first_req.programming_language_usage_frequency,  # noqa: line too long
+            "teaching_frequency_expectation": self.first_req.teaching_frequency_expectation,  # noqa: line too long
+            "teaching_frequency_expectation_other": self.first_req.teaching_frequency_expectation_other,  # noqa: line too long
             "max_travelling_frequency": self.first_req.max_travelling_frequency,
-            "max_travelling_frequency_other": self.first_req.max_travelling_frequency_other,
+            "max_travelling_frequency_other": self.first_req.max_travelling_frequency_other,  # noqa: line too long
             "reason": self.first_req.reason,
             "user_notes": self.first_req.user_notes,
-            "training_completion_agreement": self.first_req.training_completion_agreement,
+            "training_completion_agreement": self.first_req.training_completion_agreement,  # noqa: line too long
             "workshop_teaching_agreement": self.first_req.workshop_teaching_agreement,
             "data_privacy_agreement": self.first_req.data_privacy_agreement,
             "code_of_conduct_agreement": self.first_req.code_of_conduct_agreement,

--- a/amy/extrequests/tests/test_workshop_inquiries.py
+++ b/amy/extrequests/tests/test_workshop_inquiries.py
@@ -654,7 +654,8 @@ class TestAcceptWorkshopInquiryAddsEmailAction(FakeRedisTestCaseMixin, TestBase)
             body_template="Sample text.",
         )
         self.trigger1 = Trigger.objects.create(
-            action="week-after-workshop-completion", template=template1,
+            action="week-after-workshop-completion",
+            template=template1,
         )
 
         self.url = reverse("workshopinquiry_accept_event", args=[self.wi1.pk])

--- a/amy/extrequests/tests/test_workshop_requests.py
+++ b/amy/extrequests/tests/test_workshop_requests.py
@@ -582,7 +582,8 @@ class TestAcceptWorkshopRequestAddsEmailAction(FakeRedisTestCaseMixin, TestBase)
             body_template="Sample text.",
         )
         self.trigger1 = Trigger.objects.create(
-            action="week-after-workshop-completion", template=template1,
+            action="week-after-workshop-completion",
+            template=template1,
         )
 
         self.url = reverse("workshoprequest_accept_event", args=[self.wr1.pk])

--- a/amy/extrequests/tests/test_wrfinitial.py
+++ b/amy/extrequests/tests/test_wrfinitial.py
@@ -20,16 +20,20 @@ class InitialWRFTestMixin:
         self.view.other_object = self.setUpOther()
         self.expected = {
             "public_status": "public",
-            "curricula": Curriculum.objects.filter(slug__in=[
-                "swc-other",
-                "dc-other",
-                "lc-other",
-                "",  # mix & match
-            ]),
-            "tags": Tag.objects.filter(name__in=[
-                "Circuits",
-                "online",
-            ]),
+            "curricula": Curriculum.objects.filter(
+                slug__in=[
+                    "swc-other",
+                    "dc-other",
+                    "lc-other",
+                    "",  # mix & match
+                ]
+            ),
+            "tags": Tag.objects.filter(
+                name__in=[
+                    "Circuits",
+                    "online",
+                ]
+            ),
             "contact": "test@example.org;test2@example.org",
             "host": Organization.objects.first(),
             "start": date(2020, 11, 11),
@@ -67,10 +71,11 @@ class TestInitialWorkshopRequestAccept(InitialWRFTestMixin, TestCase):
             online_inperson="online",
         )
         # add "(swc|dc|lc)-other" and "mix & match" curricula
-        other_object.requested_workshop_types.set(Curriculum.objects.filter(
-            Q(carpentry__in=["SWC", "DC", "LC"], other=True)
-            | Q(mix_match=True)
-        ))
+        other_object.requested_workshop_types.set(
+            Curriculum.objects.filter(
+                Q(carpentry__in=["SWC", "DC", "LC"], other=True) | Q(mix_match=True)
+            )
+        )
         return other_object
 
 
@@ -93,10 +98,11 @@ class TestInitialWorkshopInquiryAccept(InitialWRFTestMixin, TestCase):
             online_inperson="online",
         )
         # add "(swc|dc|lc)-other" and "mix & match" curricula
-        other_object.requested_workshop_types.set(Curriculum.objects.filter(
-            Q(carpentry__in=["SWC", "DC", "LC"], other=True)
-            | Q(mix_match=True)
-        ))
+        other_object.requested_workshop_types.set(
+            Curriculum.objects.filter(
+                Q(carpentry__in=["SWC", "DC", "LC"], other=True) | Q(mix_match=True)
+            )
+        )
         return other_object
 
 
@@ -121,8 +127,9 @@ class TestInitialSelfOrganisedSubmissionAccept(InitialWRFTestMixin, TestCase):
             online_inperson="online",
         )
         # add "(swc|dc|lc)-other" and "mix & match" curricula
-        other_object.workshop_types.set(Curriculum.objects.filter(
-            Q(carpentry__in=["SWC", "DC", "LC"], other=True)
-            | Q(mix_match=True)
-        ))
+        other_object.workshop_types.set(
+            Curriculum.objects.filter(
+                Q(carpentry__in=["SWC", "DC", "LC"], other=True) | Q(mix_match=True)
+            )
+        )
         return other_object

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -196,7 +196,8 @@ class WorkshopRequestAcceptEvent(
                 logger=logger,
                 scheduler=scheduler,
                 triggers=Trigger.objects.filter(
-                    active=True, action="week-after-workshop-completion",
+                    active=True,
+                    action="week-after-workshop-completion",
                 ),
                 context_objects=objs,
                 object_=event,
@@ -313,7 +314,8 @@ class WorkshopInquiryAcceptEvent(
                 logger=logger,
                 scheduler=scheduler,
                 triggers=Trigger.objects.filter(
-                    active=True, action="week-after-workshop-completion",
+                    active=True,
+                    action="week-after-workshop-completion",
                 ),
                 context_objects=objs,
                 object_=event,
@@ -508,7 +510,8 @@ class SelfOrganisedSubmissionAcceptEvent(
                 logger=logger,
                 scheduler=scheduler,
                 triggers=Trigger.objects.filter(
-                    active=True, action="week-after-workshop-completion",
+                    active=True,
+                    action="week-after-workshop-completion",
                 ),
                 context_objects=objs,
                 object_=event,
@@ -607,7 +610,8 @@ def all_trainingrequests(request):
                         request,
                         'Training "{}" has start or end date outside '
                         'membership "{}" agreement dates.'.format(
-                            str(event), str(member_site),
+                            str(event),
+                            str(member_site),
                         ),
                     )
 
@@ -961,7 +965,9 @@ def bulk_upload_training_request_scores(request):
         "charset": settings.DEFAULT_CHARSET,
     }
     return render(
-        request, "requests/trainingrequest_bulk_upload_manual_score_form.html", context,
+        request,
+        "requests/trainingrequest_bulk_upload_manual_score_form.html",
+        context,
     )
 
 
@@ -1010,7 +1016,8 @@ def bulk_upload_training_request_scores_confirmation(request):
                     return redirect("bulk_upload_training_request_scores")
             else:
                 messages.warning(
-                    request, "Please fix the data according to error messages below.",
+                    request,
+                    "Please fix the data according to error messages below.",
                 )
 
         else:
@@ -1022,7 +1029,8 @@ def bulk_upload_training_request_scores_confirmation(request):
         errors, cleaned_data = clean_upload_trainingrequest_manual_score(data)
         if errors:
             messages.warning(
-                request, "Please fix errors in the provided CSV file and re-upload.",
+                request,
+                "Please fix errors in the provided CSV file and re-upload.",
             )
 
     context = {

--- a/amy/fiscal/apps.py
+++ b/amy/fiscal/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class FiscalConfig(AppConfig):
-    name = 'fiscal'
+    name = "fiscal"

--- a/amy/fiscal/tests/test_organization.py
+++ b/amy/fiscal/tests/test_organization.py
@@ -15,19 +15,33 @@ class TestOrganization(TestBase):
         """Make sure deleted organization is longer accessible.
 
         Additionally check on_delete behavior for Event."""
-        Event.objects.create(host=self.org_alpha,
-                             administrator=self.org_beta,
-                             slug='test-event')
+        Event.objects.create(
+            host=self.org_alpha, administrator=self.org_beta, slug="test-event"
+        )
 
         for org_domain in [self.org_alpha.domain, self.org_beta.domain]:
-            rv = self.client.post(reverse('organization_delete', args=[org_domain, ]))
-            content = rv.content.decode('utf-8')
-            assert 'Failed to delete' in content
+            rv = self.client.post(
+                reverse(
+                    "organization_delete",
+                    args=[
+                        org_domain,
+                    ],
+                )
+            )
+            content = rv.content.decode("utf-8")
+            assert "Failed to delete" in content
 
-        Event.objects.get(slug='test-event').delete()
+        Event.objects.get(slug="test-event").delete()
 
         for org_domain in [self.org_alpha.domain, self.org_beta.domain]:
-            rv = self.client.post(reverse('organization_delete', args=[org_domain, ]))
+            rv = self.client.post(
+                reverse(
+                    "organization_delete",
+                    args=[
+                        org_domain,
+                    ],
+                )
+            )
             assert rv.status_code == 302
 
             with self.assertRaises(Organization.DoesNotExist):
@@ -44,11 +58,11 @@ class TestOrganization(TestBase):
         for the organization_details URL has `[\w\.-]+` matching...
         """
         data = {
-            'domain': 'http://beta.com/',
-            'fullname': self.org_beta.fullname,
-            'country': self.org_beta.country,
+            "domain": "http://beta.com/",
+            "fullname": self.org_beta.fullname,
+            "country": self.org_beta.country,
         }
-        url = reverse('organization_edit', args=[self.org_beta.domain])
+        url = reverse("organization_edit", args=[self.org_beta.domain])
         rv = self.client.post(url, data=data)
         # make sure we're not updating to good values
         assert rv.status_code == 200
@@ -58,9 +72,9 @@ class TestOrganization(TestBase):
         comment content is saved."""
         self.assertEqual(Comment.objects.count(), 0)
         data = {
-            'fullname': 'Test Organization',
-            'domain': 'test.org',
-            'comment': '',
+            "fullname": "Test Organization",
+            "domain": "test.org",
+            "comment": "",
         }
         form = OrganizationCreateForm(data)
         form.save()
@@ -71,13 +85,13 @@ class TestOrganization(TestBase):
         comment content is saved."""
         self.assertEqual(Comment.objects.count(), 0)
         data = {
-            'fullname': 'Test Organization',
-            'domain': 'test.org',
-            'comment': 'This is a test comment.',
+            "fullname": "Test Organization",
+            "domain": "test.org",
+            "comment": "This is a test comment.",
         }
         form = OrganizationCreateForm(data)
         obj = form.save()
         self.assertEqual(Comment.objects.count(), 1)
         comment = Comment.objects.first()
-        self.assertEqual(comment.comment, 'This is a test comment.')
+        self.assertEqual(comment.comment, "This is a test comment.")
         self.assertIn(comment, Comment.objects.for_model(obj))

--- a/amy/fiscal/tests/test_sponsorship.py
+++ b/amy/fiscal/tests/test_sponsorship.py
@@ -3,7 +3,7 @@ from django.db import IntegrityError
 from django.urls import reverse
 
 from workshops.tests.base import TestBase
-from workshops.models import Event, Organization, Sponsorship
+from workshops.models import Event, Sponsorship
 
 
 class TestSponsorshipModel(TestBase):
@@ -46,13 +46,13 @@ class TestSponsorshipModel(TestBase):
 
     def test_unique_together_constraint(self):
         """Check that no two sponsorships with same values can exist"""
-        sponsorship = Sponsorship.objects.create(
+        Sponsorship.objects.create(
             organization=self.org_beta,
             event=self.event,
             amount=500,
         )
         with self.assertRaises(IntegrityError):
-            sponsorship = Sponsorship.objects.create(
+            Sponsorship.objects.create(
                 organization=self.org_beta,
                 event=self.event,
                 amount=500,
@@ -163,7 +163,10 @@ class TestSponsorshipViews(TestBase):
             response,
             form="form",
             field=None,
-            errors="Sponsorship with this Organization, Event and Sponsorship amount already exists.",
+            errors=(
+                "Sponsorship with this Organization, Event and Sponsorship amount"
+                " already exists."
+            ),
         )
 
     def test_delete_sponsor(self):

--- a/amy/fiscal/tests/test_sponsorship.py
+++ b/amy/fiscal/tests/test_sponsorship.py
@@ -7,16 +7,15 @@ from workshops.models import Event, Organization, Sponsorship
 
 
 class TestSponsorshipModel(TestBase):
-
     def setUp(self):
         super().setUp()
         self.event = Event.objects.create(
-            slug='2016-07-05-test-event',
+            slug="2016-07-05-test-event",
             host=self.org_alpha,
         )
 
     def test_positive_amount_field(self):
-        '''Check that we cannot add negative amount of sponsorship'''
+        """Check that we cannot add negative amount of sponsorship"""
         with self.assertRaises(ValidationError):
             Sponsorship.objects.create(
                 organization=self.org_beta,
@@ -25,14 +24,14 @@ class TestSponsorshipModel(TestBase):
             ).full_clean()
 
     def test_sponsorship_without_amount(self):
-        '''Check that we can have blank amount field'''
+        """Check that we can have blank amount field"""
         Sponsorship.objects.create(
             organization=self.org_beta,
             event=self.event,
         ).full_clean()
 
     def test_sponsorship_can_be_deleted_and_related_objects_are_intact(self):
-        '''Check that the event and organization aren't deleted'''
+        """Check that the event and organization aren't deleted"""
         sponsorship = Sponsorship.objects.create(
             organization=self.org_beta,
             event=self.event,
@@ -46,7 +45,7 @@ class TestSponsorshipModel(TestBase):
         self.org_beta.refresh_from_db()
 
     def test_unique_together_constraint(self):
-        '''Check that no two sponsorships with same values can exist'''
+        """Check that no two sponsorships with same values can exist"""
         sponsorship = Sponsorship.objects.create(
             organization=self.org_beta,
             event=self.event,
@@ -61,11 +60,10 @@ class TestSponsorshipModel(TestBase):
 
 
 class TestSponsorshipViews(TestBase):
-
     def setUp(self):
         super().setUp()
         self.event = Event.objects.create(
-            slug='2016-07-05-test-event',
+            slug="2016-07-05-test-event",
             host=self.org_alpha,
         )
         self.sponsorship = Sponsorship.objects.create(
@@ -76,114 +74,109 @@ class TestSponsorshipViews(TestBase):
         self._setUpUsersAndLogin()
 
     def test_sponsor_visible_on_event_detail_page(self):
-        '''Check that added sponsor is visible on the event detail page'''
-        rv = self.client.get(
-            reverse('event_details', kwargs={'slug': self.event.slug})
-        )
+        """Check that added sponsor is visible on the event detail page"""
+        rv = self.client.get(reverse("event_details", kwargs={"slug": self.event.slug}))
         self.assertEqual(rv.status_code, 200)
-        self.assertIn(self.sponsorship, rv.context['event'].sponsorship_set.all())
+        self.assertIn(self.sponsorship, rv.context["event"].sponsorship_set.all())
 
     def test_sponsor_visible_on_event_edit_page(self):
-        rv = self.client.get(
-            reverse('event_edit', kwargs={'slug': self.event.slug})
-        )
+        rv = self.client.get(reverse("event_edit", kwargs={"slug": self.event.slug}))
         self.assertEqual(rv.status_code, 200)
-        self.assertIn(self.sponsorship, rv.context['object'].sponsorship_set.all())
+        self.assertIn(self.sponsorship, rv.context["object"].sponsorship_set.all())
 
     def test_add_sponsor_minimal(self):
-        '''Check that we can add a sponsor w/ minimal parameters'''
+        """Check that we can add a sponsor w/ minimal parameters"""
         payload = {
-            'organization': self.org_beta.pk,
-            'event': self.event.pk,
-            'amount': "0",
+            "organization": self.org_beta.pk,
+            "event": self.event.pk,
+            "amount": "0",
         }
-        response = self.client.post(
-            reverse('sponsorship_add'), payload, follow=True
-        )
+        response = self.client.post(reverse("sponsorship_add"), payload, follow=True)
         self.assertRedirects(
             response,
-            '{}#sponsors'.format(
-                reverse('event_edit', kwargs={'slug': self.event.slug}),
-            )
+            "{}#sponsors".format(
+                reverse("event_edit", kwargs={"slug": self.event.slug}),
+            ),
         )
-        self.assertTrue(response.context['object'].sponsorship_set.all())
-        self.assertEqual(response.context['object'].sponsors.count(), 2)
+        self.assertTrue(response.context["object"].sponsorship_set.all())
+        self.assertEqual(response.context["object"].sponsors.count(), 2)
 
     def test_add_sponsor_with_amount(self):
-        '''Check that we can add a sponsor with amount'''
+        """Check that we can add a sponsor with amount"""
         payload = {
-            'organization': self.org_beta.pk,
-            'event': self.event.pk,
-            'amount': 1500,
+            "organization": self.org_beta.pk,
+            "event": self.event.pk,
+            "amount": 1500,
         }
-        response = self.client.post(
-            reverse('sponsorship_add'), payload, follow=True
-        )
+        response = self.client.post(reverse("sponsorship_add"), payload, follow=True)
         self.assertRedirects(
             response,
-            '{}#sponsors'.format(
-                reverse('event_edit', kwargs={'slug': self.event.slug}),
-            )
+            "{}#sponsors".format(
+                reverse("event_edit", kwargs={"slug": self.event.slug}),
+            ),
         )
-        self.assertTrue(response.context['object'].sponsorship_set.all())
-        self.assertEqual(response.context['object'].sponsors.count(), 2)
+        self.assertTrue(response.context["object"].sponsorship_set.all())
+        self.assertEqual(response.context["object"].sponsors.count(), 2)
         self.assertIn(
             1500,
-            response.context['object'].sponsorship_set.values_list('amount', flat=True)
+            response.context["object"].sponsorship_set.values_list("amount", flat=True),
         )
 
     def test_add_sponsor_with_contact(self):
-        '''Check that we can add a sponsor with a contact person'''
+        """Check that we can add a sponsor with a contact person"""
         payload = {
-            'organization': self.org_beta.pk,
-            'event': self.event.pk,
-            'contact': self.harry.pk,
-            'amount': 1500,
+            "organization": self.org_beta.pk,
+            "event": self.event.pk,
+            "contact": self.harry.pk,
+            "amount": 1500,
         }
-        response = self.client.post(
-            reverse('sponsorship_add'), payload, follow=True
-        )
+        response = self.client.post(reverse("sponsorship_add"), payload, follow=True)
         self.assertRedirects(
             response,
-            '{}#sponsors'.format(
-                reverse('event_edit', kwargs={'slug': self.event.slug}),
-            )
+            "{}#sponsors".format(
+                reverse("event_edit", kwargs={"slug": self.event.slug}),
+            ),
         )
-        self.assertTrue(response.context['object'].sponsorship_set.all())
-        self.assertEqual(response.context['object'].sponsors.count(), 2)
+        self.assertTrue(response.context["object"].sponsorship_set.all())
+        self.assertEqual(response.context["object"].sponsors.count(), 2)
         self.assertIn(
             self.harry.pk,
-            response.context['object'].sponsorship_set.values_list('contact', flat=True)
+            response.context["object"].sponsorship_set.values_list(
+                "contact", flat=True
+            ),
         )
 
     def test_add_duplicate_sponsorship_instance(self):
-        '''Check that we cannot successfully submit duplicates'''
+        """Check that we cannot successfully submit duplicates"""
         payload = {
-            'organization': self.sponsorship.organization.pk,
-            'event': self.sponsorship.event.pk,
-            'amount': self.sponsorship.amount,
+            "organization": self.sponsorship.organization.pk,
+            "event": self.sponsorship.event.pk,
+            "amount": self.sponsorship.amount,
         }
         response = self.client.post(
-            reverse('sponsorship_add'), payload, follow=True,
+            reverse("sponsorship_add"),
+            payload,
+            follow=True,
         )
         self.assertEqual(response.status_code, 200)
-        self.assertFormError(response,
-            form='form',
+        self.assertFormError(
+            response,
+            form="form",
             field=None,
-            errors='Sponsorship with this Organization, Event and Sponsorship amount already exists.',
+            errors="Sponsorship with this Organization, Event and Sponsorship amount already exists.",
         )
 
     def test_delete_sponsor(self):
-        '''Check that we can delete a sponsor from `sponsor_delete` view'''
+        """Check that we can delete a sponsor from `sponsor_delete` view"""
         response = self.client.post(
-            reverse('sponsorship_delete', kwargs={'pk': self.sponsorship.pk}),
-            follow=True
+            reverse("sponsorship_delete", kwargs={"pk": self.sponsorship.pk}),
+            follow=True,
         )
         self.assertRedirects(
             response,
-            reverse('event_edit', kwargs={'slug': self.event.slug}) + '#sponsors',
+            reverse("event_edit", kwargs={"slug": self.event.slug}) + "#sponsors",
         )
-        self.assertFalse(response.context['object'].sponsorship_set.all())
-        self.assertEqual(response.context['object'].sponsors.count(), 0)
+        self.assertFalse(response.context["object"].sponsorship_set.all())
+        self.assertEqual(response.context["object"].sponsors.count(), 0)
         with self.assertRaises(ObjectDoesNotExist):
             self.sponsorship.refresh_from_db()

--- a/amy/reports/admin.py
+++ b/amy/reports/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/amy/reports/apps.py
+++ b/amy/reports/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class ReportsConfig(AppConfig):
-    name = 'reports'
+    name = "reports"

--- a/amy/reports/models.py
+++ b/amy/reports/models.py
@@ -1,3 +1,1 @@
-from django.db import models
-
 # Create your models here.

--- a/amy/reports/tests/test_finding_duplicates.py
+++ b/amy/reports/tests/test_finding_duplicates.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import timedelta
 
 from django.utils import timezone
 from django.urls import reverse
@@ -290,9 +290,7 @@ class TestFindingReviewedDuplicates(TestBase):
         self.assertFalse(self.harry.duplication_reviewed_on)
         self.assertFalse(self.ron.duplication_reviewed_on)
 
-        rv = self.client.post(
-            self.review_url, {"person_id": [self.harry.pk, self.ron.pk]}
-        )
+        self.client.post(self.review_url, {"person_id": [self.harry.pk, self.ron.pk]})
 
         self.harry.refresh_from_db()
         self.ron.refresh_from_db()

--- a/amy/reports/tests/test_finding_duplicates.py
+++ b/amy/reports/tests/test_finding_duplicates.py
@@ -9,28 +9,41 @@ from workshops.tests.base import TestBase
 
 class TestEmptyDuplicates(TestBase):
     """Tests to return empty context variables when no matches found."""
+
     def setUp(self):
         self._setUpUsersAndLogin()
 
         self.harry = Person.objects.create(
-            personal='Harry', family='Potter', username='potter_harry',
-            email='hp@hogwart.edu')
+            personal="Harry",
+            family="Potter",
+            username="potter_harry",
+            email="hp@hogwart.edu",
+        )
         self.kira = Person.objects.create(
-            personal='Light', family='Yagami', username='light_yagami',
-            email='ly@hogwart.edu')
+            personal="Light",
+            family="Yagami",
+            username="light_yagami",
+            email="ly@hogwart.edu",
+        )
         self.batman = Person.objects.create(
-            personal='Bruce', family='Wayne', username='bruce_wayne',
-            email='batman@waynecorp.com')
+            personal="Bruce",
+            family="Wayne",
+            username="bruce_wayne",
+            email="batman@waynecorp.com",
+        )
         self.ironman = Person.objects.create(
-            personal='Tony', family='Stark', username='tony_stark',
-            email='ironman@starkindustries.com')
+            personal="Tony",
+            family="Stark",
+            username="tony_stark",
+            email="ironman@starkindustries.com",
+        )
 
-        self.url = reverse('duplicate_persons')
+        self.url = reverse("duplicate_persons")
 
     def test_switched_names_persons(self):
         """Ensure none of the above persons are in `switched_persons`."""
         rv = self.client.get(self.url)
-        switched = rv.context['switched_persons']
+        switched = rv.context["switched_persons"]
         self.assertNotIn(self.harry, switched)
         self.assertNotIn(self.kira, switched)
         self.assertNotIn(self.batman, switched)
@@ -39,7 +52,7 @@ class TestEmptyDuplicates(TestBase):
     def test_duplicate_persons(self):
         """Ensure none of the above persons are in `duplicate_persons`."""
         rv = self.client.get(self.url)
-        switched = rv.context['duplicate_persons']
+        switched = rv.context["duplicate_persons"]
         self.assertNotIn(self.harry, switched)
         self.assertNotIn(self.kira, switched)
         self.assertNotIn(self.batman, switched)
@@ -51,23 +64,35 @@ class TestFindingDuplicates(TestBase):
         self._setUpUsersAndLogin()
 
         self.harry = Person.objects.create(
-            personal='Harry', family='Potter', username='potter_harry',
-            email='hp@hogwart.edu')
+            personal="Harry",
+            family="Potter",
+            username="potter_harry",
+            email="hp@hogwart.edu",
+        )
         self.potter = Person.objects.create(
-            personal='Potter', family='Harry', username='harry_potter',
-            email='hp+1@hogwart.edu')
+            personal="Potter",
+            family="Harry",
+            username="harry_potter",
+            email="hp+1@hogwart.edu",
+        )
         self.ron = Person.objects.create(
-            personal='Ron', family='Weasley', username='weasley_ron',
-            email='rw@hogwart.edu')
+            personal="Ron",
+            family="Weasley",
+            username="weasley_ron",
+            email="rw@hogwart.edu",
+        )
         self.ron2 = Person.objects.create(
-            personal='Ron', family='Weasley', username='weasley_ron_2',
-            email='rw+1@hogwart.edu')
+            personal="Ron",
+            family="Weasley",
+            username="weasley_ron_2",
+            email="rw+1@hogwart.edu",
+        )
 
-        self.url = reverse('duplicate_persons')
+        self.url = reverse("duplicate_persons")
 
     def test_switched_names_persons(self):
         rv = self.client.get(self.url)
-        switched = rv.context['switched_persons']
+        switched = rv.context["switched_persons"]
         self.assertIn(self.harry, switched)
         self.assertIn(self.potter, switched)
         self.assertNotIn(self.ron, switched)
@@ -75,7 +100,7 @@ class TestFindingDuplicates(TestBase):
 
     def test_duplicate_persons(self):
         rv = self.client.get(self.url)
-        duplicated = rv.context['duplicate_persons']
+        duplicated = rv.context["duplicate_persons"]
         self.assertIn(self.ron, duplicated)
         self.assertIn(self.ron2, duplicated)
         self.assertNotIn(self.harry, duplicated)
@@ -87,25 +112,37 @@ class TestFindingReviewedDuplicates(TestBase):
         self._setUpUsersAndLogin()
 
         self.harry = Person.objects.create(
-            personal='Harry', family='Potter', username='potter_harry',
-            email='hp@hogwart.edu')
+            personal="Harry",
+            family="Potter",
+            username="potter_harry",
+            email="hp@hogwart.edu",
+        )
         self.potter = Person.objects.create(
-            personal='Potter', family='Harry', username='harry_potter',
-            email='hp+1@hogwart.edu')
+            personal="Potter",
+            family="Harry",
+            username="harry_potter",
+            email="hp+1@hogwart.edu",
+        )
         self.ron = Person.objects.create(
-            personal='Ron', family='Weasley', username='weasley_ron',
-            email='rw@hogwart.edu')
+            personal="Ron",
+            family="Weasley",
+            username="weasley_ron",
+            email="rw@hogwart.edu",
+        )
         self.ron2 = Person.objects.create(
-            personal='Ron', family='Weasley', username='weasley_ron_2',
-            email='rw+1@hogwart.edu')
+            personal="Ron",
+            family="Weasley",
+            username="weasley_ron_2",
+            email="rw+1@hogwart.edu",
+        )
 
-        self.url = reverse('duplicate_persons')
-        self.review_url = reverse('review_duplicate_persons')
+        self.url = reverse("duplicate_persons")
+        self.review_url = reverse("review_duplicate_persons")
 
     def test_finding_unreviewed_duplicates(self):
         rv = self.client.get(self.url)
-        switched = rv.context['switched_persons']
-        duplicates = rv.context['duplicate_persons']
+        switched = rv.context["switched_persons"]
+        duplicates = rv.context["duplicate_persons"]
 
         self.assertEqual(self.harry.duplication_reviewed_on, None)
         self.assertEqual(self.potter.duplication_reviewed_on, None)
@@ -141,9 +178,9 @@ class TestFindingReviewedDuplicates(TestBase):
         self.ron2.save()
 
         rv = self.client.get(self.url)
-        switched = rv.context['switched_persons']
-        duplicates = rv.context['duplicate_persons']
-        
+        switched = rv.context["switched_persons"]
+        duplicates = rv.context["duplicate_persons"]
+
         self.assertNotIn(self.harry, switched)
         self.assertNotIn(self.potter, switched)
         self.assertNotIn(self.ron, switched)
@@ -170,9 +207,9 @@ class TestFindingReviewedDuplicates(TestBase):
         self.ron2.save()
 
         rv = self.client.get(self.url)
-        switched = rv.context['switched_persons']
-        duplicates = rv.context['duplicate_persons']
-        
+        switched = rv.context["switched_persons"]
+        duplicates = rv.context["duplicate_persons"]
+
         self.assertIn(self.harry, switched)
         self.assertIn(self.potter, switched)
         self.assertNotIn(self.ron, switched)
@@ -203,9 +240,9 @@ class TestFindingReviewedDuplicates(TestBase):
         self.ron2.save()
 
         rv = self.client.get(self.url)
-        switched = rv.context['switched_persons']
-        duplicates = rv.context['duplicate_persons']
-        
+        switched = rv.context["switched_persons"]
+        duplicates = rv.context["duplicate_persons"]
+
         self.assertIn(self.harry, switched)
         self.assertIn(self.potter, switched)
         self.assertNotIn(self.ron, switched)
@@ -228,17 +265,17 @@ class TestFindingReviewedDuplicates(TestBase):
 
         self.harry.duplication_reviewed_on = review_date
         self.harry.save()
-        #self.potter.duplication_reviewed_on = review_date
-        #self.potter.save()
+        # self.potter.duplication_reviewed_on = review_date
+        # self.potter.save()
         self.ron.duplication_reviewed_on = review_date
         self.ron.save()
-        #self.ron2.duplication_reviewed_on = review_date
-        #self.ron2.save()
+        # self.ron2.duplication_reviewed_on = review_date
+        # self.ron2.save()
 
         rv = self.client.get(self.url)
-        switched = rv.context['switched_persons']
-        duplicates = rv.context['duplicate_persons']
-        
+        switched = rv.context["switched_persons"]
+        duplicates = rv.context["duplicate_persons"]
+
         self.assertNotIn(self.harry, switched)
         self.assertNotIn(self.potter, switched)
         self.assertNotIn(self.ron, switched)
@@ -254,7 +291,7 @@ class TestFindingReviewedDuplicates(TestBase):
         self.assertFalse(self.ron.duplication_reviewed_on)
 
         rv = self.client.post(
-            self.review_url, {'person_id': [self.harry.pk, self.ron.pk]}
+            self.review_url, {"person_id": [self.harry.pk, self.ron.pk]}
         )
 
         self.harry.refresh_from_db()

--- a/amy/reports/tests/test_instructor_issues.py
+++ b/amy/reports/tests/test_instructor_issues.py
@@ -11,15 +11,15 @@ class TestInstructorIssues(TestBase):
         super().setUp()
         self._setUpUsersAndLogin()
 
-        TTT, _ = Tag.objects.get_or_create(name='TTT')
-        stalled = Tag.objects.get(name='stalled')
-        learner, _ = Role.objects.get_or_create(name='learner')
+        TTT, _ = Tag.objects.get_or_create(name="TTT")
+        stalled = Tag.objects.get(name="stalled")
+        learner, _ = Role.objects.get_or_create(name="learner")
 
         # add two TTT events, one stalled and one normal
-        e1 = Event.objects.create(slug='ttt-stalled', host=self.org_alpha)
+        e1 = Event.objects.create(slug="ttt-stalled", host=self.org_alpha)
         e1.tags.set([TTT, stalled])
 
-        e2 = Event.objects.create(slug='ttt-not-stalled', host=self.org_alpha)
+        e2 = Event.objects.create(slug="ttt-not-stalled", host=self.org_alpha)
         e2.tags.add(TTT)
 
         Task.objects.create(event=e1, person=self.spiderman, role=learner)
@@ -29,9 +29,9 @@ class TestInstructorIssues(TestBase):
 
     def test_stalled_trainees_not_in_pending(self):
         """"""
-        rv = self.client.get(reverse('instructor_issues'))
-        pending = [t.person for t in rv.context['pending']]
-        stalled = [t.person for t in rv.context['stalled']]
+        rv = self.client.get(reverse("instructor_issues"))
+        pending = [t.person for t in rv.context["pending"]]
+        stalled = [t.person for t in rv.context["stalled"]]
 
         self.assertIn(self.spiderman, pending)
         self.assertNotIn(self.spiderman, stalled)

--- a/amy/reports/tests/test_issues.py
+++ b/amy/reports/tests/test_issues.py
@@ -12,129 +12,207 @@ class TestIssuesViews(TestBase):
         super()._setUpRoles()
         super()._setUpTags()
 
-        self.url = reverse('workshop_issues')
+        self.url = reverse("workshop_issues")
         self.today = date.today()
         oneday = timedelta(days=1)
         self.weekago = self.today - 7 * oneday
         self.yesterday = self.today - oneday
         self.tomorrow = self.today + oneday
-        self.instructor_role = Role.objects.get(name='instructor')
+        self.instructor_role = Role.objects.get(name="instructor")
 
     def test_workshop_issues_past(self):
         """Test if workshop issues collects events from past only."""
         past = Event.objects.create(
-            slug='event-in-past', start=self.yesterday,
-            host=Organization.objects.first())
+            slug="event-in-past",
+            start=self.yesterday,
+            host=Organization.objects.first(),
+        )
         future = Event.objects.create(
-            slug='event-in-future', start=self.tomorrow,
-            host=Organization.objects.first())
+            slug="event-in-future",
+            start=self.tomorrow,
+            host=Organization.objects.first(),
+        )
 
         rv = self.client.get(self.url)
-        self.assertIn(past, rv.context['events'])
-        self.assertNotIn(future, rv.context['events'])
+        self.assertIn(past, rv.context["events"])
+        self.assertNotIn(future, rv.context["events"])
 
     def test_workshop_issues_active(self):
         """Test if workshop issues collects active events only."""
         inactive = Event.objects.create(
-            slug='inactive-event', start=self.yesterday,
-            completed=True, host=Organization.objects.first())
+            slug="inactive-event",
+            start=self.yesterday,
+            completed=True,
+            host=Organization.objects.first(),
+        )
         active = Event.objects.create(
-            slug='active-event', start=self.yesterday,
-            completed=False, host=Organization.objects.first())
+            slug="active-event",
+            start=self.yesterday,
+            completed=False,
+            host=Organization.objects.first(),
+        )
 
         rv = self.client.get(self.url)
-        self.assertNotIn(inactive, rv.context['events'])
-        self.assertIn(active, rv.context['events'])
+        self.assertNotIn(inactive, rv.context["events"])
+        self.assertIn(active, rv.context["events"])
 
     def test_workshop_issues_no_attendance(self):
         """Test if workshop issues collects events without attendance
         figures."""
         attendance = Event.objects.create(
-            slug='event-with-attendance',
-            start=self.weekago, end=self.yesterday,
-            manual_attendance=36, host=Organization.objects.first(),
-            country='US', address='A', venue='B', latitude=89, longitude=179)
-        attendance.task_set.create(person=Person.objects.first(),
-                                   role=self.instructor_role)
+            slug="event-with-attendance",
+            start=self.weekago,
+            end=self.yesterday,
+            manual_attendance=36,
+            host=Organization.objects.first(),
+            country="US",
+            address="A",
+            venue="B",
+            latitude=89,
+            longitude=179,
+        )
+        attendance.task_set.create(
+            person=Person.objects.first(), role=self.instructor_role
+        )
         no_attendance = Event.objects.create(
-            slug='event-with-no-attendance',
-            start=self.weekago, end=self.yesterday,
-            manual_attendance=0, host=Organization.objects.first(),
-            country='US', address='A', venue='B', latitude=89, longitude=179)
-        no_attendance.task_set.create(person=Person.objects.first(),
-                                      role=self.instructor_role)
+            slug="event-with-no-attendance",
+            start=self.weekago,
+            end=self.yesterday,
+            manual_attendance=0,
+            host=Organization.objects.first(),
+            country="US",
+            address="A",
+            venue="B",
+            latitude=89,
+            longitude=179,
+        )
+        no_attendance.task_set.create(
+            person=Person.objects.first(), role=self.instructor_role
+        )
         no_attendance_unresponsive = Event.objects.create(
-            slug='unresponsive-event-with-no-attendance',
-            start=self.weekago, end=self.yesterday,
-            manual_attendance=0, host=Organization.objects.first(),
-            country='US', address='A', venue='B', latitude=89, longitude=179)
+            slug="unresponsive-event-with-no-attendance",
+            start=self.weekago,
+            end=self.yesterday,
+            manual_attendance=0,
+            host=Organization.objects.first(),
+            country="US",
+            address="A",
+            venue="B",
+            latitude=89,
+            longitude=179,
+        )
         no_attendance_unresponsive.task_set.create(
-            person=Person.objects.first(), role=self.instructor_role)
-        no_attendance_unresponsive.tags.add(
-            Tag.objects.get(name='unresponsive'))
+            person=Person.objects.first(), role=self.instructor_role
+        )
+        no_attendance_unresponsive.tags.add(Tag.objects.get(name="unresponsive"))
 
         rv = self.client.get(self.url)
-        self.assertNotIn(attendance, rv.context['events'])
-        self.assertNotIn(no_attendance_unresponsive, rv.context['events'])
-        self.assertIn(no_attendance, rv.context['events'])
+        self.assertNotIn(attendance, rv.context["events"])
+        self.assertNotIn(no_attendance_unresponsive, rv.context["events"])
+        self.assertIn(no_attendance, rv.context["events"])
 
     def test_workshop_issues_no_location(self):
         """Test if workshop issues collects events without location."""
         location = Event.objects.create(
-            slug='event-with-location',
-            start=self.weekago, end=self.yesterday,
-            manual_attendance=36, host=Organization.objects.first(),
-            country='US', address='A', venue='B', latitude=89, longitude=179)
-        location.task_set.create(person=Person.objects.first(),
-                                 role=self.instructor_role)
+            slug="event-with-location",
+            start=self.weekago,
+            end=self.yesterday,
+            manual_attendance=36,
+            host=Organization.objects.first(),
+            country="US",
+            address="A",
+            venue="B",
+            latitude=89,
+            longitude=179,
+        )
+        location.task_set.create(
+            person=Person.objects.first(), role=self.instructor_role
+        )
         no_location = Event.objects.create(
-            slug='event-with-no-location',
-            start=self.weekago, end=self.yesterday,
-            manual_attendance=36, host=Organization.objects.first(),
-            country='US', address='', venue='B', latitude=89, longitude=179)
-        no_location.task_set.create(person=Person.objects.first(),
-                                    role=self.instructor_role)
+            slug="event-with-no-location",
+            start=self.weekago,
+            end=self.yesterday,
+            manual_attendance=36,
+            host=Organization.objects.first(),
+            country="US",
+            address="",
+            venue="B",
+            latitude=89,
+            longitude=179,
+        )
+        no_location.task_set.create(
+            person=Person.objects.first(), role=self.instructor_role
+        )
 
         rv = self.client.get(self.url)
-        self.assertNotIn(location, rv.context['events'])
-        self.assertIn(no_location, rv.context['events'])
+        self.assertNotIn(location, rv.context["events"])
+        self.assertIn(no_location, rv.context["events"])
 
     def test_workshop_issues_wrong_dates(self):
         """Test if workshop issues collects events with invalid dates."""
         okay = Event.objects.create(
-            slug='event-with-okay-dates',
-            start=self.weekago, end=self.yesterday,
-            manual_attendance=36, host=Organization.objects.first(),
-            country='US', address='A', venue='B', latitude=89, longitude=179)
-        okay.task_set.create(person=Person.objects.first(),
-                             role=self.instructor_role)
+            slug="event-with-okay-dates",
+            start=self.weekago,
+            end=self.yesterday,
+            manual_attendance=36,
+            host=Organization.objects.first(),
+            country="US",
+            address="A",
+            venue="B",
+            latitude=89,
+            longitude=179,
+        )
+        okay.task_set.create(person=Person.objects.first(), role=self.instructor_role)
         invalid_dates = Event.objects.create(
-            slug='event-with-invalid-dates',
-            start=self.yesterday, end=self.weekago,
-            manual_attendance=36, host=Organization.objects.first(),
-            country='US', address='A', venue='B', latitude=89, longitude=179)
-        invalid_dates.task_set.create(person=Person.objects.first(),
-                                      role=self.instructor_role)
+            slug="event-with-invalid-dates",
+            start=self.yesterday,
+            end=self.weekago,
+            manual_attendance=36,
+            host=Organization.objects.first(),
+            country="US",
+            address="A",
+            venue="B",
+            latitude=89,
+            longitude=179,
+        )
+        invalid_dates.task_set.create(
+            person=Person.objects.first(), role=self.instructor_role
+        )
 
         rv = self.client.get(self.url)
-        self.assertNotIn(okay, rv.context['events'])
-        self.assertIn(invalid_dates, rv.context['events'])
+        self.assertNotIn(okay, rv.context["events"])
+        self.assertIn(invalid_dates, rv.context["events"])
 
     def test_workshop_issues_no_instructors(self):
         """Test if workshop issues collects events without instructors."""
         instructor = Event.objects.create(
-            slug='event-with-instructor',
-            start=self.weekago, end=self.yesterday,
-            manual_attendance=36, host=Organization.objects.first(),
-            country='US', address='A', venue='B', latitude=89, longitude=179)
-        instructor.task_set.create(person=Person.objects.first(),
-                                   role=self.instructor_role)
+            slug="event-with-instructor",
+            start=self.weekago,
+            end=self.yesterday,
+            manual_attendance=36,
+            host=Organization.objects.first(),
+            country="US",
+            address="A",
+            venue="B",
+            latitude=89,
+            longitude=179,
+        )
+        instructor.task_set.create(
+            person=Person.objects.first(), role=self.instructor_role
+        )
         no_instructors = Event.objects.create(
-            slug='event-with-no-instructors',
-            start=self.weekago, end=self.yesterday,
-            manual_attendance=36, host=Organization.objects.first(),
-            country='US', address='A', venue='B', latitude=89, longitude=179)
+            slug="event-with-no-instructors",
+            start=self.weekago,
+            end=self.yesterday,
+            manual_attendance=36,
+            host=Organization.objects.first(),
+            country="US",
+            address="A",
+            venue="B",
+            latitude=89,
+            longitude=179,
+        )
 
         rv = self.client.get(self.url)
-        self.assertNotIn(instructor, rv.context['events'])
-        self.assertIn(no_instructors, rv.context['events'])
+        self.assertNotIn(instructor, rv.context["events"])
+        self.assertIn(no_instructors, rv.context["events"])

--- a/amy/reports/views.py
+++ b/amy/reports/views.py
@@ -38,82 +38,94 @@ def membership_trainings_stats(request):
     """Display basic statistics for memberships and instructor trainings."""
     # today = datetime.date.today()
     data = (
-            Membership.objects
-            # .filter(agreement_end__gte=today, agreement_start__lte=today)
-            .select_related('organization')
-            .prefetch_related('task_set')
-            .annotate(
-                instructor_training_seats_total=(
-                    F('seats_instructor_training') +
-                    F('additional_instructor_training_seats')
-                ),
-                instructor_training_seats_utilized=(
-                    Count('task', filter=Q(task__role__name='learner'))
-                ),
-                instructor_training_seats_remaining=(
-                    F('seats_instructor_training') +
-                    F('additional_instructor_training_seats') -
-                    Count('task', filter=Q(task__role__name='learner'))
-                ),
-            )
+        Membership.objects
+        # .filter(agreement_end__gte=today, agreement_start__lte=today)
+        .select_related("organization")
+        .prefetch_related("task_set")
+        .annotate(
+            instructor_training_seats_total=(
+                F("seats_instructor_training")
+                + F("additional_instructor_training_seats")
+            ),
+            instructor_training_seats_utilized=(
+                Count("task", filter=Q(task__role__name="learner"))
+            ),
+            instructor_training_seats_remaining=(
+                F("seats_instructor_training")
+                + F("additional_instructor_training_seats")
+                - Count("task", filter=Q(task__role__name="learner"))
+            ),
+        )
     )
 
     filter_ = MembershipTrainingsFilter(request.GET, data)
     paginated = get_pagination_items(request, filter_.qs)
     context = {
-        'title': 'Membership trainings statistics',
-        'data': paginated,
-        'filter': filter_,
+        "title": "Membership trainings statistics",
+        "data": paginated,
+        "filter": filter_,
     }
-    return render(request, 'reports/membership_trainings_stats.html',
-                  context)
+    return render(request, "reports/membership_trainings_stats.html", context)
 
 
 @admin_required
 def workshop_issues(request):
-    '''Display workshops in the database whose records need attention.'''
+    """Display workshops in the database whose records need attention."""
 
     assignment_form = AssignmentForm(request.GET)
     assigned_to: Optional[Person] = None
     if assignment_form.is_valid():
         assigned_to = assignment_form.cleaned_data["assigned_to"]
 
-    events = Event.objects.active().past_events().annotate(
-        num_instructors=Count(
-            Case(
-                When(
-                    task__role__name='instructor',
-                    then=Value(1)
-                ),
-                output_field=IntegerField()
+    events = (
+        Event.objects.active()
+        .past_events()
+        .annotate(
+            num_instructors=Count(
+                Case(
+                    When(task__role__name="instructor", then=Value(1)),
+                    output_field=IntegerField(),
+                )
             )
         )
-    ).attendance().order_by('-start')
+        .attendance()
+        .order_by("-start")
+    )
 
     no_attendance = Q(attendance=None) | Q(attendance=0)
-    no_location = (Q(country=None) |
-                   Q(venue=None) | Q(venue__exact='') |
-                   Q(address=None) | Q(address__exact='') |
-                   Q(latitude=None) | Q(longitude=None))
-    bad_dates = Q(start__gt=F('end'))
+    no_location = (
+        Q(country=None)
+        | Q(venue=None)
+        | Q(venue__exact="")
+        | Q(address=None)
+        | Q(address__exact="")
+        | Q(latitude=None)
+        | Q(longitude=None)
+    )
+    bad_dates = Q(start__gt=F("end"))
 
     events = events.filter(
-        (no_attendance & ~Q(tags__name='unresponsive')) |
-        no_location |
-        bad_dates |
-        Q(num_instructors=0)
-    ).prefetch_related('task_set', 'task_set__person')
+        (no_attendance & ~Q(tags__name="unresponsive"))
+        | no_location
+        | bad_dates
+        | Q(num_instructors=0)
+    ).prefetch_related("task_set", "task_set__person")
 
-    events = events.prefetch_related(Prefetch(
-        'task_set',
-        to_attr='contacts',
-        queryset=Task.objects.select_related('person').filter(
-            # we only want hosts, organizers and instructors
-            Q(role__name='host') | Q(role__name='organizer') |
-            Q(role__name='instructor')
-        ).filter(person__may_contact=True)
-        .exclude(Q(person__email='') | Q(person__email=None))
-    ))
+    events = events.prefetch_related(
+        Prefetch(
+            "task_set",
+            to_attr="contacts",
+            queryset=Task.objects.select_related("person")
+            .filter(
+                # we only want hosts, organizers and instructors
+                Q(role__name="host")
+                | Q(role__name="organizer")
+                | Q(role__name="instructor")
+            )
+            .filter(person__may_contact=True)
+            .exclude(Q(person__email="") | Q(person__email=None)),
+        )
+    )
 
     if assigned_to is not None:
         events = events.filter(assigned_to=assigned_to)
@@ -137,49 +149,52 @@ def workshop_issues(request):
     )
 
     context = {
-        'title': 'Workshops with Issues',
-        'events': events,
-        'assignment_form': assignment_form,
-        'assigned_to': assigned_to,
+        "title": "Workshops with Issues",
+        "events": events,
+        "assignment_form": assignment_form,
+        "assigned_to": assigned_to,
     }
-    return render(request, 'reports/workshop_issues.html', context)
+    return render(request, "reports/workshop_issues.html", context)
 
 
 @admin_required
 def instructor_issues(request):
-    '''Display instructors in the database who need attention.'''
+    """Display instructors in the database who need attention."""
 
     # Everyone who has a badge but needs attention.
     instructor_badges = Badge.objects.instructor_badges()
-    instructors = Person.objects.filter(badges__in=instructor_badges) \
-                                .filter(airport__isnull=True)
+    instructors = Person.objects.filter(badges__in=instructor_badges).filter(
+        airport__isnull=True
+    )
 
     # Everyone who's been in instructor training but doesn't yet have a badge.
-    learner = Role.objects.get(name='learner')
-    ttt = Tag.objects.get(name='TTT')
-    stalled = Tag.objects.get(name='stalled')
-    trainees = Task.objects \
-        .filter(event__tags__in=[ttt], role=learner) \
-        .exclude(person__badges__in=instructor_badges) \
-        .order_by('person__family', 'person__personal', 'event__start') \
-        .select_related('person', 'event')
+    learner = Role.objects.get(name="learner")
+    ttt = Tag.objects.get(name="TTT")
+    stalled = Tag.objects.get(name="stalled")
+    trainees = (
+        Task.objects.filter(event__tags__in=[ttt], role=learner)
+        .exclude(person__badges__in=instructor_badges)
+        .order_by("person__family", "person__personal", "event__start")
+        .select_related("person", "event")
+    )
 
     pending_instructors = trainees.exclude(event__tags=stalled)
     pending_instructors_person_ids = pending_instructors.values_list(
-        'person__pk', flat=True,
+        "person__pk",
+        flat=True,
     )
 
-    stalled_instructors = trainees \
-        .filter(event__tags=stalled) \
-        .exclude(person__id__in=pending_instructors_person_ids)
+    stalled_instructors = trainees.filter(event__tags=stalled).exclude(
+        person__id__in=pending_instructors_person_ids
+    )
 
     context = {
-        'title': 'Instructors with Issues',
-        'instructors': instructors,
-        'pending': pending_instructors,
-        'stalled': stalled_instructors,
+        "title": "Instructors with Issues",
+        "instructors": instructors,
+        "pending": pending_instructors,
+        "stalled": stalled_instructors,
     }
-    return render(request, 'reports/instructor_issues.html', context)
+    return render(request, "reports/instructor_issues.html", context)
 
 
 @admin_required
@@ -191,12 +206,10 @@ def duplicate_persons(request):
     * same name on different people."""
 
     names_normal = set(
-        Person.objects.duplication_review_expired()
-                      .values_list('personal', 'family')
-                    )
+        Person.objects.duplication_review_expired().values_list("personal", "family")
+    )
     names_switched = set(
-        Person.objects.duplication_review_expired()
-                      .values_list('family', 'personal')
+        Person.objects.duplication_review_expired().values_list("family", "personal")
     )
     names = names_normal & names_switched  # intersection
 
@@ -204,53 +217,56 @@ def duplicate_persons(request):
     # empty query results if names is empty
     for personal, family in names:
         # get people who appear in `names`
-        switched_criteria |= (Q(personal=personal) & Q(family=family))
+        switched_criteria |= Q(personal=personal) & Q(family=family)
 
-    switched_persons = Person.objects.duplication_review_expired()\
-                                     .filter(switched_criteria) \
-                                     .order_by('email')
+    switched_persons = (
+        Person.objects.duplication_review_expired()
+        .filter(switched_criteria)
+        .order_by("email")
+    )
 
-    duplicate_names = Person.objects.duplication_review_expired() \
-                                    .values('personal', 'family') \
-                                    .order_by('family', 'personal') \
-                                    .annotate(count_id=Count('id')) \
-                                    .filter(count_id__gt=1)
+    duplicate_names = (
+        Person.objects.duplication_review_expired()
+        .values("personal", "family")
+        .order_by("family", "personal")
+        .annotate(count_id=Count("id"))
+        .filter(count_id__gt=1)
+    )
 
     duplicate_criteria = Q(id=0)
     for name in duplicate_names:
         # get people who appear in `names`
-        duplicate_criteria |= (Q(personal=name['personal']) &
-                               Q(family=name['family']))
+        duplicate_criteria |= Q(personal=name["personal"]) & Q(family=name["family"])
 
-    duplicate_persons = Person.objects.duplication_review_expired() \
-                                      .filter(duplicate_criteria) \
-                                      .order_by('family', 'personal', 'email')
+    duplicate_persons = (
+        Person.objects.duplication_review_expired()
+        .filter(duplicate_criteria)
+        .order_by("family", "personal", "email")
+    )
 
     context = {
-        'title': 'Possible duplicate persons',
-        'switched_persons': switched_persons,
-        'duplicate_persons': duplicate_persons,
+        "title": "Possible duplicate persons",
+        "switched_persons": switched_persons,
+        "duplicate_persons": duplicate_persons,
     }
 
-    return render(request, 'reports/duplicate_persons.html', context)
+    return render(request, "reports/duplicate_persons.html", context)
 
 
 @admin_required
 def review_duplicate_persons(request):
-    if request.method == 'POST' and 'person_id' in request.POST:
-        ids = request.POST.getlist('person_id')
+    if request.method == "POST" and "person_id" in request.POST:
+        ids = request.POST.getlist("person_id")
         now = timezone.now()
-        number = Person.objects.filter(id__in=ids) \
-                               .update(duplication_reviewed_on=now)
+        number = Person.objects.filter(id__in=ids).update(duplication_reviewed_on=now)
         messages.success(
-            request,
-            'Successfully marked {} persons as reviewed.'.format(number)
+            request, "Successfully marked {} persons as reviewed.".format(number)
         )
 
     else:
-        messages.warning(request, 'Wrong request or request data missing.')
+        messages.warning(request, "Wrong request or request data missing.")
 
-    return redirect(reverse('duplicate_persons'))
+    return redirect(reverse("duplicate_persons"))
 
 
 @admin_required
@@ -262,40 +278,38 @@ def duplicate_training_requests(request):
     * the same email.
     """
     names = (
-        TrainingRequest.objects
-        .values('personal', 'family')
-        .order_by('family', 'personal')
-        .annotate(count_id=Count('id'))
+        TrainingRequest.objects.values("personal", "family")
+        .order_by("family", "personal")
+        .annotate(count_id=Count("id"))
         .filter(count_id__gt=1)
     )
     duplicate_names_criteria = Q(id=0)
     for name in names:
-        duplicate_names_criteria |= (Q(personal=name['personal']) &
-                                     Q(family=name['family']))
+        duplicate_names_criteria |= Q(personal=name["personal"]) & Q(
+            family=name["family"]
+        )
 
     emails = (
-        TrainingRequest.objects
-        .values_list('email', flat=True)
-        .order_by('family', 'personal')
-        .annotate(count_id=Count('id'))
+        TrainingRequest.objects.values_list("email", flat=True)
+        .order_by("family", "personal")
+        .annotate(count_id=Count("id"))
         .filter(count_id__gt=1)
     )
     duplicate_emails_criteria = Q(id=0)
     for email in emails:
         duplicate_emails_criteria |= Q(email=email)
 
-    duplicate_names = TrainingRequest.objects \
-                                     .filter(duplicate_names_criteria) \
-                                     .order_by('family', 'personal')
-    duplicate_emails = TrainingRequest.objects \
-                                      .filter(duplicate_emails_criteria) \
-                                      .order_by('email')
+    duplicate_names = TrainingRequest.objects.filter(duplicate_names_criteria).order_by(
+        "family", "personal"
+    )
+    duplicate_emails = TrainingRequest.objects.filter(
+        duplicate_emails_criteria
+    ).order_by("email")
 
     context = {
-        'title': 'Possible duplicate training requests',
-        'duplicate_names': duplicate_names,
-        'duplicate_emails': duplicate_emails,
+        "title": "Possible duplicate training requests",
+        "duplicate_names": duplicate_names,
+        "duplicate_emails": duplicate_emails,
     }
 
-    return render(request, 'reports/duplicate_training_requests.html',
-                  context)
+    return render(request, "reports/duplicate_training_requests.html", context)

--- a/amy/trainings/admin.py
+++ b/amy/trainings/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/amy/trainings/apps.py
+++ b/amy/trainings/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class TrainingsConfig(AppConfig):
-    name = 'trainings'
+    name = "trainings"

--- a/amy/trainings/filters.py
+++ b/amy/trainings/filters.py
@@ -22,20 +22,22 @@ def filter_all_persons(queryset, name, all_persons):
         return queryset
     else:
         return queryset.filter(
-            task__role__name='learner',
-            task__event__tags__name='TTT').distinct()
+            task__role__name="learner", task__event__tags__name="TTT"
+        ).distinct()
 
 
 def filter_trainees_by_trainee_name_or_email(queryset, name, value):
     if value:
         # 'Harry Potter' -> ['Harry', 'Potter']
-        tokens = re.split(r'\s+', value)
+        tokens = re.split(r"\s+", value)
         # Each token must match email address or github username or personal or
         # family name.
         for token in tokens:
-            queryset = queryset.filter(Q(personal__icontains=token) |
-                                       Q(family__icontains=token) |
-                                       Q(email__icontains=token))
+            queryset = queryset.filter(
+                Q(personal__icontains=token)
+                | Q(family__icontains=token)
+                | Q(email__icontains=token)
+            )
         return queryset
     else:
         return queryset
@@ -43,7 +45,7 @@ def filter_trainees_by_trainee_name_or_email(queryset, name, value):
 
 def filter_trainees_by_unevaluated_homework_presence(queryset, name, flag):
     if flag:  # return only trainees with an unevaluated homework
-        return queryset.filter(trainingprogress__state='n').distinct()
+        return queryset.filter(trainingprogress__state="n").distinct()
     else:
         return queryset
 
@@ -58,32 +60,30 @@ def filter_trainees_by_training_request_presence(queryset, name, flag):
 
 
 def filter_trainees_by_instructor_status(queryset, name, choice):
-    if choice == 'all':
+    if choice == "all":
         return queryset.filter(
             is_swc_instructor=True,
             is_dc_instructor=True,
             is_lc_instructor=True,
         )
-    elif choice == 'any':
+    elif choice == "any":
         return queryset.filter(
-            Q(is_swc_instructor=True) |
-            Q(is_dc_instructor=True) |
-            Q(is_lc_instructor=True)
+            Q(is_swc_instructor=True)
+            | Q(is_dc_instructor=True)
+            | Q(is_lc_instructor=True)
         )
-    elif choice == 'swc':
+    elif choice == "swc":
         return queryset.filter(is_swc_instructor=True)
-    elif choice == 'dc':
+    elif choice == "dc":
         return queryset.filter(is_dc_instructor=True)
-    elif choice == 'lc':
+    elif choice == "lc":
         return queryset.filter(is_lc_instructor=True)
-    elif choice == 'eligible':
+    elif choice == "eligible":
         # Instructor eligible but without any badge.
         # This code is kept in Q()-expressions to allow for fast condition
         # change.
-        return queryset.filter(
-            Q(instructor_eligible__gte=1) & Q(is_instructor=False)
-        )
-    elif choice == 'no':
+        return queryset.filter(Q(instructor_eligible__gte=1) & Q(is_instructor=False))
+    elif choice == "no":
         return queryset.filter(
             is_instructor=False,
         )
@@ -95,69 +95,71 @@ def filter_trainees_by_training(queryset, name, training):
     if training is None:
         return queryset
     else:
-        return queryset.filter(task__role__name='learner',
-                               task__event=training).distinct()
+        return queryset.filter(
+            task__role__name="learner", task__event=training
+        ).distinct()
 
 
 class TraineeFilter(AMYFilterSet):
     search = django_filters.CharFilter(
-        method=filter_trainees_by_trainee_name_or_email,
-        label='Name or Email')
+        method=filter_trainees_by_trainee_name_or_email, label="Name or Email"
+    )
 
     all_persons = django_filters.BooleanFilter(
-        label='Include all people, not only trainees',
+        label="Include all people, not only trainees",
         method=filter_all_persons,
-        widget=widgets.CheckboxInput)
+        widget=widgets.CheckboxInput,
+    )
 
     homework = django_filters.BooleanFilter(
-        label='Only trainees with unevaluated homework',
+        label="Only trainees with unevaluated homework",
         widget=widgets.CheckboxInput,
         method=filter_trainees_by_unevaluated_homework_presence,
     )
 
     training_request = django_filters.BooleanFilter(
-        label='Is training request present?',
+        label="Is training request present?",
         method=filter_trainees_by_training_request_presence,
     )
 
     is_instructor = django_filters.ChoiceFilter(
-        label='Is Instructor?',
+        label="Is Instructor?",
         method=filter_trainees_by_instructor_status,
         choices=[
-            ('', 'Unknown'),
-            ('all', 'All instructor badges'),
-            ('any', 'Any instructor badge '),
-            ('swc', 'SWC instructor'),
-            ('dc', 'DC instructor'),
-            ('lc', 'LC instructor'),
-            ('eligible', 'No, but eligible to be certified'),
-            ('no', 'No instructor badge'),
-        ]
+            ("", "Unknown"),
+            ("all", "All instructor badges"),
+            ("any", "Any instructor badge "),
+            ("swc", "SWC instructor"),
+            ("dc", "DC instructor"),
+            ("lc", "LC instructor"),
+            ("eligible", "No, but eligible to be certified"),
+            ("no", "No instructor badge"),
+        ],
     )
 
     training = django_filters.ModelChoiceFilter(
         queryset=Event.objects.ttt(),
         method=filter_trainees_by_training,
-        label='Training',
+        label="Training",
         widget=ModelSelect2Widget(
-            data_view='ttt-event-lookup',
+            data_view="ttt-event-lookup",
             attrs=SELECT2_SIDEBAR,
         ),
     )
 
     order_by = NamesOrderingFilter(
         fields=(
-            'last_login',
-            'email',
+            "last_login",
+            "email",
         ),
     )
 
     class Meta:
         model = Person
         fields = [
-            'search',
-            'all_persons',
-            'homework',
-            'is_instructor',
-            'training',
+            "search",
+            "all_persons",
+            "homework",
+            "is_instructor",
+            "training",
         ]

--- a/amy/trainings/forms.py
+++ b/amy/trainings/forms.py
@@ -15,6 +15,7 @@ from workshops.models import (
     Person,
     TrainingProgress,
 )
+
 # this is used instead of Django Autocomplete Light widgets
 # see issue #1330: https://github.com/swcarpentry/amy/issues/1330
 from workshops.fields import (
@@ -24,121 +25,128 @@ from workshops.fields import (
 
 class TrainingProgressForm(forms.ModelForm):
     trainee = forms.ModelChoiceField(
-        label='Trainee',
+        label="Trainee",
         required=True,
         queryset=Person.objects.all(),
-        widget=ModelSelect2Widget(data_view='person-lookup')
+        widget=ModelSelect2Widget(data_view="person-lookup"),
     )
     evaluated_by = forms.ModelChoiceField(
-        label='Evaluated by',
+        label="Evaluated by",
         required=False,
         queryset=Person.objects.all(),
-        widget=ModelSelect2Widget(data_view='admin-lookup')
+        widget=ModelSelect2Widget(data_view="admin-lookup"),
     )
     event = forms.ModelChoiceField(
-        label='Event',
+        label="Event",
         required=False,
         queryset=Event.objects.all(),
-        widget=ModelSelect2Widget(data_view='event-lookup',
-                                  attrs=SELECT2_SIDEBAR)
+        widget=ModelSelect2Widget(data_view="event-lookup", attrs=SELECT2_SIDEBAR),
     )
 
     # helper used in edit view
-    helper = BootstrapHelper(duplicate_buttons_on_top=True,
-                             submit_label='Update',
-                             add_delete_button=True,
-                             additional_form_class='training-progress',
-                             add_cancel_button=False)
+    helper = BootstrapHelper(
+        duplicate_buttons_on_top=True,
+        submit_label="Update",
+        add_delete_button=True,
+        additional_form_class="training-progress",
+        add_cancel_button=False,
+    )
 
     # helper used in create view
-    create_helper = BootstrapHelper(duplicate_buttons_on_top=True,
-                                    submit_label='Add',
-                                    additional_form_class='training-progress',
-                                    add_cancel_button=False)
+    create_helper = BootstrapHelper(
+        duplicate_buttons_on_top=True,
+        submit_label="Add",
+        additional_form_class="training-progress",
+        add_cancel_button=False,
+    )
 
     class Meta:
         model = TrainingProgress
         fields = [
-            'trainee',
-            'evaluated_by',
-            'requirement',
-            'state',
-            'discarded',
-            'event',
-            'url',
-            'notes',
+            "trainee",
+            "evaluated_by",
+            "requirement",
+            "state",
+            "discarded",
+            "event",
+            "url",
+            "notes",
         ]
         widgets = {
-            'state': RadioSelect,
+            "state": RadioSelect,
         }
 
     def clean(self):
         cleaned_data = super().clean()
 
-        trainee = cleaned_data.get('trainee')
+        trainee = cleaned_data.get("trainee")
 
         # check if trainee has at least one training task
         training_tasks = trainee.get_training_tasks()
 
         if not training_tasks:
-            raise ValidationError("It's not possible to add training progress "
-                                  "to a trainee without any training task.")
+            raise ValidationError(
+                "It's not possible to add training progress "
+                "to a trainee without any training task."
+            )
 
 
 class BulkAddTrainingProgressForm(forms.ModelForm):
     event = forms.ModelChoiceField(
-        label='Training',
+        label="Training",
         required=False,
-        queryset=Event.objects.filter(tags__name='TTT'),
-        widget=ModelSelect2Widget(data_view='ttt-event-lookup',
-                                  attrs=SELECT2_SIDEBAR)
+        queryset=Event.objects.filter(tags__name="TTT"),
+        widget=ModelSelect2Widget(data_view="ttt-event-lookup", attrs=SELECT2_SIDEBAR),
     )
 
     trainees = forms.ModelMultipleChoiceField(queryset=Person.objects.all())
 
-    helper = BootstrapHelper(additional_form_class='training-progress',
-                             submit_label='Add',
-                             form_tag=False,
-                             add_cancel_button=False)
+    helper = BootstrapHelper(
+        additional_form_class="training-progress",
+        submit_label="Add",
+        form_tag=False,
+        add_cancel_button=False,
+    )
     helper.layout = Layout(
         # no 'trainees' -- you should take care of generating it manually in
         # the template where this form is used
-
-        'requirement',
-        'state',
-        'event',
-        'url',
-        'notes',
+        "requirement",
+        "state",
+        "event",
+        "url",
+        "notes",
     )
 
     class Meta:
         model = TrainingProgress
         fields = [
             # no 'trainees'
-            'requirement',
-            'state',
-            'event',
-            'url',
-            'notes',
+            "requirement",
+            "state",
+            "event",
+            "url",
+            "notes",
         ]
         widgets = {
-            'state': RadioSelect,
-            'notes': TextInput,
+            "state": RadioSelect,
+            "notes": TextInput,
         }
 
     def clean(self):
         cleaned_data = super().clean()
 
-        trainees = cleaned_data.get('trainees')
+        trainees = cleaned_data.get("trainees")
 
         # check if all trainees have at least one training task
         for trainee in trainees:
             training_tasks = trainee.get_training_tasks()
 
             if not training_tasks:
-                raise ValidationError("It's not possible to add training "
-                                      "progress to a trainee without any "
-                                      "training task.")
+                raise ValidationError(
+                    "It's not possible to add training "
+                    "progress to a trainee without any "
+                    "training task."
+                )
 
 
 class BulkDiscardProgressesForm(forms.Form):
@@ -147,35 +155,38 @@ class BulkDiscardProgressesForm(forms.Form):
 
     trainees = forms.ModelMultipleChoiceField(queryset=Person.objects.all())
 
-    helper = BootstrapHelper(add_submit_button=False,
-                             form_tag=False,
-                             display_labels=False,
-                             add_cancel_button=False)
+    helper = BootstrapHelper(
+        add_submit_button=False,
+        form_tag=False,
+        display_labels=False,
+        add_cancel_button=False,
+    )
 
-    SUBMIT_POPOVER = '''<p>Discarded progress will be displayed in the following
+    SUBMIT_POPOVER = """<p>Discarded progress will be displayed in the following
     way: <span class='badge badge-dark'><strike>Discarded</strike></span>.</p>
 
     <p>If you want to permanently remove records from system,
-    click one of the progress labels and, then, click "delete" button.</p>'''
+    click one of the progress labels and, then, click "delete" button.</p>"""
 
     helper.layout = Layout(
         # no 'trainees' -- you should take care of generating it manually in
         # the template where this form is used
-
         # We use formnovalidate on submit button to disable browser
         # validation. This is necessary because this form is used along with
         # BulkAddTrainingProgressForm, which have required fields. Both forms
         # live inside the same <form> tag. Without this attribute, when you
         # click the following submit button, the browser reports missing
         # values in required fields in BulkAddTrainingProgressForm.
-        Submit('discard',
-               'Discard all progress of selected trainees',
-               formnovalidate='formnovalidate',
-               **{
-                   'data-toggle': 'popover',
-                   'data-trigger': 'hover',
-                   'data-html': 'true',
-                   'data-content': SUBMIT_POPOVER,
-                   'css_class': 'btn btn-warning',
-               }),
+        Submit(
+            "discard",
+            "Discard all progress of selected trainees",
+            formnovalidate="formnovalidate",
+            **{
+                "data-toggle": "popover",
+                "data-trigger": "hover",
+                "data-html": "true",
+                "data-content": SUBMIT_POPOVER,
+                "css_class": "btn btn-warning",
+            },
+        ),
     )

--- a/amy/trainings/models.py
+++ b/amy/trainings/models.py
@@ -1,3 +1,1 @@
-from django.db import models
-
 # Create your models here.

--- a/amy/trainings/tests/test_trainees.py
+++ b/amy/trainings/tests/test_trainees.py
@@ -26,72 +26,79 @@ class TestTraineesView(TestBase):
         self._setUpTags()
         self._setUpRoles()
 
-        self.training = TrainingRequirement.objects.get(name='Training')
-        self.homework = TrainingRequirement.objects.get(name='SWC Homework')
-        self.discussion = TrainingRequirement.objects.get(name='Discussion')
+        self.training = TrainingRequirement.objects.get(name="Training")
+        self.homework = TrainingRequirement.objects.get(name="SWC Homework")
+        self.discussion = TrainingRequirement.objects.get(name="Discussion")
 
         self.ttt_event = Event.objects.create(
             start=datetime(2018, 7, 14),
-            slug='2018-07-14-training',
+            slug="2018-07-14-training",
             host=Organization.objects.first(),
         )
-        self.ttt_event.tags.add(Tag.objects.get(name='TTT'))
+        self.ttt_event.tags.add(Tag.objects.get(name="TTT"))
 
     def test_view_loads(self):
-        rv = self.client.get(reverse('all_trainees'))
+        rv = self.client.get(reverse("all_trainees"))
         self.assertEqual(rv.status_code, 200)
 
     def test_bulk_add_progress(self):
         TrainingProgress.objects.create(
-            trainee=self.spiderman, requirement=self.discussion, state='n')
+            trainee=self.spiderman, requirement=self.discussion, state="n"
+        )
         data = {
-            'trainees': [self.spiderman.pk, self.ironman.pk],
-            'requirement': self.discussion.pk,
-            'state': 'f',
-            'submit': '',
+            "trainees": [self.spiderman.pk, self.ironman.pk],
+            "requirement": self.discussion.pk,
+            "state": "f",
+            "submit": "",
         }
 
         # all trainees need to have a training task to assign a training
         # progress to them
         self.ironman.task_set.create(
             event=self.ttt_event,
-            role=Role.objects.get(name='learner'),
+            role=Role.objects.get(name="learner"),
         )
         self.spiderman.task_set.create(
             event=self.ttt_event,
-            role=Role.objects.get(name='learner'),
+            role=Role.objects.get(name="learner"),
         )
 
-        rv = self.client.post(reverse('all_trainees'), data, follow=True)
+        rv = self.client.post(reverse("all_trainees"), data, follow=True)
 
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainees')
-        msg = 'Successfully changed progress of all selected trainees.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainees")
+        msg = "Successfully changed progress of all selected trainees."
         self.assertContains(rv, msg)
-        got = set(TrainingProgress.objects.values_list(
-            'trainee', 'requirement', 'state', 'evaluated_by'))
+        got = set(
+            TrainingProgress.objects.values_list(
+                "trainee", "requirement", "state", "evaluated_by"
+            )
+        )
         expected = {
-            (self.spiderman.pk, self.discussion.pk, 'n', None),
-            (self.spiderman.pk, self.discussion.pk, 'f', self.admin.pk),
-            (self.ironman.pk, self.discussion.pk, 'f', self.admin.pk),
+            (self.spiderman.pk, self.discussion.pk, "n", None),
+            (self.spiderman.pk, self.discussion.pk, "f", self.admin.pk),
+            (self.ironman.pk, self.discussion.pk, "f", self.admin.pk),
         }
         self.assertEqual(got, expected)
 
     def test_bulk_discard_progress(self):
         spiderman_progress = TrainingProgress.objects.create(
-            trainee=self.spiderman, requirement=self.discussion, state='n')
+            trainee=self.spiderman, requirement=self.discussion, state="n"
+        )
         ironman_progress = TrainingProgress.objects.create(
-            trainee=self.ironman, requirement=self.discussion, state='n')
+            trainee=self.ironman, requirement=self.discussion, state="n"
+        )
         blackwidow_progress = TrainingProgress.objects.create(
-            trainee=self.blackwidow, requirement=self.discussion, state='n')
+            trainee=self.blackwidow, requirement=self.discussion, state="n"
+        )
         data = {
-            'trainees': [self.spiderman.pk, self.ironman.pk],
-            'discard': '',
+            "trainees": [self.spiderman.pk, self.ironman.pk],
+            "discard": "",
         }
-        rv = self.client.post(reverse('all_trainees'), data, follow=True)
+        rv = self.client.post(reverse("all_trainees"), data, follow=True)
 
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainees')
-        msg = 'Successfully discarded progress of all selected trainees.'
+        self.assertEqual(rv.resolver_match.view_name, "all_trainees")
+        msg = "Successfully discarded progress of all selected trainees."
         self.assertContains(rv, msg)
         spiderman_progress.refresh_from_db()
         self.assertTrue(spiderman_progress.discarded)
@@ -109,171 +116,184 @@ class TestFilterTraineesByInstructorStatus(TestBase):
         pass
 
     def _setUpTrainingRequirements(self):
-        self.swc_demo = TrainingRequirement.objects.get(name='SWC Demo')
-        self.swc_homework = TrainingRequirement.objects.get(name='SWC Homework')
-        self.dc_demo = TrainingRequirement.objects.get(name='DC Demo')
-        self.dc_homework = TrainingRequirement.objects.get(name='DC Homework')
-        self.lc_demo = TrainingRequirement.objects.get(name='LC Demo')
-        self.lc_homework = TrainingRequirement.objects.get(name='LC Homework')
-        self.discussion = TrainingRequirement.objects.get(name='Discussion')
-        self.training = TrainingRequirement.objects.get(name='Training')
+        self.swc_demo = TrainingRequirement.objects.get(name="SWC Demo")
+        self.swc_homework = TrainingRequirement.objects.get(name="SWC Homework")
+        self.dc_demo = TrainingRequirement.objects.get(name="DC Demo")
+        self.dc_homework = TrainingRequirement.objects.get(name="DC Homework")
+        self.lc_demo = TrainingRequirement.objects.get(name="LC Demo")
+        self.lc_homework = TrainingRequirement.objects.get(name="LC Homework")
+        self.discussion = TrainingRequirement.objects.get(name="Discussion")
+        self.training = TrainingRequirement.objects.get(name="Training")
 
     def _setUpInstructors(self):
         # prepare data
 
         # 1 SWC/DC/LC instructor
         self.instructor1 = Person.objects.create(
-            personal='Instructor1', family='Instructor1',
-            email='instructor1@example.org',
-            username='instructor1_instructor1',
+            personal="Instructor1",
+            family="Instructor1",
+            email="instructor1@example.org",
+            username="instructor1_instructor1",
         )
-        Award.objects.create(person=self.instructor1,
-                             badge=self.swc_instructor,
-                             awarded=date(2014, 1, 1))
+        Award.objects.create(
+            person=self.instructor1, badge=self.swc_instructor, awarded=date(2014, 1, 1)
+        )
         self.instructor2 = Person.objects.create(
-            personal='Instructor2', family='Instructor2',
-            email='instructor2@example.org',
-            username='instructor2_instructor2',
+            personal="Instructor2",
+            family="Instructor2",
+            email="instructor2@example.org",
+            username="instructor2_instructor2",
         )
-        Award.objects.create(person=self.instructor2,
-                             badge=self.dc_instructor,
-                             awarded=date(2014, 1, 1))
+        Award.objects.create(
+            person=self.instructor2, badge=self.dc_instructor, awarded=date(2014, 1, 1)
+        )
         self.instructor3 = Person.objects.create(
-            personal='Instructor3', family='Instructor3',
-            email='instructor3@example.org',
-            username='instructor3_instructor3',
+            personal="Instructor3",
+            family="Instructor3",
+            email="instructor3@example.org",
+            username="instructor3_instructor3",
         )
-        Award.objects.create(person=self.instructor3,
-                             badge=self.lc_instructor,
-                             awarded=date(2014, 1, 1))
+        Award.objects.create(
+            person=self.instructor3, badge=self.lc_instructor, awarded=date(2014, 1, 1)
+        )
 
         # 1 combined instructor (SWC-DC-LC)
         self.instructor4 = Person.objects.create(
-            personal='Instructor4', family='Instructor4',
-            email='instructor4@example.org',
-            username='instructor4_instructor4',
+            personal="Instructor4",
+            family="Instructor4",
+            email="instructor4@example.org",
+            username="instructor4_instructor4",
         )
-        Award.objects.create(person=self.instructor4,
-                             badge=self.swc_instructor,
-                             awarded=date(2014, 1, 1))
-        Award.objects.create(person=self.instructor4,
-                             badge=self.dc_instructor,
-                             awarded=date(2014, 1, 1))
-        Award.objects.create(person=self.instructor4,
-                             badge=self.lc_instructor,
-                             awarded=date(2014, 1, 1))
+        Award.objects.create(
+            person=self.instructor4, badge=self.swc_instructor, awarded=date(2014, 1, 1)
+        )
+        Award.objects.create(
+            person=self.instructor4, badge=self.dc_instructor, awarded=date(2014, 1, 1)
+        )
+        Award.objects.create(
+            person=self.instructor4, badge=self.lc_instructor, awarded=date(2014, 1, 1)
+        )
 
         # 1 eligible trainee with no instructor badges
         self.trainee1 = Person.objects.create(
-            personal='Trainee1', family='Trainee1',
-            email='trainee1@example.org',
-            username='trainee1_trainee1',
+            personal="Trainee1",
+            family="Trainee1",
+            email="trainee1@example.org",
+            username="trainee1_trainee1",
         )
-        TrainingProgress.objects.bulk_create([
-            TrainingProgress(
-                trainee=self.trainee1,
-                evaluated_by=None,
-                requirement=self.training,
-                state='p',  # passed
-            ),
-            TrainingProgress(
-                trainee=self.trainee1,
-                evaluated_by=None,
-                requirement=self.discussion,
-                state='p',
-            ),
-            TrainingProgress(
-                trainee=self.trainee1,
-                evaluated_by=None,
-                requirement=self.swc_homework,
-                state='p',
-            ),
-            TrainingProgress(
-                trainee=self.trainee1,
-                evaluated_by=None,
-                requirement=self.dc_homework,
-                state='p',
-            ),
-            TrainingProgress(
-                trainee=self.trainee1,
-                evaluated_by=None,
-                requirement=self.lc_demo,
-                state='p',
-            ),
-        ])
+        TrainingProgress.objects.bulk_create(
+            [
+                TrainingProgress(
+                    trainee=self.trainee1,
+                    evaluated_by=None,
+                    requirement=self.training,
+                    state="p",  # passed
+                ),
+                TrainingProgress(
+                    trainee=self.trainee1,
+                    evaluated_by=None,
+                    requirement=self.discussion,
+                    state="p",
+                ),
+                TrainingProgress(
+                    trainee=self.trainee1,
+                    evaluated_by=None,
+                    requirement=self.swc_homework,
+                    state="p",
+                ),
+                TrainingProgress(
+                    trainee=self.trainee1,
+                    evaluated_by=None,
+                    requirement=self.dc_homework,
+                    state="p",
+                ),
+                TrainingProgress(
+                    trainee=self.trainee1,
+                    evaluated_by=None,
+                    requirement=self.lc_demo,
+                    state="p",
+                ),
+            ]
+        )
         # 1 eligible trainee with instructor badge
         self.trainee2 = Person.objects.create(
-            personal='Trainee2', family='Trainee2',
-            email='trainee2@example.org',
-            username='trainee2_trainee2',
+            personal="Trainee2",
+            family="Trainee2",
+            email="trainee2@example.org",
+            username="trainee2_trainee2",
         )
-        TrainingProgress.objects.bulk_create([
-            TrainingProgress(
-                trainee=self.trainee2,
-                evaluated_by=None,
-                requirement=self.training,
-                state='p',  # passed
-            ),
-            TrainingProgress(
-                trainee=self.trainee2,
-                evaluated_by=None,
-                requirement=self.discussion,
-                state='p',
-            ),
-            TrainingProgress(
-                trainee=self.trainee2,
-                evaluated_by=None,
-                requirement=self.dc_homework,
-                state='p',
-            ),
-            TrainingProgress(
-                trainee=self.trainee2,
-                evaluated_by=None,
-                requirement=self.swc_demo,
-                state='p',
-            ),
-            TrainingProgress(
-                trainee=self.trainee2,
-                evaluated_by=None,
-                requirement=self.lc_demo,
-                state='p',
-            ),
-        ])
-        Award.objects.create(person=self.trainee2,
-                             badge=self.lc_instructor,
-                             awarded=date(2014, 1, 1))
+        TrainingProgress.objects.bulk_create(
+            [
+                TrainingProgress(
+                    trainee=self.trainee2,
+                    evaluated_by=None,
+                    requirement=self.training,
+                    state="p",  # passed
+                ),
+                TrainingProgress(
+                    trainee=self.trainee2,
+                    evaluated_by=None,
+                    requirement=self.discussion,
+                    state="p",
+                ),
+                TrainingProgress(
+                    trainee=self.trainee2,
+                    evaluated_by=None,
+                    requirement=self.dc_homework,
+                    state="p",
+                ),
+                TrainingProgress(
+                    trainee=self.trainee2,
+                    evaluated_by=None,
+                    requirement=self.swc_demo,
+                    state="p",
+                ),
+                TrainingProgress(
+                    trainee=self.trainee2,
+                    evaluated_by=None,
+                    requirement=self.lc_demo,
+                    state="p",
+                ),
+            ]
+        )
+        Award.objects.create(
+            person=self.trainee2, badge=self.lc_instructor, awarded=date(2014, 1, 1)
+        )
         # 1 non-eligible trainee
         self.trainee3 = Person.objects.create(
-            personal='Trainee3', family='Trainee3',
-            email='trainee3@example.org',
-            username='trainee3_trainee3',
+            personal="Trainee3",
+            family="Trainee3",
+            email="trainee3@example.org",
+            username="trainee3_trainee3",
         )
-        TrainingProgress.objects.bulk_create([
-            TrainingProgress(
-                trainee=self.trainee3,
-                evaluated_by=None,
-                requirement=self.training,
-                state='p',  # passed
-            ),
-            TrainingProgress(
-                trainee=self.trainee3,
-                evaluated_by=None,
-                requirement=self.discussion,
-                state='f',  # failed
-            ),
-            TrainingProgress(
-                trainee=self.trainee3,
-                evaluated_by=None,
-                requirement=self.lc_homework,
-                state='p',
-            ),
-            TrainingProgress(
-                trainee=self.trainee3,
-                evaluated_by=None,
-                requirement=self.lc_demo,
-                state='p',
-            ),
-        ])
+        TrainingProgress.objects.bulk_create(
+            [
+                TrainingProgress(
+                    trainee=self.trainee3,
+                    evaluated_by=None,
+                    requirement=self.training,
+                    state="p",  # passed
+                ),
+                TrainingProgress(
+                    trainee=self.trainee3,
+                    evaluated_by=None,
+                    requirement=self.discussion,
+                    state="f",  # failed
+                ),
+                TrainingProgress(
+                    trainee=self.trainee3,
+                    evaluated_by=None,
+                    requirement=self.lc_homework,
+                    state="p",
+                ),
+                TrainingProgress(
+                    trainee=self.trainee3,
+                    evaluated_by=None,
+                    requirement=self.lc_demo,
+                    state="p",
+                ),
+            ]
+        )
 
     def setUp(self):
         self._setUpTrainingRequirements()
@@ -282,62 +302,65 @@ class TestFilterTraineesByInstructorStatus(TestBase):
         # `filter_trainees_by_instructor_status` takes 3 parameters (queryset,
         # name and choice), but only 1 is used for tests (choice)
         self.queryset = all_trainees_queryset()
-        self.filter = partial(filter_trainees_by_instructor_status,
-                              queryset=self.queryset,
-                              name='')
+        self.filter = partial(
+            filter_trainees_by_instructor_status, queryset=self.queryset, name=""
+        )
 
     def test_no_choice(self):
         # result should be the same as original queryset
-        rv = self.filter(choice='')
+        rv = self.filter(choice="")
         self.assertEqual(rv, self.queryset)
-        self.assertQuerysetEqual(rv, list(self.queryset),
-                                 transform=lambda x: x)
+        self.assertQuerysetEqual(rv, list(self.queryset), transform=lambda x: x)
 
     def test_all_instructors(self):
         # only instructors who have all 3 badges should be returned
-        rv = self.filter(choice='all')
+        rv = self.filter(choice="all")
         values = [self.instructor4]
         self.assertQuerysetEqual(rv, values, transform=lambda x: x)
 
     def test_any_instructors(self):
         # any instructor should be returned
-        rv = self.filter(choice='any')
-        values = [self.instructor1, self.instructor2, self.instructor3,
-                  self.instructor4]
+        rv = self.filter(choice="any")
+        values = [
+            self.instructor1,
+            self.instructor2,
+            self.instructor3,
+            self.instructor4,
+        ]
         self.assertQuerysetEqual(rv, values, transform=lambda x: x)
 
     def test_swc_instructors(self):
         # only SWC instructors should be returned
-        rv = self.filter(choice='swc')
+        rv = self.filter(choice="swc")
         values = [self.instructor1, self.instructor4]
         self.assertQuerysetEqual(rv, values, transform=lambda x: x)
 
     def test_dc_instructors(self):
         # only DC instructors should be returned
-        rv = self.filter(choice='dc')
+        rv = self.filter(choice="dc")
         values = [self.instructor2, self.instructor4]
         self.assertQuerysetEqual(rv, values, transform=lambda x: x)
 
     def test_lc_instructors(self):
         # only LC instructors should be returned
-        rv = self.filter(choice='lc')
+        rv = self.filter(choice="lc")
         values = [self.instructor3, self.instructor4]
         self.assertQuerysetEqual(rv, values, transform=lambda x: x)
 
     def test_eligible_trainees(self):
         # only 1 eligible trainee should be returned
-        rv = self.filter(choice='eligible')
+        rv = self.filter(choice="eligible")
         values = [self.trainee1]
         self.assertQuerysetEqual(rv, values, transform=lambda x: x)
 
     def test_eligibility_query(self):
         # check if eligibility query works correctly
         self.assertEqual(Person.objects.all().count(), 7)
-        rv = all_trainees_queryset().order_by('pk')
+        rv = all_trainees_queryset().order_by("pk")
         conditions_per_person = [
             # self.instructor1
             dict(
-                username='instructor1_instructor1',
+                username="instructor1_instructor1",
                 is_swc_instructor=1,
                 is_dc_instructor=0,
                 is_lc_instructor=0,
@@ -346,7 +369,7 @@ class TestFilterTraineesByInstructorStatus(TestBase):
             ),
             # self.instructor2
             dict(
-                username='instructor2_instructor2',
+                username="instructor2_instructor2",
                 is_swc_instructor=0,
                 is_dc_instructor=1,
                 is_lc_instructor=0,
@@ -355,7 +378,7 @@ class TestFilterTraineesByInstructorStatus(TestBase):
             ),
             # self.instructor3
             dict(
-                username='instructor3_instructor3',
+                username="instructor3_instructor3",
                 is_swc_instructor=0,
                 is_dc_instructor=0,
                 is_lc_instructor=1,
@@ -364,7 +387,7 @@ class TestFilterTraineesByInstructorStatus(TestBase):
             ),
             # self.instructor4
             dict(
-                username='instructor4_instructor4',
+                username="instructor4_instructor4",
                 is_swc_instructor=1,
                 is_dc_instructor=1,
                 is_lc_instructor=1,
@@ -373,7 +396,7 @@ class TestFilterTraineesByInstructorStatus(TestBase):
             ),
             # self.trainee1
             dict(
-                username='trainee1_trainee1',
+                username="trainee1_trainee1",
                 is_swc_instructor=0,
                 is_dc_instructor=0,
                 is_lc_instructor=0,
@@ -392,7 +415,7 @@ class TestFilterTraineesByInstructorStatus(TestBase):
             ),
             # self.trainee2
             dict(
-                username='trainee2_trainee2',
+                username="trainee2_trainee2",
                 is_swc_instructor=0,
                 is_dc_instructor=0,
                 # no idea why this is counting this way, but
@@ -413,7 +436,7 @@ class TestFilterTraineesByInstructorStatus(TestBase):
             ),
             # self.trainee3
             dict(
-                username='trainee3_trainee3',
+                username="trainee3_trainee3",
                 is_swc_instructor=0,
                 is_dc_instructor=0,
                 is_lc_instructor=0,
@@ -434,11 +457,13 @@ class TestFilterTraineesByInstructorStatus(TestBase):
         for person, conditions in zip(rv, conditions_per_person):
             for k, v in conditions.items():
                 self.assertEqual(
-                    getattr(person, k), v,
-                    f"{person.username} attr {k} doesn't have value {v}")
+                    getattr(person, k),
+                    v,
+                    f"{person.username} attr {k} doesn't have value {v}",
+                )
 
     def test_no_instructors(self):
         # only non-instructors should be returned
-        rv = self.filter(choice='no')
+        rv = self.filter(choice="no")
         values = [self.trainee1, self.trainee3]
         self.assertQuerysetEqual(rv, values, transform=lambda x: x)

--- a/amy/trainings/tests/test_training_progress.py
+++ b/amy/trainings/tests/test_training_progress.py
@@ -25,120 +25,142 @@ class TestTrainingProgressValidation(TestBase):
         self._setUpNonInstructors()
 
         self.requirement = TrainingRequirement.objects.create(
-            name='Discussion', url_required=False, event_required=False)
+            name="Discussion", url_required=False, event_required=False
+        )
         self.url_required = TrainingRequirement.objects.create(
-            name='SWC Homework', url_required=True, event_required=False)
+            name="SWC Homework", url_required=True, event_required=False
+        )
         self.event_required = TrainingRequirement.objects.create(
-            name='Training', url_required=False, event_required=True)
+            name="Training", url_required=False, event_required=True
+        )
 
     def test_url_is_required(self):
-        p1 = TrainingProgress.objects.create(requirement=self.requirement,
-                                             trainee=self.admin,
-                                             evaluated_by=self.admin)
-        p2 = TrainingProgress.objects.create(requirement=self.url_required,
-                                             trainee=self.admin,
-                                             evaluated_by=self.admin)
+        p1 = TrainingProgress.objects.create(
+            requirement=self.requirement, trainee=self.admin, evaluated_by=self.admin
+        )
+        p2 = TrainingProgress.objects.create(
+            requirement=self.url_required, trainee=self.admin, evaluated_by=self.admin
+        )
         p1.full_clean()
         with self.assertRaises(ValidationError):
             p2.full_clean()
 
     def test_url_must_be_blank(self):
-        p1 = TrainingProgress.objects.create(requirement=self.requirement,
-                                             trainee=self.admin,
-                                             evaluated_by=self.admin,
-                                             url='http://example.com')
-        p2 = TrainingProgress.objects.create(requirement=self.url_required,
-                                             trainee=self.admin,
-                                             evaluated_by=self.admin,
-                                             url='http://example.com')
+        p1 = TrainingProgress.objects.create(
+            requirement=self.requirement,
+            trainee=self.admin,
+            evaluated_by=self.admin,
+            url="http://example.com",
+        )
+        p2 = TrainingProgress.objects.create(
+            requirement=self.url_required,
+            trainee=self.admin,
+            evaluated_by=self.admin,
+            url="http://example.com",
+        )
         with self.assertRaises(ValidationError):
             p1.full_clean()
         p2.full_clean()
 
     def test_event_is_required(self):
-        p1 = TrainingProgress.objects.create(requirement=self.requirement,
-                                             trainee=self.admin,
-                                             evaluated_by=self.admin)
-        p2 = TrainingProgress.objects.create(requirement=self.event_required,
-                                             trainee=self.admin,
-                                             evaluated_by=self.admin)
+        p1 = TrainingProgress.objects.create(
+            requirement=self.requirement, trainee=self.admin, evaluated_by=self.admin
+        )
+        p2 = TrainingProgress.objects.create(
+            requirement=self.event_required, trainee=self.admin, evaluated_by=self.admin
+        )
         p1.full_clean()
         with self.assertRaises(ValidationError):
             p2.full_clean()
 
     def test_event_must_be_blank(self):
-        org = Organization.objects.create(domain='example.com',
-                                          fullname='Test Organization')
-        ttt, _ = Tag.objects.get_or_create(name='TTT')
-        event = Event.objects.create(slug='ttt', host=org)
+        org = Organization.objects.create(
+            domain="example.com", fullname="Test Organization"
+        )
+        ttt, _ = Tag.objects.get_or_create(name="TTT")
+        event = Event.objects.create(slug="ttt", host=org)
         event.tags.add(ttt)
-        p1 = TrainingProgress.objects.create(requirement=self.requirement,
-                                             trainee=self.admin,
-                                             evaluated_by=self.admin,
-                                             event=event)
-        p2 = TrainingProgress.objects.create(requirement=self.event_required,
-                                             trainee=self.admin,
-                                             evaluated_by=self.admin,
-                                             event=event)
+        p1 = TrainingProgress.objects.create(
+            requirement=self.requirement,
+            trainee=self.admin,
+            evaluated_by=self.admin,
+            event=event,
+        )
+        p2 = TrainingProgress.objects.create(
+            requirement=self.event_required,
+            trainee=self.admin,
+            evaluated_by=self.admin,
+            event=event,
+        )
         with self.assertRaises(ValidationError):
             p1.full_clean()
         p2.full_clean()
 
     def test_evaluated_progress_may_have_mentor_or_examiner_associated(self):
-        p1 = TrainingProgress.objects.create(requirement=self.requirement,
-                                             trainee=self.admin, state='p',
-                                             evaluated_by=self.admin)
-        p2 = TrainingProgress.objects.create(requirement=self.requirement,
-                                             trainee=self.admin, state='p',
-                                             evaluated_by=None)
+        p1 = TrainingProgress.objects.create(
+            requirement=self.requirement,
+            trainee=self.admin,
+            state="p",
+            evaluated_by=self.admin,
+        )
+        p2 = TrainingProgress.objects.create(
+            requirement=self.requirement,
+            trainee=self.admin,
+            state="p",
+            evaluated_by=None,
+        )
         p1.full_clean()
         p2.full_clean()
 
     def test_unevaluated_progress_may_have_mentor_or_examiner_associated(self):
-        p1 = TrainingProgress.objects.create(requirement=self.requirement,
-                                             trainee=self.admin, state='n',
-                                             evaluated_by=self.admin)
-        p2 = TrainingProgress.objects.create(requirement=self.requirement,
-                                             trainee=self.admin, state='n',
-                                             evaluated_by=None)
+        p1 = TrainingProgress.objects.create(
+            requirement=self.requirement,
+            trainee=self.admin,
+            state="n",
+            evaluated_by=self.admin,
+        )
+        p2 = TrainingProgress.objects.create(
+            requirement=self.requirement,
+            trainee=self.admin,
+            state="n",
+            evaluated_by=None,
+        )
         p1.full_clean()
         p2.full_clean()
 
     def test_form_invalid_if_trainee_has_no_training_task(self):
         data = {
-            'requirement': self.requirement.pk,
-            'state': 'p',
-            'evaluated_by': self.admin.pk,
-            'trainee': self.ironman.pk,
+            "requirement": self.requirement.pk,
+            "state": "p",
+            "evaluated_by": self.admin.pk,
+            "trainee": self.ironman.pk,
         }
         form = TrainingProgressForm(data)
         self.assertEqual(form.is_valid(), False)
-        self.assertIn("not possible to add training progress",
-                      form.non_field_errors()[0])
+        self.assertIn(
+            "not possible to add training progress", form.non_field_errors()[0]
+        )
 
 
 class TestProgressLabelTemplateTag(TestBase):
     def test_passed(self):
-        self._test(state='p', discarded=False, expected='badge badge-success')
+        self._test(state="p", discarded=False, expected="badge badge-success")
 
     def test_not_evaluated_yet(self):
-        self._test(state='n', discarded=False, expected='badge badge-warning')
+        self._test(state="n", discarded=False, expected="badge badge-warning")
 
     def test_failed(self):
-        self._test(state='f', discarded=False, expected='badge badge-danger')
+        self._test(state="f", discarded=False, expected="badge badge-danger")
 
     def test_discarded(self):
-        self._test(state='p', discarded=True, expected='badge badge-dark')
-        self._test(state='n', discarded=True, expected='badge badge-dark')
-        self._test(state='f', discarded=True, expected='badge badge-dark')
+        self._test(state="p", discarded=True, expected="badge badge-dark")
+        self._test(state="n", discarded=True, expected="badge badge-dark")
+        self._test(state="f", discarded=True, expected="badge badge-dark")
 
     def _test(self, state, discarded, expected):
-        template = Template(
-            r'{% load training_progress %}'
-            r'{% progress_label p %}'
-        )
+        template = Template(r"{% load training_progress %}" r"{% progress_label p %}")
         training_progress = TrainingProgress(state=state, discarded=discarded)
-        context = Context({'p': training_progress})
+        context = Context({"p": training_progress})
         got = template.render(context)
         self.assertEqual(got, expected)
 
@@ -151,68 +173,67 @@ class TestProgressDescriptionTemplateTag(TestBase):
     def test_basic(self):
         self._test(
             progress=TrainingProgress(
-                state='p',
+                state="p",
                 evaluated_by=self.spiderman,
                 trainee=self.ironman,
                 created_at=datetime(2016, 5, 1, 16, 00),
-                requirement=TrainingRequirement(name='Discussion')
+                requirement=TrainingRequirement(name="Discussion"),
             ),
-            expected='Passed Discussion<br />'
-                     'evaluated by Peter Q. Parker<br />'
-                     'on Sunday 01 May 2016 at 16:00.',
+            expected="Passed Discussion<br />"
+            "evaluated by Peter Q. Parker<br />"
+            "on Sunday 01 May 2016 at 16:00.",
         )
 
     def test_notes(self):
         self._test(
             progress=TrainingProgress(
-                state='p',
+                state="p",
                 evaluated_by=self.spiderman,
                 trainee=self.ironman,
                 created_at=datetime(2016, 5, 1, 16, 00),
-                requirement=TrainingRequirement(name='Discussion'),
-                notes='Additional notes',
+                requirement=TrainingRequirement(name="Discussion"),
+                notes="Additional notes",
             ),
-            expected='Passed Discussion<br />'
-                     'evaluated by Peter Q. Parker<br />'
-                     'on Sunday 01 May 2016 at 16:00.<br />'
-                     'Notes: Additional notes',
+            expected="Passed Discussion<br />"
+            "evaluated by Peter Q. Parker<br />"
+            "on Sunday 01 May 2016 at 16:00.<br />"
+            "Notes: Additional notes",
         )
 
     def test_discarded(self):
         self._test(
             progress=TrainingProgress(
-                state='p',
+                state="p",
                 discarded=True,
                 evaluated_by=self.spiderman,
                 trainee=self.ironman,
                 created_at=datetime(2016, 5, 1, 16, 00),
-                requirement=TrainingRequirement(name='Discussion'),
+                requirement=TrainingRequirement(name="Discussion"),
             ),
-            expected='Discarded Passed Discussion<br />'
-                     'evaluated by Peter Q. Parker<br />'
-                     'on Sunday 01 May 2016 at 16:00.',
+            expected="Discarded Passed Discussion<br />"
+            "evaluated by Peter Q. Parker<br />"
+            "on Sunday 01 May 2016 at 16:00.",
         )
 
     def test_no_mentor_or_examiner_assigned(self):
         self._test(
             progress=TrainingProgress(
-                state='p',
+                state="p",
                 evaluated_by=None,
                 trainee=self.ironman,
                 created_at=datetime(2016, 5, 1, 16, 00),
-                requirement=TrainingRequirement(name='Discussion'),
+                requirement=TrainingRequirement(name="Discussion"),
             ),
-            expected='Passed Discussion<br />'
-                     'submitted<br />'
-                     'on Sunday 01 May 2016 at 16:00.',
+            expected="Passed Discussion<br />"
+            "submitted<br />"
+            "on Sunday 01 May 2016 at 16:00.",
         )
 
     def _test(self, progress, expected):
         template = Template(
-            '{% load training_progress %}'
-            '{% progress_description p %}'
+            "{% load training_progress %}" "{% progress_description p %}"
         )
-        context = Context({'p': progress})
+        context = Context({"p": progress})
         got = template.render(context)
         self.assertEqual(got, expected)
 
@@ -225,81 +246,78 @@ class TestCRUDViews(TestBase):
         self._setUpTags()
         self._setUpRoles()
 
-        self.requirement = TrainingRequirement.objects.create(name='Discussion')
+        self.requirement = TrainingRequirement.objects.create(name="Discussion")
         self.progress = TrainingProgress.objects.create(
             requirement=self.requirement,
-            state='p',
+            state="p",
             evaluated_by=self.admin,
             trainee=self.ironman,
         )
         self.ttt_event = Event.objects.create(
             start=datetime(2018, 7, 14),
-            slug='2018-07-14-training',
+            slug="2018-07-14-training",
             host=Organization.objects.first(),
         )
-        self.ttt_event.tags.add(Tag.objects.get(name='TTT'))
+        self.ttt_event.tags.add(Tag.objects.get(name="TTT"))
 
     def test_create_view_loads(self):
-        rv = self.client.get(reverse('trainingprogress_add'))
+        rv = self.client.get(reverse("trainingprogress_add"))
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.context['form'].initial['evaluated_by'], self.admin)
+        self.assertEqual(rv.context["form"].initial["evaluated_by"], self.admin)
 
     def test_create_view_works_with_initial_trainee(self):
-        rv = self.client.get(reverse('trainingprogress_add'), {
-            'trainee': self.ironman.pk
-        })
+        rv = self.client.get(
+            reverse("trainingprogress_add"), {"trainee": self.ironman.pk}
+        )
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.context['form'].initial['evaluated_by'], self.admin)
-        self.assertEqual(int(rv.context['form'].initial['trainee']), self.ironman.pk)
+        self.assertEqual(rv.context["form"].initial["evaluated_by"], self.admin)
+        self.assertEqual(int(rv.context["form"].initial["trainee"]), self.ironman.pk)
 
     def test_create_view_works(self):
         data = {
-            'requirement': self.requirement.pk,
-            'state': 'p',
-            'evaluated_by': self.admin.pk,
-            'trainee': self.ironman.pk,
+            "requirement": self.requirement.pk,
+            "state": "p",
+            "evaluated_by": self.admin.pk,
+            "trainee": self.ironman.pk,
         }
 
         # in order to add training progress, the trainee needs to have
         # a training task
         self.ironman.task_set.create(
             event=self.ttt_event,
-            role=Role.objects.get(name='learner'),
+            role=Role.objects.get(name="learner"),
         )
 
-        rv = self.client.post(reverse('trainingprogress_add'), data,
-                              follow=True)
+        rv = self.client.post(reverse("trainingprogress_add"), data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'trainingprogress_edit')
+        self.assertEqual(rv.resolver_match.view_name, "trainingprogress_edit")
         self.assertEqual(len(TrainingProgress.objects.all()), 2)
 
     def test_edit_view_loads(self):
-        rv = self.client.get(reverse('trainingprogress_edit',
-                                     args=[self.progress.pk]))
+        rv = self.client.get(reverse("trainingprogress_edit", args=[self.progress.pk]))
         self.assertEqual(rv.status_code, 200)
 
     def test_delete_view_get_request_not_allowed(self):
-        rv = self.client.get(reverse('trainingprogress_delete',
-                                     args=[self.progress.pk]))
+        rv = self.client.get(
+            reverse("trainingprogress_delete", args=[self.progress.pk])
+        )
         self.assertEqual(rv.status_code, 405)
 
     def test_delete_view_works(self):
-        rv = self.client.post(reverse('trainingprogress_delete',
-                                      args=[self.progress.pk]),
-                              follow=True)
+        rv = self.client.post(
+            reverse("trainingprogress_delete", args=[self.progress.pk]), follow=True
+        )
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'all_trainees')
+        self.assertEqual(rv.resolver_match.view_name, "all_trainees")
         self.assertEqual(set(TrainingProgress.objects.all()), set())
 
     def test_delete_trainingprogress_from_edit_view(self):
         """Regression test for issue #1085."""
         trainingprogress_edit = self.app.get(
-            reverse('trainingprogress_edit', args=[self.progress.pk]),
-            user='admin'
+            reverse("trainingprogress_edit", args=[self.progress.pk]), user="admin"
         )
         self.assertRedirects(
-            trainingprogress_edit.forms['delete-form'].submit(),
-            reverse('all_trainees')
+            trainingprogress_edit.forms["delete-form"].submit(), reverse("all_trainees")
         )
         with self.assertRaises(TrainingProgress.DoesNotExist):
             self.progress.refresh_from_db()

--- a/amy/trainings/views.py
+++ b/amy/trainings/views.py
@@ -43,93 +43,106 @@ from workshops.util import (
 
 
 class AllTrainings(OnlyForAdminsMixin, AMYListView):
-    context_object_name = 'all_trainings'
-    template_name = 'trainings/all_trainings.html'
-    queryset = Event.objects.filter(tags__name='TTT').annotate(
-        trainees=Count(Case(When(task__role__name='learner',
-                                 then=F('task__person__id')),
-                            output_field=IntegerField()),
-                       distinct=True),
-        finished=Count(Case(When(task__role__name='learner',
-                                 task__person__badges__in=Badge.objects.instructor_badges(),
-                                 then=F('task__person__id')),
-                            output_field=IntegerField()),
-                       distinct=True),
-    ).exclude(trainees=0).order_by('-start')
-    title = 'All Instructor Trainings'
+    context_object_name = "all_trainings"
+    template_name = "trainings/all_trainings.html"
+    queryset = (
+        Event.objects.filter(tags__name="TTT")
+        .annotate(
+            trainees=Count(
+                Case(
+                    When(task__role__name="learner", then=F("task__person__id")),
+                    output_field=IntegerField(),
+                ),
+                distinct=True,
+            ),
+            finished=Count(
+                Case(
+                    When(
+                        task__role__name="learner",
+                        task__person__badges__in=Badge.objects.instructor_badges(),
+                        then=F("task__person__id"),
+                    ),
+                    output_field=IntegerField(),
+                ),
+                distinct=True,
+            ),
+        )
+        .exclude(trainees=0)
+        .order_by("-start")
+    )
+    title = "All Instructor Trainings"
 
 
 # ------------------------------------------------------------
 # Instructor Training related views
 
-class TrainingProgressCreate(RedirectSupportMixin,
-                             PrepopulationSupportMixin,
-                             OnlyForAdminsMixin,
-                             AMYCreateView):
+
+class TrainingProgressCreate(
+    RedirectSupportMixin, PrepopulationSupportMixin, OnlyForAdminsMixin, AMYCreateView
+):
     model = TrainingProgress
     form_class = TrainingProgressForm
-    populate_fields = ['trainee']
+    populate_fields = ["trainee"]
 
     def get_initial(self):
         initial = super().get_initial()
-        initial['evaluated_by'] = self.request.user
+        initial["evaluated_by"] = self.request.user
         return initial
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['form'].helper = context['form'].create_helper
+        context["form"].helper = context["form"].create_helper
         return context
 
 
-class TrainingProgressUpdate(RedirectSupportMixin, OnlyForAdminsMixin,
-                             AMYUpdateView):
+class TrainingProgressUpdate(RedirectSupportMixin, OnlyForAdminsMixin, AMYUpdateView):
     model = TrainingProgress
     form_class = TrainingProgressForm
-    template_name = 'trainings/trainingprogress_form.html'
+    template_name = "trainings/trainingprogress_form.html"
 
 
-class TrainingProgressDelete(RedirectSupportMixin, OnlyForAdminsMixin,
-                             AMYDeleteView):
+class TrainingProgressDelete(RedirectSupportMixin, OnlyForAdminsMixin, AMYDeleteView):
     model = TrainingProgress
-    success_url = reverse_lazy('all_trainees')
+    success_url = reverse_lazy("all_trainees")
 
 
 def all_trainees_queryset():
     def has_badge(badge):
-        return Sum(Case(When(badges__name=badge, then=1),
-                        default=0,
-                        output_field=IntegerField()))
+        return Sum(
+            Case(
+                When(badges__name=badge, then=1), default=0, output_field=IntegerField()
+            )
+        )
 
     return (
-        Person.objects
-        .annotate_with_instructor_eligibility()
+        Person.objects.annotate_with_instructor_eligibility()
         .prefetch_related(
             Prefetch(
-                'task_set',
-                to_attr='training_tasks',
-                queryset=Task.objects.filter(role__name='learner',
-                                             event__tags__name='TTT')
+                "task_set",
+                to_attr="training_tasks",
+                queryset=Task.objects.filter(
+                    role__name="learner", event__tags__name="TTT"
+                ),
             ),
-            'training_tasks__event',
-            'trainingrequest_set',
-            'trainingprogress_set',
-            'trainingprogress_set__requirement',
-            'trainingprogress_set__evaluated_by',
-        ).annotate(
-            is_swc_instructor=has_badge('swc-instructor'),
-            is_dc_instructor=has_badge('dc-instructor'),
-            is_lc_instructor=has_badge('lc-instructor'),
+            "training_tasks__event",
+            "trainingrequest_set",
+            "trainingprogress_set",
+            "trainingprogress_set__requirement",
+            "trainingprogress_set__evaluated_by",
+        )
+        .annotate(
+            is_swc_instructor=has_badge("swc-instructor"),
+            is_dc_instructor=has_badge("dc-instructor"),
+            is_lc_instructor=has_badge("lc-instructor"),
             is_instructor=Sum(
                 Case(
-                    When(
-                        badges__name__in=Badge.INSTRUCTOR_BADGES,
-                        then=1
-                    ),
+                    When(badges__name__in=Badge.INSTRUCTOR_BADGES, then=1),
                     default=0,
-                    output_field=IntegerField()
+                    output_field=IntegerField(),
                 )
             ),
-        ).order_by('family', 'personal')
+        )
+        .order_by("family", "personal")
     )
 
 
@@ -141,51 +154,52 @@ def all_trainees(request):
     )
     trainees = get_pagination_items(request, filter.qs)
 
-    if request.method == 'POST' and 'discard' in request.POST:
+    if request.method == "POST" and "discard" in request.POST:
         # Bulk discard progress of selected trainees
         form = BulkAddTrainingProgressForm()
         discard_form = BulkDiscardProgressesForm(request.POST)
         if discard_form.is_valid():
-            for trainee in discard_form.cleaned_data['trainees']:
-                TrainingProgress.objects.filter(trainee=trainee)\
-                                        .update(discarded=True)
-            messages.success(request, 'Successfully discarded progress of '
-                                      'all selected trainees.')
+            for trainee in discard_form.cleaned_data["trainees"]:
+                TrainingProgress.objects.filter(trainee=trainee).update(discarded=True)
+            messages.success(
+                request, "Successfully discarded progress of " "all selected trainees."
+            )
 
             # Raw uri contains GET parameters from django filters. We use it
             # to preserve filter settings.
             return redirect(request.get_raw_uri())
 
-    elif request.method == 'POST' and 'submit' in request.POST:
+    elif request.method == "POST" and "submit" in request.POST:
         # Bulk add progress to selected trainees
         instance = TrainingProgress(evaluated_by=request.user)
         form = BulkAddTrainingProgressForm(request.POST, instance=instance)
         discard_form = BulkDiscardProgressesForm()
         if form.is_valid():
-            for trainee in form.cleaned_data['trainees']:
+            for trainee in form.cleaned_data["trainees"]:
                 TrainingProgress.objects.create(
                     trainee=trainee,
                     evaluated_by=request.user,
-                    requirement=form.cleaned_data['requirement'],
-                    state=form.cleaned_data['state'],
+                    requirement=form.cleaned_data["requirement"],
+                    state=form.cleaned_data["state"],
                     discarded=False,
-                    event=form.cleaned_data['event'],
-                    url=form.cleaned_data['url'],
-                    notes=form.cleaned_data['notes'],
+                    event=form.cleaned_data["event"],
+                    url=form.cleaned_data["url"],
+                    notes=form.cleaned_data["notes"],
                 )
-            messages.success(request, 'Successfully changed progress of '
-                                      'all selected trainees.')
+            messages.success(
+                request, "Successfully changed progress of " "all selected trainees."
+            )
 
             return redirect(request.get_raw_uri())
 
     else:  # GET request
         # If the user filters by training, we want to set initial values for
         # "requirement" and "training" fields.
-        training_id = request.GET.get('training', None) or None
+        training_id = request.GET.get("training", None) or None
         try:
             initial = {
-                'event': Event.objects.get(pk=training_id),
-                'requirement': TrainingRequirement.objects.get(name='Training')
+                "event": Event.objects.get(pk=training_id),
+                "requirement": TrainingRequirement.objects.get(name="Training"),
             }
         except Event.DoesNotExist:  # or there is no `training` GET parameter
             initial = None
@@ -193,12 +207,14 @@ def all_trainees(request):
         form = BulkAddTrainingProgressForm(initial=initial)
         discard_form = BulkDiscardProgressesForm()
 
-    context = {'title': 'Trainees',
-               'all_trainees': trainees,
-               'swc': Badge.objects.get(name='swc-instructor'),
-               'dc': Badge.objects.get(name='dc-instructor'),
-               'lc': Badge.objects.get(name='lc-instructor'),
-               'filter': filter,
-               'form': form,
-               'discard_form': discard_form}
-    return render(request, 'trainings/all_trainees.html', context)
+    context = {
+        "title": "Trainees",
+        "all_trainees": trainees,
+        "swc": Badge.objects.get(name="swc-instructor"),
+        "dc": Badge.objects.get(name="dc-instructor"),
+        "lc": Badge.objects.get(name="lc-instructor"),
+        "filter": filter,
+        "form": form,
+        "discard_form": discard_form,
+    }
+    return render(request, "trainings/all_trainees.html", context)

--- a/amy/workshops/__init__.py
+++ b/amy/workshops/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 'v2.17.0-dev'
+__version__ = "v2.17.0-dev"

--- a/amy/workshops/action_required.py
+++ b/amy/workshops/action_required.py
@@ -8,33 +8,30 @@ class PrivacyPolicy:
         self.get_response = get_response
 
     def __call__(self, request):
-        url = reverse('action_required_privacy')
+        url = reverse("action_required_privacy")
 
-        allowed_urls = [
-            reverse('logout'),
-            url
-        ]
+        allowed_urls = [reverse("logout"), url]
 
-        if 'next' in request.GET:
+        if "next" in request.GET:
             # prepare `?next` URL if it's already present (e.g. user refreshes
             # the `action_required_privacy` page)
-            next_param = request.GET['next']
+            next_param = request.GET["next"]
         else:
             # grab requested page path to use in `?next` query string
             next_param = request.path
 
         # only add `?next` if it's outside the scope of allowed URLs
         if next_param not in allowed_urls:
-            url += '?{}'.format(urlencode({'next': next_param}))
+            url += "?{}".format(urlencode({"next": next_param}))
 
         # redirect only users who didn't agree on the privacy policy
         # also don't redirect if the requested page is the page we want to
         # redirect to
         if (
-            request.path not in allowed_urls and
-            not request.user.is_anonymous and
-            hasattr(request.user, 'data_privacy_agreement') and
-            not request.user.data_privacy_agreement
+            request.path not in allowed_urls
+            and not request.user.is_anonymous
+            and hasattr(request.user, "data_privacy_agreement")
+            and not request.user.data_privacy_agreement
         ):
             return redirect(url)
         else:

--- a/amy/workshops/apps.py
+++ b/amy/workshops/apps.py
@@ -13,29 +13,29 @@ def trainingrequest_m2m_changed(sender, **kwargs):
     it was being called before M2M fields changed."""
 
     # react only on "post_add"/"post_remove", forward (not reverse) action
-    action = kwargs.get('action', '')
-    forward = not kwargs.get('reverse', True)
-    instance = kwargs.get('instance', None)
-    using = kwargs.get('using')
+    action = kwargs.get("action", "")
+    forward = not kwargs.get("reverse", True)
+    instance = kwargs.get("instance", None)
+    using = kwargs.get("using")
 
     # There's a catch - we can alter the relation from a different side, ie.
     # from KnowledgeDomain.trainingrequest_set, but it's harder to recalculate
     # because we'd have to make N recalculations. Therefore we only allow
     # `forward` direction.
-    if instance and forward and action in ['post_add', 'post_remove']:
+    if instance and forward and action in ["post_add", "post_remove"]:
         # recalculation happens in `save()` method
         instance.save(using=using)
 
 
 class WorkshopsConfig(AppConfig):
-    name = 'workshops'
-    label = 'workshops'
-    verbose_name = 'Workshops'
+    name = "workshops"
+    label = "workshops"
+    verbose_name = "Workshops"
 
     def ready(self):
         # connect m2m_changed signal for TrainingRequest.domains to calculate
         # score_auto
-        TrainingRequest = self.get_model('TrainingRequest')
+        TrainingRequest = self.get_model("TrainingRequest")
 
         m2m_changed.connect(
             trainingrequest_m2m_changed,

--- a/amy/workshops/context_processors.py
+++ b/amy/workshops/context_processors.py
@@ -2,5 +2,5 @@ from . import __version__
 
 
 def version(request):
-    data = {'amy_version': __version__}
+    data = {"amy_version": __version__}
     return data

--- a/amy/workshops/fields.py
+++ b/amy/workshops/fields.py
@@ -11,8 +11,9 @@ from django import forms
 from django.utils.safestring import mark_safe
 
 
-GHUSERNAME_MAX_LENGTH_VALIDATOR = MaxLengthValidator(39,
-    message='Maximum allowed username length is 39 characters.',
+GHUSERNAME_MAX_LENGTH_VALIDATOR = MaxLengthValidator(
+    39,
+    message="Maximum allowed username length is 39 characters.",
 )
 # according to https://stackoverflow.com/q/30281026,
 # GH username can only contain alphanumeric characters and
@@ -20,18 +21,18 @@ GHUSERNAME_MAX_LENGTH_VALIDATOR = MaxLengthValidator(39,
 # a hyphen, and can't be longer than 39 characters
 GHUSERNAME_REGEX_VALIDATOR = RegexValidator(
     # regex inspired by above StackOverflow thread
-    regex=r'^([a-zA-Z\d](?:-?[a-zA-Z\d])*)$',
-    message='This is not a valid GitHub username.',
+    regex=r"^([a-zA-Z\d](?:-?[a-zA-Z\d])*)$",
+    message="This is not a valid GitHub username.",
 )
 
 
 class NullableGithubUsernameField(models.CharField):
     def __init__(self, **kwargs):
-        kwargs.setdefault('null', True)
-        kwargs.setdefault('blank', True)
-        kwargs.setdefault('default', '')
+        kwargs.setdefault("null", True)
+        kwargs.setdefault("blank", True)
+        kwargs.setdefault("default", "")
         # max length of the GH username is 39 characters
-        kwargs.setdefault('max_length', 39)
+        kwargs.setdefault("max_length", 39)
         super().__init__(**kwargs)
 
     default_validators = [
@@ -40,14 +41,15 @@ class NullableGithubUsernameField(models.CharField):
     ]
 
 
-#------------------------------------------------------------
+# ------------------------------------------------------------
+
 
 class FakeRequiredMixin:
     def __init__(self, *args, **kwargs):
         # Intercept "fake_required" attribute that's used for marking field
         # with "*" (asterisk) even though it's not required.
         # Additionally `fake_required` doesn't trigger any validation.
-        self.fake_required = kwargs.pop('fake_required', False)
+        self.fake_required = kwargs.pop("fake_required", False)
         super().__init__(*args, **kwargs)
 
 
@@ -87,6 +89,7 @@ class RadioSelectFakeMultiple(FakeRequiredMixin, forms.RadioSelect):
     """Pretend to be a radio-select with multiple selection possible. This
     is intended to 'fool' Django into thinking that user selected 1 item on
     a multi-select item list."""
+
     allow_multiple_selected = True
 
 
@@ -99,8 +102,9 @@ class SafeModelChoiceField(SafeLabelFromInstanceMixin, forms.ModelChoiceField):
     pass
 
 
-class SafeModelMultipleChoiceField(SafeLabelFromInstanceMixin,
-                                   forms.ModelMultipleChoiceField):
+class SafeModelMultipleChoiceField(
+    SafeLabelFromInstanceMixin, forms.ModelMultipleChoiceField
+):
     pass
 
 
@@ -111,18 +115,20 @@ class CurriculumModelMultipleChoiceField(SafeModelMultipleChoiceField):
         # popover by clicking will automatically select the clicked item)
         data = (
             '<a tabindex="0" role="button" data-toggle="tooltip" '
-            'data-placement="top" title="{description}">{obj}</a>'
-            .format(obj=obj, description=obj.description)
+            'data-placement="top" title="{description}">{obj}</a>'.format(
+                obj=obj, description=obj.description
+            )
         )
         return super().label_from_instance(data)
 
 
-#------------------------------------------------------------
+# ------------------------------------------------------------
+
 
 class Select2BootstrapMixin:
     def build_attrs(self, *args, **kwargs):
         attrs = super().build_attrs(*args, **kwargs)
-        attrs.setdefault('data-theme', 'bootstrap4')
+        attrs.setdefault("data-theme", "bootstrap4")
         return attrs
 
 
@@ -131,13 +137,12 @@ class Select2NoMinimumInputLength:
         # Let's set up the minimum input length first!
         # It will overwrite `setdefault('data-minimum-input-length')` from
         # other mixins.
-        self.attrs.setdefault('data-minimum-input-length', 0)
+        self.attrs.setdefault("data-minimum-input-length", 0)
         attrs = super().build_attrs(*args, **kwargs)
         return attrs
 
 
-class Select2Widget(FakeRequiredMixin, Select2BootstrapMixin,
-                    DS2_Select2Widget):
+class Select2Widget(FakeRequiredMixin, Select2BootstrapMixin, DS2_Select2Widget):
     pass
 
 
@@ -145,18 +150,19 @@ class Select2MultipleWidget(Select2BootstrapMixin, DS2_Select2MultipleWidget):
     pass
 
 
-class ModelSelect2Widget(Select2BootstrapMixin, Select2NoMinimumInputLength,
-                         DS2_ModelSelect2Widget):
+class ModelSelect2Widget(
+    Select2BootstrapMixin, Select2NoMinimumInputLength, DS2_ModelSelect2Widget
+):
     pass
 
 
-class ModelSelect2MultipleWidget(Select2BootstrapMixin,
-                                 Select2NoMinimumInputLength,
-                                 DS2_ModelSelect2MultipleWidget):
+class ModelSelect2MultipleWidget(
+    Select2BootstrapMixin, Select2NoMinimumInputLength, DS2_ModelSelect2MultipleWidget
+):
     pass
 
 
-TAG_SEPARATOR = ';'
+TAG_SEPARATOR = ";"
 
 
 class Select2TagWidget(Select2BootstrapMixin, DS2_Select2TagWidget):
@@ -164,11 +170,11 @@ class Select2TagWidget(Select2BootstrapMixin, DS2_Select2TagWidget):
         """Select2's tag attributes. By default other token separators are
         used, but we want to use "," and ";"."""
         default_attrs = {
-            'data-minimum-input-length': 1,
-            'data-tags': 'true',
-            'data-token-separators': '[",", ";"]'
+            "data-minimum-input-length": 1,
+            "data-tags": "true",
+            "data-token-separators": '[",", ";"]',
         }
-        assert TAG_SEPARATOR in default_attrs['data-token-separators']
+        assert TAG_SEPARATOR in default_attrs["data-token-separators"]
 
         default_attrs.update(base_attrs)
         return super().build_attrs(default_attrs, extra_attrs=extra_attrs)
@@ -182,7 +188,7 @@ class Select2TagWidget(Select2BootstrapMixin, DS2_Select2TagWidget):
         except AttributeError:
             data_mutable = data
 
-        data_mutable.setdefault(name, '')
+        data_mutable.setdefault(name, "")
         values = super().value_from_datadict(data_mutable, files, name)
         return TAG_SEPARATOR.join(values)
 
@@ -196,7 +202,6 @@ class Select2TagWidget(Select2BootstrapMixin, DS2_Select2TagWidget):
 
         selected = set(values)
         subgroup = [
-            self.create_option(name, v, v, selected, i)
-            for i, v in enumerate(values)
+            self.create_option(name, v, v, selected, i) for i, v in enumerate(values)
         ]
         return [(None, subgroup, 0)]

--- a/amy/workshops/fields.py
+++ b/amy/workshops/fields.py
@@ -194,7 +194,7 @@ class Select2TagWidget(Select2BootstrapMixin, DS2_Select2TagWidget):
 
     def optgroups(self, name, value, attrs=None):
         """Example from
-        https://django-select2.readthedocs.io/en/latest/django_select2.html#django_select2.forms.Select2TagWidget"""
+        https://django-select2.readthedocs.io/en/latest/django_select2.html#django_select2.forms.Select2TagWidget"""  # noqa
         try:
             values = value[0].split(TAG_SEPARATOR)
         except (IndexError, AttributeError):

--- a/amy/workshops/filters.py
+++ b/amy/workshops/filters.py
@@ -35,14 +35,13 @@ class AllCountriesFilter(django_filters.ChoiceFilter):
     @property
     def field(self):
         qs = self.model._default_manager.distinct()
-        qs = qs.order_by(self.field_name).values_list(self.field_name,
-                                                      flat=True)
+        qs = qs.order_by(self.field_name).values_list(self.field_name, flat=True)
 
         choices = [o for o in qs if o]
         countries = Countries()
         countries.only = choices
 
-        self.extra['choices'] = list(countries)
+        self.extra["choices"] = list(countries)
         return super().field
 
 
@@ -50,14 +49,13 @@ class AllCountriesMultipleFilter(django_filters.MultipleChoiceFilter):
     @property
     def field(self):
         qs = self.model._default_manager.distinct()
-        qs = qs.order_by(self.field_name).values_list(self.field_name,
-                                                      flat=True)
+        qs = qs.order_by(self.field_name).values_list(self.field_name, flat=True)
 
         choices = [o for o in qs if o]
         countries = Countries()
         countries.only = choices
 
-        self.extra['choices'] = list(countries)
+        self.extra["choices"] = list(countries)
         return super().field
 
 
@@ -74,7 +72,7 @@ class ForeignKeyAllValuesFilter(django_filters.ChoiceFilter):
         qs1 = self.model._default_manager.distinct()
         qs1 = qs1.order_by(name).values_list(name, flat=True)
         qs2 = model.objects.filter(pk__in=qs1)
-        self.extra['choices'] = [(o.pk, str(o)) for o in qs2]
+        self.extra["choices"] = [(o.pk, str(o)) for o in qs2]
         return super().field
 
 
@@ -84,7 +82,7 @@ class EventStateFilter(django_filters.ChoiceFilter):
             value = value.value
 
         # no filtering
-        if value in ([], (), {}, None, '', 'all'):
+        if value in ([], (), {}, None, "", "all"):
             return qs
 
         # no need to check if value exists in self.extra['choices'] because
@@ -98,11 +96,11 @@ class EventStateFilter(django_filters.ChoiceFilter):
 class NamesOrderingFilter(django_filters.OrderingFilter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.extra['choices'] += [
-            ('lastname', 'Last name'),
-            ('-lastname', 'Last name (descending)'),
-            ('firstname', 'First name'),
-            ('-firstname', 'First name (descending)'),
+        self.extra["choices"] += [
+            ("lastname", "Last name"),
+            ("-lastname", "Last name (descending)"),
+            ("firstname", "First name"),
+            ("-firstname", "First name (descending)"),
         ]
 
     def filter(self, qs, value):
@@ -112,14 +110,14 @@ class NamesOrderingFilter(django_filters.OrderingFilter):
             return ordering
 
         # `value` is a list
-        if any(v in ['lastname'] for v in value):
-            return ordering.order_by('family', 'middle', 'personal')
-        elif any(v in ['-lastname'] for v in value):
-            return ordering.order_by('-family', '-middle', '-personal')
-        elif any(v in ['firstname'] for v in value):
-            return ordering.order_by('personal', 'middle', 'family')
-        elif any(v in ['-firstname'] for v in value):
-            return ordering.order_by('-personal', '-middle', '-family')
+        if any(v in ["lastname"] for v in value):
+            return ordering.order_by("family", "middle", "personal")
+        elif any(v in ["-lastname"] for v in value):
+            return ordering.order_by("-family", "-middle", "-personal")
+        elif any(v in ["firstname"] for v in value):
+            return ordering.order_by("personal", "middle", "family")
+        elif any(v in ["-firstname"] for v in value):
+            return ordering.order_by("-personal", "-middle", "-family")
 
         return ordering
 
@@ -127,7 +125,7 @@ class NamesOrderingFilter(django_filters.OrderingFilter):
 class ContinentFilter(django_filters.ChoiceFilter):
     @property
     def field(self):
-        self.extra['choices'] = Continent.objects.values_list('pk', 'name')
+        self.extra["choices"] = Continent.objects.values_list("pk", "name")
         return super().field
 
     def filter(self, qs, value):
@@ -135,14 +133,15 @@ class ContinentFilter(django_filters.ChoiceFilter):
             value = value.value
 
         # no filtering
-        if value in ([], (), {}, None, '', 'all'):
+        if value in ([], (), {}, None, "", "all"):
             return qs
 
         # filtering: qs `country` must be in the list of countries given by
         # selected continent
         return qs.filter(country__in=Continent.objects.get(pk=value).countries)
 
-#------------------------------------------------------------
+
+# ------------------------------------------------------------
 
 
 class AMYFilterSet(django_filters.FilterSet):
@@ -163,40 +162,41 @@ class StateFilterSet(django_filters.FilterSet):
 
     state = django_filters.ChoiceFilter(
         choices=StateMixin.STATE_CHOICES,
-        label='State',
+        label="State",
         widget=widgets.RadioSelect,
-        empty_label='Any',
+        empty_label="Any",
         null_label=None,
         null_value=None,
     )
 
 
-#------------------------------------------------------------
+# ------------------------------------------------------------
 
 
 class EventFilter(AMYFilterSet):
     assigned_to = ForeignKeyAllValuesFilter(Person, widget=Select2Widget)
     host = ForeignKeyAllValuesFilter(Organization, widget=Select2Widget)
-    administrator = ForeignKeyAllValuesFilter(Organization,
-                                              widget=Select2Widget)
+    administrator = ForeignKeyAllValuesFilter(Organization, widget=Select2Widget)
 
     STATUS_CHOICES = [
-        ('', 'All'),
-        ('active', 'Active'),
-        ('past_events', 'Past'),
-        ('ongoing_events', 'Ongoing'),
-        ('upcoming_events', 'Upcoming'),
-        ('unpublished_events', 'Unpublished'),
-        ('published_events', 'Published'),
-        ('metadata_changed', 'Detected changes in metadata'),
+        ("", "All"),
+        ("active", "Active"),
+        ("past_events", "Past"),
+        ("ongoing_events", "Ongoing"),
+        ("upcoming_events", "Upcoming"),
+        ("unpublished_events", "Unpublished"),
+        ("published_events", "Published"),
+        ("metadata_changed", "Detected changes in metadata"),
     ]
-    state = EventStateFilter(choices=STATUS_CHOICES, label='Status',
-                             widget=Select2Widget)
+    state = EventStateFilter(
+        choices=STATUS_CHOICES, label="Status", widget=Select2Widget
+    )
 
     tags = django_filters.ModelMultipleChoiceFilter(
-        queryset=Tag.objects.all(), label='Tags',
+        queryset=Tag.objects.all(),
+        label="Tags",
         widget=ModelSelect2MultipleWidget(
-            data_view='tag-lookup',
+            data_view="tag-lookup",
         ),
     )
 
@@ -205,22 +205,22 @@ class EventFilter(AMYFilterSet):
 
     order_by = django_filters.OrderingFilter(
         fields=(
-            'slug',
-            'start',
-            'end',
+            "slug",
+            "start",
+            "end",
         ),
     )
 
     class Meta:
         model = Event
         fields = [
-            'assigned_to',
-            'tags',
-            'host',
-            'administrator',
-            'completed',
-            'country',
-            'continent',
+            "assigned_to",
+            "tags",
+            "host",
+            "administrator",
+            "completed",
+            "country",
+            "continent",
         ]
 
 
@@ -235,125 +235,126 @@ def filter_taught_workshops(queryset, name, values):
     if not values:
         return queryset
 
-    return queryset.filter(task__role__name='instructor',
-                           task__event__tags__in=values) \
-                   .distinct()
+    return queryset.filter(
+        task__role__name="instructor", task__event__tags__in=values
+    ).distinct()
 
 
 class PersonFilter(AMYFilterSet):
     badges = django_filters.ModelMultipleChoiceFilter(
-        queryset=Badge.objects.all(), label='Badges',
+        queryset=Badge.objects.all(),
+        label="Badges",
         widget=ModelSelect2MultipleWidget(
-            data_view='badge-lookup',
+            data_view="badge-lookup",
         ),
     )
     taught_workshops = django_filters.ModelMultipleChoiceFilter(
-        queryset=Tag.objects.all(), label='Taught at workshops of type',
+        queryset=Tag.objects.all(),
+        label="Taught at workshops of type",
         method=filter_taught_workshops,
         widget=ModelSelect2MultipleWidget(
-            data_view='tag-lookup',
+            data_view="tag-lookup",
         ),
     )
 
     order_by = NamesOrderingFilter(
-        fields=(
-            'email',
-        ),
+        fields=("email",),
     )
 
     class Meta:
         model = Person
         fields = [
-            'badges', 'taught_workshops',
+            "badges",
+            "taught_workshops",
         ]
 
 
 class TaskFilter(AMYFilterSet):
     event = django_filters.ModelChoiceFilter(
         queryset=Event.objects.all(),
-        label='Event',
+        label="Event",
         widget=ModelSelect2Widget(
-            data_view='event-lookup',
+            data_view="event-lookup",
             attrs=SELECT2_SIDEBAR,
         ),
     )
 
     order_by = django_filters.OrderingFilter(
         fields=(
-            ('event__slug', 'event'),
-            ('person__family', 'person'),
-            ('role', 'role'),
+            ("event__slug", "event"),
+            ("person__family", "person"),
+            ("role", "role"),
         ),
         field_labels={
-            'event__slug': 'Event',
-            'person__family': 'Person',
-            'role': 'Role',
-        }
+            "event__slug": "Event",
+            "person__family": "Person",
+            "role": "Role",
+        },
     )
 
     class Meta:
         model = Task
         fields = [
-            'event',
+            "event",
             # can't filter on person because person's name contains 3 fields:
             # person.personal, person.middle, person.family
             # 'person',
-            'role',
+            "role",
         ]
 
 
 class AirportFilter(AMYFilterSet):
-    fullname = django_filters.CharFilter(lookup_expr='icontains')
+    fullname = django_filters.CharFilter(lookup_expr="icontains")
 
     continent = ContinentFilter(widget=Select2Widget, label="Continent")
 
     order_by = django_filters.OrderingFilter(
         fields=(
-            'iata',
-            'fullname',
+            "iata",
+            "fullname",
         ),
         field_labels={
-            'iata': 'IATA',
-            'fullname': 'Full name',
-        }
+            "iata": "IATA",
+            "fullname": "Full name",
+        },
     )
 
     class Meta:
         model = Airport
         fields = [
-            'fullname',
+            "fullname",
         ]
 
 
 class BadgeAwardsFilter(AMYFilterSet):
-    awarded_after = django_filters.DateFilter(field_name='awarded',
-                                              lookup_expr='gte')
-    awarded_before = django_filters.DateFilter(field_name='awarded',
-                                               lookup_expr='lte')
+    awarded_after = django_filters.DateFilter(field_name="awarded", lookup_expr="gte")
+    awarded_before = django_filters.DateFilter(field_name="awarded", lookup_expr="lte")
     event = django_filters.ModelChoiceFilter(
         queryset=Event.objects.all(),
-        label='Event',
+        label="Event",
         widget=ModelSelect2Widget(
-            data_view='event-lookup',
+            data_view="event-lookup",
             attrs=SELECT2_SIDEBAR,
         ),
     )
 
     order_by = django_filters.OrderingFilter(
         fields=(
-            'awarded',
-            'person__family',
+            "awarded",
+            "person__family",
         ),
         field_labels={
-            'awarded': 'Awarded date',
-            'person__family': 'Person',
-        }
+            "awarded": "Awarded date",
+            "person__family": "Person",
+        },
     )
 
     class Meta:
         model = Award
         fields = (
-            'awarded_after', 'awarded_before', 'event',
+            "awarded_after",
+            "awarded_before",
+            "event",
         )
 
 
@@ -362,52 +363,51 @@ class WorkshopStaffFilter(AMYFilterSet):
     (.forms.WorkshopStaffForm) is used. So there's no need to specify widgets
     here.
     """
+
     country = django_filters.MultipleChoiceFilter(
         choices=list(Countries()),
         method="filter_country",
     )
     continent = ContinentFilter(label="Continent")
     lessons = django_filters.ModelMultipleChoiceFilter(
-        label='Lessons',
+        label="Lessons",
         queryset=Lesson.objects.all(),
         conjoined=True,  # `AND`
     )
     badges = django_filters.ModelMultipleChoiceFilter(
-        label='Badges',
+        label="Badges",
         queryset=Badge.objects.instructor_badges(),
         conjoined=False,  # `OR`
     )
     is_trainer = django_filters.BooleanFilter(
         widget=widgets.CheckboxInput,
-        method='filter_trainer',
+        method="filter_trainer",
     )
     languages = django_filters.ModelMultipleChoiceFilter(
-        label='Languages',
+        label="Languages",
         queryset=Language.objects.all(),
         conjoined=True,  # `AND`
     )
     gender = django_filters.ChoiceFilter(
-        label='Gender',
+        label="Gender",
         choices=Person.GENDER_CHOICES,
     )
     was_helper = django_filters.BooleanFilter(
         widget=widgets.CheckboxInput,
-        method='filter_helper',
+        method="filter_helper",
     )
     was_organizer = django_filters.BooleanFilter(
         widget=widgets.CheckboxInput,
-        method='filter_organizer',
+        method="filter_organizer",
     )
     is_in_progress_trainee = django_filters.BooleanFilter(
         widget=widgets.CheckboxInput,
-        method='filter_in_progress_trainee',
+        method="filter_in_progress_trainee",
     )
 
     def filter_country(self, qs, n, v):
         if v:
-            return qs.filter(
-                Q(airport__country__in=v) | Q(country__in=v)
-            )
+            return qs.filter(Q(airport__country__in=v) | Q(country__in=v))
         return qs
 
     def filter_trainer(self, qs, n, v):

--- a/amy/workshops/filters.py
+++ b/amy/workshops/filters.py
@@ -1,5 +1,3 @@
-import re
-
 import django_filters
 from django.db.models import Q
 from django.forms import widgets
@@ -8,7 +6,6 @@ from django_countries import Countries
 from dashboard.models import Continent
 from workshops.fields import (
     Select2Widget,
-    Select2MultipleWidget,
     ModelSelect2Widget,
     ModelSelect2MultipleWidget,
 )

--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -247,20 +247,27 @@ class WorkshopStaffForm(forms.Form):
         required=False,
         queryset=Language.objects.all(),
         widget=ModelSelect2MultipleWidget(
-            data_view="language-lookup", attrs=SELECT2_SIDEBAR,
+            data_view="language-lookup",
+            attrs=SELECT2_SIDEBAR,
         ),
     )
 
     country = forms.MultipleChoiceField(
-        choices=list(Countries()), required=False, widget=Select2MultipleWidget,
+        choices=list(Countries()),
+        required=False,
+        widget=Select2MultipleWidget,
     )
 
     continent = forms.ChoiceField(
-        choices=continent_list, required=False, widget=Select2Widget,
+        choices=continent_list,
+        required=False,
+        widget=Select2Widget,
     )
 
     lessons = forms.ModelMultipleChoiceField(
-        queryset=Lesson.objects.all(), widget=SelectMultiple(), required=False,
+        queryset=Lesson.objects.all(),
+        widget=SelectMultiple(),
+        required=False,
     )
 
     badges = forms.ModelMultipleChoiceField(
@@ -607,7 +614,8 @@ class TaskForm(WidgetOverrideMixin, forms.ModelForm):
         required=False,
         queryset=Membership.objects.all(),
         widget=ModelSelect2Widget(
-            data_view="membership-lookup", attrs=SELECT2_SIDEBAR,
+            data_view="membership-lookup",
+            attrs=SELECT2_SIDEBAR,
         ),
     )
 
@@ -796,69 +804,146 @@ class PersonsMergeForm(forms.Form):
         queryset=Person.objects.all(), widget=forms.HiddenInput
     )
 
-    id = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
+    id = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
     username = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     personal = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
-    middle = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
-    family = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
-    email = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
+    middle = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
+    family = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
+    email = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
     secondary_email = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     may_contact = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     publish_profile = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     data_privacy_agreement = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
-    gender = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
+    gender = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
     gender_other = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
-    airport = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
-    github = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
-    twitter = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
-    url = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
+    airport = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
+    github = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
+    twitter = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
+    url = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
     affiliation = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     occupation = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
-    orcid = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,)
+    orcid = forms.ChoiceField(
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+    )
     award_set = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     qualification_set = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect, label="Lessons",
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
+        label="Lessons",
     )
     domains = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     languages = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     task_set = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     is_active = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     trainingprogress_set = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     comment_comments = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     comments = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
 
 
@@ -911,7 +996,10 @@ class AdminLookupForm(forms.Form):
         label="Administrator",
         required=True,
         queryset=Person.objects.all(),
-        widget=ModelSelect2Widget(data_view="admin-lookup", attrs=SELECT2_SIDEBAR,),
+        widget=ModelSelect2Widget(
+            data_view="admin-lookup",
+            attrs=SELECT2_SIDEBAR,
+        ),
     )
 
     helper = BootstrapHelper(add_cancel_button=False)
@@ -954,60 +1042,92 @@ class EventsMergeForm(forms.Form):
     id = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     slug = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     completed = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     assigned_to = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     start = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     end = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     host = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     administrator = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     tags = forms.ChoiceField(choices=THREE, initial=DEFAULT, widget=forms.RadioSelect)
     url = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     language = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     reg_key = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     manual_attendance = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     contact = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     country = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     venue = forms.ChoiceField(choices=THREE, initial=DEFAULT, widget=forms.RadioSelect)
     address = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     latitude = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     longitude = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     learners_pre = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     learners_post = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     instructors_pre = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     instructors_post = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     learners_longterm = forms.ChoiceField(
-        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=TWO,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     task_set = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
     comments = forms.ChoiceField(
-        choices=THREE, initial=DEFAULT, widget=forms.RadioSelect,
+        choices=THREE,
+        initial=DEFAULT,
+        widget=forms.RadioSelect,
     )
 
 

--- a/amy/workshops/github_auth.py
+++ b/amy/workshops/github_auth.py
@@ -28,9 +28,10 @@ def abort_if_no_user_found(user=None, **kwargs):
 class GithubAuthMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
         if isinstance(exception, NoPersonAssociatedWithGithubAccount):
-            messages.error(request,
-                           'No account is associated with your GitHub account.')
-            return redirect(reverse('login'))
+            messages.error(
+                request, "No account is associated with your GitHub account."
+            )
+            return redirect(reverse("login"))
 
 
 def github_username_to_uid(username):
@@ -49,7 +50,7 @@ def github_username_to_uid(username):
         raise ValueError(msg) from e
 
     except IOError as e:
-        msg = 'Impossible to check username due to IO errors.'
+        msg = "Impossible to check username due to IO errors."
         raise ValueError(msg) from e
 
     else:

--- a/amy/workshops/github_auth.py
+++ b/amy/workshops/github_auth.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib import messages
-from django.core.exceptions import ValidationError
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin

--- a/amy/workshops/management/commands/check_certificates.py
+++ b/amy/workshops/management/commands/check_certificates.py
@@ -7,72 +7,116 @@ from workshops.models import Award, Badge, Person
 
 
 class Command(BaseCommand):
-    help = 'Report inconsistencies in PDF certificates.'
+    help = "Report inconsistencies in PDF certificates."
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'path', help='Path to root directory of certificates repository',
+            "path",
+            help="Path to root directory of certificates repository",
         )
 
     def handle(self, *args, **options):
-        '''Main entry point.'''
+        """Main entry point."""
 
-        path_to_root = options['path']
+        path_to_root = options["path"]
 
         badges = self.get_badges()
-        result = [['which', 'badge', 'event', 'awarded_by', 'username', 'person', 'email', 'awarded']]
+        result = [
+            [
+                "which",
+                "badge",
+                "event",
+                "awarded_by",
+                "username",
+                "person",
+                "email",
+                "awarded",
+            ]
+        ]
         for (name, badge) in badges:
             db_records = self.get_db_records(badge)
             db_people = db_records.keys()
             cert_path = os.path.join(path_to_root, name)
             if not os.path.isdir(cert_path):
-                print('No directory {0}'.format(name), file=sys.stderr)
+                print("No directory {0}".format(name), file=sys.stderr)
             else:
                 file_people = self.get_file_people(cert_path)
-                self.missing(result, 'database-disk', name, db_people - file_people, db_records)
-                self.missing(result, 'disk-database', name, file_people - db_people, db_records)
+                self.missing(
+                    result, "database-disk", name, db_people - file_people, db_records
+                )
+                self.missing(
+                    result, "disk-database", name, file_people - db_people, db_records
+                )
         csv.writer(sys.stdout).writerows(result)
 
     def get_badges(self):
-        '''Get all available badges as list of lower-case name and badge pairs.'''
+        """Get all available badges as list of lower-case name and badge pairs."""
 
         return [(b.name.lower(), b) for b in Badge.objects.all()]
 
     def get_db_records(self, badge):
-        '''Get set of usernames of all people with the given badge.'''
+        """Get set of usernames of all people with the given badge."""
 
-        objects = Award.objects.filter(badge=badge).values_list('person__username', 'awarded', 'event__slug', 'awarded_by__username')
-        return dict((obj[0], {'awarded': obj[1], 'event': obj[2], 'awarded_by': obj[3]}) for obj in objects)
+        objects = Award.objects.filter(badge=badge).values_list(
+            "person__username", "awarded", "event__slug", "awarded_by__username"
+        )
+        return dict(
+            (obj[0], {"awarded": obj[1], "event": obj[2], "awarded_by": obj[3]})
+            for obj in objects
+        )
 
     def get_file_people(self, path):
-        '''Get names of all people with the given certificate.'''
+        """Get names of all people with the given certificate."""
 
-        return set([os.path.splitext(e)[0]
-                    for e in os.listdir(path)
-                    if e.endswith('.pdf')])
+        return set(
+            [os.path.splitext(e)[0] for e in os.listdir(path) if e.endswith(".pdf")]
+        )
 
     def missing(self, report, title, kind, usernames, records):
-        '''Report missing usernames.'''
+        """Report missing usernames."""
         for uid in usernames:
             try:
                 receiver = Person.objects.get(username=uid)
             except Person.DoesNotExist as e:
-                self.stderr.write('{0} does not exist'.format(username))
+                self.stderr.write("{0} does not exist".format(username))
             else:
                 name = receiver.full_name
 
                 if uid in records:
-                    event = records[uid]['event']
-                    awarded = records[uid]['awarded']
-                    username = records[uid]['awarded_by']
+                    event = records[uid]["event"]
+                    awarded = records[uid]["awarded"]
+                    username = records[uid]["awarded_by"]
                     try:
                         awarded_by = Person.objects.get(username=username).full_name
                     except Person.DoesNotExist as e:
                         self.stderr.write(
-                            'Person with username={0} who awarded {1} '
-                            'does not exist'.format(username, uid))
+                            "Person with username={0} who awarded {1} "
+                            "does not exist".format(username, uid)
+                        )
                     else:
-                        report.append([title, kind, event, awarded_by, uid, name, receiver.email, awarded])
+                        report.append(
+                            [
+                                title,
+                                kind,
+                                event,
+                                awarded_by,
+                                uid,
+                                name,
+                                receiver.email,
+                                awarded,
+                            ]
+                        )
                 else:
-                    event, awarded, awarded_by = '', '', ''
-                    report.append([title, kind, event, awarded_by, uid, name, receiver.email, awarded])
+                    event, awarded, awarded_by = "", "", ""
+                    report.append(
+                        [
+                            title,
+                            kind,
+                            event,
+                            awarded_by,
+                            uid,
+                            name,
+                            receiver.email,
+                            awarded,
+                        ]
+                    )

--- a/amy/workshops/management/commands/check_certificates.py
+++ b/amy/workshops/management/commands/check_certificates.py
@@ -1,8 +1,7 @@
 import sys
 import os
 import csv
-from django.core.exceptions import ObjectDoesNotExist
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from workshops.models import Award, Badge, Person
 
 
@@ -77,8 +76,8 @@ class Command(BaseCommand):
         for uid in usernames:
             try:
                 receiver = Person.objects.get(username=uid)
-            except Person.DoesNotExist as e:
-                self.stderr.write("{0} does not exist".format(username))
+            except Person.DoesNotExist:
+                self.stderr.write("{0} does not exist".format(uid))
             else:
                 name = receiver.full_name
 
@@ -88,7 +87,7 @@ class Command(BaseCommand):
                     username = records[uid]["awarded_by"]
                     try:
                         awarded_by = Person.objects.get(username=username).full_name
-                    except Person.DoesNotExist as e:
+                    except Person.DoesNotExist:
                         self.stderr.write(
                             "Person with username={0} who awarded {1} "
                             "does not exist".format(username, uid)

--- a/amy/workshops/management/commands/create_superuser.py
+++ b/amy/workshops/management/commands/create_superuser.py
@@ -1,16 +1,19 @@
 from django.core.management.base import BaseCommand, CommandError
 from workshops.models import Person
 
+
 class Command(BaseCommand):
-    args = 'no arguments'
+    args = "no arguments"
     help = 'Create a superuser called "admin" with password "admin".'
 
     def handle(self, *args, **options):
         try:
-            Person.objects.create_superuser(username='admin',
-                                            personal='admin',
-                                            family='admin',
-                                            email='admin@example.org',
-                                            password='admin')
+            Person.objects.create_superuser(
+                username="admin",
+                personal="admin",
+                family="admin",
+                email="admin@example.org",
+                password="admin",
+            )
         except Exception as e:
-            raise CommandError('Failed to create admin: {0}'.format(str(e)))
+            raise CommandError("Failed to create admin: {0}".format(str(e)))

--- a/amy/workshops/management/commands/instructors_activity.py
+++ b/amy/workshops/management/commands/instructors_activity.py
@@ -11,25 +11,33 @@ logger = logging.getLogger()
 
 
 class Command(BaseCommand):
-    help = 'Report instructors activity.'
+    help = "Report instructors activity."
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--send-out-for-real', action='store_true', default=False,
-            help='Send information to the instructors.',
+            "--send-out-for-real",
+            action="store_true",
+            default=False,
+            help="Send information to the instructors.",
         )
         parser.add_argument(
-            '--no-may-contact-only', action='store_true', default=False,
-            help='Include instructors not willing to be contacted.',
+            "--no-may-contact-only",
+            action="store_true",
+            default=False,
+            help="Include instructors not willing to be contacted.",
         )
         parser.add_argument(
-            '--django-mailing', action='store_true', default=False,
-            help='Use Django mailing system. This requires some environmental '
-                 'variables to be set, see `settings.py`.',
+            "--django-mailing",
+            action="store_true",
+            default=False,
+            help="Use Django mailing system. This requires some environmental "
+            "variables to be set, see `settings.py`.",
         )
         parser.add_argument(
-            '-s', '--sender', action='store',
-            default='workshops@carpentries.org',
+            "-s",
+            "--sender",
+            action="store",
+            default="workshops@carpentries.org",
             help='E-mail used in "from:" field.',
         )
 
@@ -37,13 +45,13 @@ class Command(BaseCommand):
         """List of other instructors' tasks, per event."""
         return [
             task.event.task_set.filter(role__in=roles)
-                               .exclude(person=person)
-                               .select_related('person')
+            .exclude(person=person)
+            .select_related("person")
             for task in tasks
         ]
 
     def fetch_activity(self, may_contact_only=True):
-        roles = Role.objects.filter(name__in=['instructor', 'helper'])
+        roles = Role.objects.filter(name__in=["instructor", "helper"])
         instructor_badges = Badge.objects.instructor_badges()
 
         instructors = Person.objects.filter(badges__in=instructor_badges)
@@ -52,43 +60,44 @@ class Command(BaseCommand):
             instructors = instructors.exclude(may_contact=False)
 
         # let's get some things faster
-        instructors = instructors.select_related('airport') \
-                                 .prefetch_related('task_set', 'lessons',
-                                                   'award_set', 'badges')
+        instructors = instructors.select_related("airport").prefetch_related(
+            "task_set", "lessons", "award_set", "badges"
+        )
 
         # don't repeat the records
         instructors = instructors.distinct()
 
         result = []
         for person in instructors:
-            tasks = person.task_set.filter(role__in=roles) \
-                                   .select_related('event', 'role')
+            tasks = person.task_set.filter(role__in=roles).select_related(
+                "event", "role"
+            )
             record = {
-                'person': person,
-                'lessons': person.lessons.all(),
-                'instructor_awards': person.award_set.filter(
+                "person": person,
+                "lessons": person.lessons.all(),
+                "instructor_awards": person.award_set.filter(
                     badge__in=person.badges.instructor_badges()
                 ),
-                'tasks': zip(tasks,
-                             self.foreign_tasks(tasks, person, roles)),
+                "tasks": zip(tasks, self.foreign_tasks(tasks, person, roles)),
             }
             result.append(record)
 
         return result
 
     def make_message(self, record):
-        tmplt = get_template('mailing/instructor_activity.txt')
+        tmplt = get_template("mailing/instructor_activity.txt")
         return tmplt.render(context=record)
 
     def subject(self, record):
         # in future we can vary the subject depending on the record details
-        return 'Updating your Software Carpentry information'
+        return "Updating your Software Carpentry information"
 
     def recipient(self, record):
-        return record['person'].email
+        return record["person"].email
 
-    def send_message(self, subject, message, sender, recipient, for_real=False,
-                     django_mailing=False):
+    def send_message(
+        self, subject, message, sender, recipient, for_real=False, django_mailing=False
+    ):
         if for_real:
             if django_mailing:
                 send_mail(subject, message, sender, [recipient])
@@ -100,34 +109,34 @@ class Command(BaseCommand):
                     recipient=recipient,
                 )
 
-                writer = os.popen(command, 'w')
+                writer = os.popen(command, "w")
                 writer.write(message)
                 writer.close()
 
         if self.verbosity >= 2:
             # write only a header
-            self.stdout.write('-' * 40 + '\n')
-            self.stdout.write('To: {}\n'.format(recipient))
-            self.stdout.write('Subject: {}\n'.format(subject))
-            self.stdout.write('From: {}\n'.format(sender))
+            self.stdout.write("-" * 40 + "\n")
+            self.stdout.write("To: {}\n".format(recipient))
+            self.stdout.write("Subject: {}\n".format(subject))
+            self.stdout.write("From: {}\n".format(sender))
         if self.verbosity >= 3:
             # write whole message out
-            self.stdout.write(message + '\n')
+            self.stdout.write(message + "\n")
 
     def handle(self, *args, **options):
         # default is dummy run - only actually send mail if told to
-        send_for_real = options['send_out_for_real']
+        send_for_real = options["send_out_for_real"]
 
         # by default include only instructors who have `may_contact==True`
-        no_may_contact_only = options['no_may_contact_only']
+        no_may_contact_only = options["no_may_contact_only"]
 
         # use mailing options from settings.py or the `mail` system command?
-        django_mailing = options['django_mailing']
+        django_mailing = options["django_mailing"]
 
         # verbosity option is added by Django
-        self.verbosity = int(options['verbosity'])
+        self.verbosity = int(options["verbosity"])
 
-        sender = options['sender']
+        sender = options["sender"]
 
         results = self.fetch_activity(not no_may_contact_only)
 
@@ -135,9 +144,14 @@ class Command(BaseCommand):
             message = self.make_message(result)
             subject = self.subject(result)
             recipient = self.recipient(result)
-            self.send_message(subject, message, sender, recipient,
-                              for_real=send_for_real,
-                              django_mailing=django_mailing)
+            self.send_message(
+                subject,
+                message,
+                sender,
+                recipient,
+                for_real=send_for_real,
+                django_mailing=django_mailing,
+            )
 
         if self.verbosity >= 1:
-            self.stdout.write('Sent {} emails.\n'.format(len(results)))
+            self.stdout.write("Sent {} emails.\n".format(len(results)))

--- a/amy/workshops/management/commands/sync_usersocialauth.py
+++ b/amy/workshops/management/commands/sync_usersocialauth.py
@@ -5,17 +5,20 @@ from workshops.models import Person
 
 
 class Command(BaseCommand):
-    help = ('Synchronizes entries in UserSocialAuth with values '
-            'in Person.github for given Persons.')
+    help = (
+        "Synchronizes entries in UserSocialAuth with values "
+        "in Person.github for given Persons."
+    )
 
     def add_arguments(self, parser):
-        parser.add_argument('username', nargs='+', type=str,
-                            help='Username in AMY database')
+        parser.add_argument(
+            "username", nargs="+", type=str, help="Username in AMY database"
+        )
 
     def handle(self, *args, **options):
-        '''Main entry point.'''
+        """Main entry point."""
 
-        usernames = options['username']
+        usernames = options["username"]
         for username in usernames:
             try:
                 person = Person.objects.get(username=username)

--- a/amy/workshops/mixins.py
+++ b/amy/workshops/mixins.py
@@ -100,8 +100,8 @@ class InstructorAvailabilityMixin(models.Model):
         blank=True,  # special condition check in the form
         default=False,
         verbose_name="I understand that if my workshop is less than two months away,"
-                     " The Carpentries can not guarantee availability of Instructors"
-                     " and I may not be able to hold my workshop as scheduled.",
+        " The Carpentries can not guarantee availability of Instructors"
+        " and I may not be able to hold my workshop as scheduled.",
     )
 
     class Meta:
@@ -173,7 +173,10 @@ class GenderMixin(models.Model):
         default=UNDISCLOSED,
     )
     gender_other = models.CharField(
-        max_length=100, verbose_name="Other gender", blank=True, null=False,
+        max_length=100,
+        verbose_name="Other gender",
+        blank=True,
+        null=False,
     )
 
     class Meta:

--- a/amy/workshops/signals.py
+++ b/amy/workshops/signals.py
@@ -17,10 +17,10 @@ create_comment_signal = Signal(
 # a receiver for "failed login attempt" signal
 @receiver(user_login_failed)
 def log_user_login_failed(sender, **kwargs):
-    credentials = kwargs.get('credentials') or dict()
-    request = kwargs.get('request') or HttpRequest()
+    credentials = kwargs.get("credentials") or dict()
+    request = kwargs.get("request") or HttpRequest()
 
-    ip = request.META.get('REMOTE_ADDR') or 'UNKNOWN'
-    username = credentials.get('username') or 'UNKNOWN'
+    ip = request.META.get("REMOTE_ADDR") or "UNKNOWN"
+    username = credentials.get("username") or "UNKNOWN"
     msg = "Login failure from IP {} for user '{}'".format(ip, username)
     logger.error(msg)

--- a/amy/workshops/templatetags/dates.py
+++ b/amy/workshops/templatetags/dates.py
@@ -1,7 +1,6 @@
 from django import template
 from django.utils.safestring import mark_safe
 
-from workshops.models import TrainingRequest
 from workshops.util import human_daterange as human_daterange_util
 
 register = template.Library()

--- a/amy/workshops/templatetags/diff.py
+++ b/amy/workshops/templatetags/diff.py
@@ -1,5 +1,4 @@
 from django import template
-from django.db.models import Q
 from django.utils.safestring import mark_safe
 
 from reversion_compare.helpers import html_diff, SEMANTIC

--- a/amy/workshops/templatetags/diff.py
+++ b/amy/workshops/templatetags/diff.py
@@ -9,8 +9,8 @@ register = template.Library()
 
 @register.simple_tag
 def semantic_diff(left, right, field):
-    left_txt = left.field_dict[field] or ''
-    right_txt = right.field_dict[field] or ''
+    left_txt = left.field_dict[field] or ""
+    right_txt = right.field_dict[field] or ""
     return mark_safe(html_diff(left_txt, right_txt, cleanup=SEMANTIC))
 
 
@@ -55,22 +55,22 @@ def relation_diff(left, right, field):
     deletions = [obj for obj in left_PKs if obj not in right_PKs]
     # Relations that exist only in both versions
     consistent = [obj for obj in left_PKs if obj in right_PKs]
-    add_label = ''.join('<a class="label label-success" href="{}">+{}</a>'.format(
-            obj.get_absolute_url() if hasattr(obj, 'get_absolute_url') else '#',
-            obj
+    add_label = "".join(
+        '<a class="label label-success" href="{}">+{}</a>'.format(
+            obj.get_absolute_url() if hasattr(obj, "get_absolute_url") else "#", obj
         )
         for obj in additions
     )
-    delete_label = ''.join('<a class="label label-danger" href="{}">-{}</a>'.format(
-            obj.get_absolute_url() if hasattr(obj, 'get_absolute_url') else '#',
-            obj
+    delete_label = "".join(
+        '<a class="label label-danger" href="{}">-{}</a>'.format(
+            obj.get_absolute_url() if hasattr(obj, "get_absolute_url") else "#", obj
         )
         for obj in deletions
     )
-    consistent_label = ''.join('<a class="label label-default" href="{}">{}</a>'.format(
-            obj.get_absolute_url() if hasattr(obj, 'get_absolute_url') else '#',
-            obj
+    consistent_label = "".join(
+        '<a class="label label-default" href="{}">{}</a>'.format(
+            obj.get_absolute_url() if hasattr(obj, "get_absolute_url") else "#", obj
         )
         for obj in consistent
     )
-    return mark_safe(''.join([consistent_label, add_label,delete_label]))
+    return mark_safe("".join([consistent_label, add_label, delete_label]))

--- a/amy/workshops/templatetags/navigation.py
+++ b/amy/workshops/templatetags/navigation.py
@@ -6,8 +6,9 @@ from django.urls import reverse
 register = template.Library()
 
 
-def navbar_template(title, url, active=False, disabled=False,
-                    dropdown=False, deprecated=False):
+def navbar_template(
+    title, url, active=False, disabled=False, dropdown=False, deprecated=False
+):
     """Compose Bootstrap v4 <li> element for top navigation bar.
 
     List item can be added one or more class attributes:
@@ -19,27 +20,37 @@ def navbar_template(title, url, active=False, disabled=False,
     * deprecated: add a deprecated badge to indicate old features
     """
     classes = []
-    screen_reader = ''
-    badge = ''
+    screen_reader = ""
+    badge = ""
 
     if disabled:
-        classes.append('disabled')
+        classes.append("disabled")
 
     if active:
-        classes.append('active')
+        classes.append("active")
         screen_reader = mark_safe(' <span class="sr-only">(current)</span>')
 
     if deprecated:
         badge = mark_safe('<span class="badge badge-secondary">deprecated</span> ')
 
-    classes = ' '.join(classes)
-    template = ('<li class="nav-item {classes}"><a class="nav-link" '
-                'href="{url}">{badge}{title}{screen_reader}</a></li>')
+    classes = " ".join(classes)
+    template = (
+        '<li class="nav-item {classes}"><a class="nav-link" '
+        'href="{url}">{badge}{title}{screen_reader}</a></li>'
+    )
     if dropdown:
-        template = ('<a class="dropdown-item {classes}" href="{url}">'
-                    '{badge}{title}{screen_reader}</a>')
-    return format_html(template, classes=classes, url=url, badge=badge,
-                       title=title, screen_reader=screen_reader)
+        template = (
+            '<a class="dropdown-item {classes}" href="{url}">'
+            "{badge}{title}{screen_reader}</a>"
+        )
+    return format_html(
+        template,
+        classes=classes,
+        url=url,
+        badge=badge,
+        title=title,
+        screen_reader=screen_reader,
+    )
 
 
 @register.simple_tag(takes_context=True)
@@ -50,9 +61,12 @@ def navbar_element(context, title, url_name, dropdown=False, deprecated=False):
     is later reversed into proper URL.
     """
     url = reverse(url_name)
-    active = context['request'].path == url
-    return mark_safe(navbar_template(title, url, active=active,
-                                     dropdown=dropdown, deprecated=deprecated))
+    active = context["request"].path == url
+    return mark_safe(
+        navbar_template(
+            title, url, active=active, dropdown=dropdown, deprecated=deprecated
+        )
+    )
 
 
 @register.simple_tag(takes_context=True)
@@ -65,17 +79,16 @@ def navbar_element_permed(context, title, url_name, perms, dropdown=False):
     permission.
     """
     url = reverse(url_name)
-    active = context['request'].path == url
+    active = context["request"].path == url
 
     # check permissions
-    perms_ctx = context['perms']
-    perms = perms.split(',')
+    perms_ctx = context["perms"]
+    perms = perms.split(",")
     # True for every perm (from perms_ctx) that's granted to the user
     perms = map(lambda x: x in perms_ctx, perms)
     disabled = not all(perms)  # or: enabled = all(perms)
 
-    return mark_safe(navbar_template(title, url, active=active,
-                                     dropdown=dropdown))
+    return mark_safe(navbar_template(title, url, active=active, dropdown=dropdown))
 
 
 @register.simple_tag(takes_context=True)
@@ -84,6 +97,5 @@ def navbar_element_url(context, title, url, dropdown=False):
     Insert Bootstrap's `<li><a>...</a></li>` with specific classes and
     accessibility elements.  This tag takes a pre-made URL as an argument.
     """
-    active = context['request'].path == url
-    return mark_safe(navbar_template(title, url, active=active,
-                                     dropdown=dropdown))
+    active = context["request"].path == url
+    return mark_safe(navbar_template(title, url, active=active, dropdown=dropdown))

--- a/amy/workshops/templatetags/navigation.py
+++ b/amy/workshops/templatetags/navigation.py
@@ -86,7 +86,7 @@ def navbar_element_permed(context, title, url_name, perms, dropdown=False):
     perms = perms.split(",")
     # True for every perm (from perms_ctx) that's granted to the user
     perms = map(lambda x: x in perms_ctx, perms)
-    disabled = not all(perms)  # or: enabled = all(perms)
+    not all(perms)  # or: enabled = all(perms)
 
     return mark_safe(navbar_template(title, url, active=active, dropdown=dropdown))
 

--- a/amy/workshops/templatetags/pagination.py
+++ b/amy/workshops/templatetags/pagination.py
@@ -1,16 +1,17 @@
 from django import template
+
 register = template.Library()
 
 
-@register.inclusion_tag('pagination.html', takes_context=True)
+@register.inclusion_tag("pagination.html", takes_context=True)
 def pagination(context, objects):
     # needed in set_page_query that's only called from 'pagination.html'
-    request = context['request']
-    return {'objects': objects, 'request': request}
+    request = context["request"]
+    return {"objects": objects, "request": request}
 
 
 @register.simple_tag(takes_context=True)
 def set_page_query(context, page):
-    query = context['request'].GET.copy()
-    query['page'] = str(page)
+    query = context["request"].GET.copy()
+    query["page"] = str(page)
     return query.urlencode()

--- a/amy/workshops/templatetags/revisions.py
+++ b/amy/workshops/templatetags/revisions.py
@@ -5,7 +5,7 @@ from reversion.models import Version
 register = template.Library()
 
 
-@register.inclusion_tag('includes/last_modified.html')
+@register.inclusion_tag("includes/last_modified.html")
 def last_modified(obj):
     """Get all versions for specific object, display:
 
@@ -13,7 +13,8 @@ def last_modified(obj):
     "Last modified on ASD by DSA."
     """
     versions = Version.objects.get_for_object(obj).select_related(
-        'revision','revision__user')
+        "revision", "revision__user"
+    )
 
     try:
         last, *_, created = versions
@@ -26,6 +27,6 @@ def last_modified(obj):
             last = None
 
     return {
-        'created': created,
-        'last_modified': last,
+        "created": created,
+        "last_modified": last,
     }

--- a/amy/workshops/templatetags/state.py
+++ b/amy/workshops/templatetags/state.py
@@ -8,11 +8,11 @@ register = template.Library()
 
 @register.simple_tag
 def state_label(req):
-    assert hasattr(req, 'state')
+    assert hasattr(req, "state")
     switch = {
-        'p': 'badge badge-warning',
-        'a': 'badge badge-success',
-        'd': 'badge badge-danger',
+        "p": "badge badge-warning",
+        "a": "badge badge-success",
+        "d": "badge badge-danger",
     }
     result = switch[req.state]
     return mark_safe(result)

--- a/amy/workshops/templatetags/state.py
+++ b/amy/workshops/templatetags/state.py
@@ -1,7 +1,6 @@
 from django import template
 from django.utils.safestring import mark_safe
 
-from workshops.models import TrainingRequest
 
 register = template.Library()
 

--- a/amy/workshops/templatetags/tags.py
+++ b/amy/workshops/templatetags/tags.py
@@ -1,4 +1,5 @@
 from django import template
+
 # from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
 
@@ -9,19 +10,19 @@ register = template.Library()
 def bootstrap_tag_class(name):
     name_low = name.lower()
 
-    class_ = 'badge-secondary'
-    if name_low.startswith('swc'):
-        class_ = 'badge-primary'
-    elif name_low.startswith('dc'):
-        class_ = 'badge-success'
-    elif name_low.startswith('online'):
-        class_ = 'badge-info'
-    elif name_low.startswith('lc'):
-        class_ = 'badge-warning'
-    elif name_low.startswith('ttt'):
-        class_ = 'badge-danger'
-    elif name_low.startswith('itt'):
-        class_ = 'badge-danger'
+    class_ = "badge-secondary"
+    if name_low.startswith("swc"):
+        class_ = "badge-primary"
+    elif name_low.startswith("dc"):
+        class_ = "badge-success"
+    elif name_low.startswith("online"):
+        class_ = "badge-info"
+    elif name_low.startswith("lc"):
+        class_ = "badge-warning"
+    elif name_low.startswith("ttt"):
+        class_ = "badge-danger"
+    elif name_low.startswith("itt"):
+        class_ = "badge-danger"
 
     return mark_safe(class_)
 

--- a/amy/workshops/templatetags/training_progress.py
+++ b/amy/workshops/templatetags/training_progress.py
@@ -12,17 +12,17 @@ def progress_label(progress):
     assert isinstance(progress, TrainingProgress)
 
     if progress.discarded:
-        additional_label = 'dark'
+        additional_label = "dark"
 
     else:
         switch = {
-            'n': 'warning',
-            'f': 'danger',
-            'p': 'success',
+            "n": "warning",
+            "f": "danger",
+            "p": "success",
         }
         additional_label = switch[progress.state]
 
-    fmt = 'badge badge-{}'.format(additional_label)
+    fmt = "badge badge-{}".format(additional_label)
     return mark_safe(fmt)
 
 
@@ -30,15 +30,19 @@ def progress_label(progress):
 def progress_description(progress):
     assert isinstance(progress, TrainingProgress)
 
-    text = '{discarded}{state} {type}<br />{evaluated_by}<br />on {day}.{notes}'.format(
-        discarded='discarded ' if progress.discarded else '',
+    text = "{discarded}{state} {type}<br />{evaluated_by}<br />on {day}.{notes}".format(
+        discarded="discarded " if progress.discarded else "",
         state=progress.get_state_display(),
         type=progress.requirement,
-        evaluated_by=('evaluated by {}'.format(
-                         progress.evaluated_by.full_name)
-                      if progress.evaluated_by is not None else 'submitted'),
-        day=progress.created_at.strftime('%A %d %B %Y at %H:%M'),
-        notes='<br />Notes: {}'.format(escape(progress.notes)) if progress.notes else '',
+        evaluated_by=(
+            "evaluated by {}".format(progress.evaluated_by.full_name)
+            if progress.evaluated_by is not None
+            else "submitted"
+        ),
+        day=progress.created_at.strftime("%A %d %B %Y at %H:%M"),
+        notes="<br />Notes: {}".format(escape(progress.notes))
+        if progress.notes
+        else "",
     )
     text = text[0].upper() + text[1:]
     return mark_safe(text)

--- a/amy/workshops/tests/base.py
+++ b/amy/workshops/tests/base.py
@@ -98,7 +98,10 @@ class TestBase(
         """Set up airport objects."""
 
         self.airport_0_10 = Airport.objects.create(
-            iata="ZZZ", fullname="Airport 0x10", latitude=0.0, longitude=10.0,
+            iata="ZZZ",
+            fullname="Airport 0x10",
+            latitude=0.0,
+            longitude=10.0,
         )
         self.airport_0_0 = Airport.objects.create(
             iata="AAA",
@@ -132,9 +135,15 @@ class TestBase(
     def _setUpLanguages(self):
         """Set up language objects."""
 
-        self.english, _ = Language.objects.get_or_create(name="English",)
-        self.french, _ = Language.objects.get_or_create(name="French",)
-        self.latin, _ = Language.objects.get_or_create(name="Latin",)
+        self.english, _ = Language.objects.get_or_create(
+            name="English",
+        )
+        self.french, _ = Language.objects.get_or_create(
+            name="French",
+        )
+        self.latin, _ = Language.objects.get_or_create(
+            name="Latin",
+        )
 
     def _setUpBadges(self):
         """Set up badge objects."""

--- a/amy/workshops/tests/base.py
+++ b/amy/workshops/tests/base.py
@@ -1,5 +1,4 @@
 import datetime
-import itertools
 
 from django.contrib.auth.models import Group, Permission
 from django.contrib.sites.models import Site

--- a/amy/workshops/tests/test_action_required.py
+++ b/amy/workshops/tests/test_action_required.py
@@ -11,10 +11,14 @@ class TestActionRequiredPrivacy(TestBase):
         super()._setUpAirports()
         super()._setUpBadges()
         self.neville = Person.objects.create(
-            personal='Neville', family='Longbottom',
-            email='neville@longbottom.com', gender='M', may_contact=True,
-            publish_profile=False, airport=self.airport_0_0,
-            username='longbottom_neville',
+            personal="Neville",
+            family="Longbottom",
+            email="neville@longbottom.com",
+            gender="M",
+            may_contact=True,
+            publish_profile=False,
+            airport=self.airport_0_0,
+            username="longbottom_neville",
             data_privacy_agreement=False,
             is_active=True,
         )
@@ -26,7 +30,7 @@ class TestActionRequiredPrivacy(TestBase):
         # force login Neville
         self.client.force_login(self.neville)
 
-        url = reverse('action_required_privacy')
+        url = reverse("action_required_privacy")
 
         # form renders
         rv = self.client.get(url)
@@ -44,9 +48,9 @@ class TestActionRequiredPrivacy(TestBase):
         "Make sure the form passes only when `data_agreement_policy` is set."
         # setup sample data
         data = {
-            'data_privacy_agreement': False,
-            'may_contact': False,
-            'publish_profile': False,
+            "data_privacy_agreement": False,
+            "may_contact": False,
+            "publish_profile": False,
         }
 
         # make sure it doesn't pass without the privacy policy consent
@@ -54,7 +58,7 @@ class TestActionRequiredPrivacy(TestBase):
         self.assertFalse(form.is_valid())
 
         # let's try with consent for privacy policy
-        data.update({'data_privacy_agreement': True})
+        data.update({"data_privacy_agreement": True})
         form = ActionRequiredPrivacyForm(data, instance=self.neville)
         self.assertTrue(form.is_valid())
 
@@ -64,25 +68,29 @@ class TestActionRequiredPrivacyMiddleware(TestBase):
         super()._setUpAirports()
         super()._setUpBadges()
         self.neville = Person.objects.create(
-            personal='Neville', family='Longbottom',
-            email='neville@longbottom.com', gender='M', may_contact=True,
-            publish_profile=False, airport=self.airport_0_0,
-            username='longbottom_neville',
+            personal="Neville",
+            family="Longbottom",
+            email="neville@longbottom.com",
+            gender="M",
+            may_contact=True,
+            publish_profile=False,
+            airport=self.airport_0_0,
+            username="longbottom_neville",
             data_privacy_agreement=False,
             is_active=True,
         )
         self.neville.save()
-        self.form_url = reverse('action_required_privacy')
+        self.form_url = reverse("action_required_privacy")
 
     def test_anonymous_user(self):
         """Ensure anonymous user can reach anything."""
         urls = [
-            reverse('login'),
-            reverse('api:root'),
-            reverse('training_request'),
-            reverse('training_request_confirm'),
-            reverse('workshop_request'),
-            reverse('workshop_request_confirm'),
+            reverse("login"),
+            reverse("api:root"),
+            reverse("training_request"),
+            reverse("training_request_confirm"),
+            reverse("workshop_request"),
+            reverse("workshop_request_confirm"),
         ]
         # ensure we're not logged in
         self.client.logout()
@@ -98,11 +106,11 @@ class TestActionRequiredPrivacyMiddleware(TestBase):
         """Ensure logged-in user w/o privacy policy agreement is redirected
         to the form."""
         urls = [
-            reverse('admin-dashboard'),
-            reverse('trainee-dashboard'),
+            reverse("admin-dashboard"),
+            reverse("trainee-dashboard"),
         ]
 
-        form_url = reverse('action_required_privacy')
+        form_url = reverse("action_required_privacy")
 
         # ensure we're logged in
         self.client.force_login(self.neville)
@@ -112,13 +120,13 @@ class TestActionRequiredPrivacyMiddleware(TestBase):
             rv = self.client.get(url)
             # redirects to the form
             self.assertEqual(rv.status_code, 302)
-            self.assertTrue(rv['Location'].startswith(form_url))
+            self.assertTrue(rv["Location"].startswith(form_url))
 
     def test_no_more_redirects_after_agreement(self):
         """Ensure user is no longer forcefully redirected to accept the
         privacy policy."""
-        url = reverse('trainee-dashboard')
-        form_url = reverse('action_required_privacy')
+        url = reverse("trainee-dashboard")
+        form_url = reverse("action_required_privacy")
 
         # ensure we're logged in
         self.client.force_login(self.neville)
@@ -127,7 +135,7 @@ class TestActionRequiredPrivacyMiddleware(TestBase):
         # we can't get to the url because we're redirected to the form
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 302)
-        self.assertTrue(rv['Location'].startswith(form_url))
+        self.assertTrue(rv["Location"].startswith(form_url))
 
         # agree on the privacy policy
         self.neville.data_privacy_agreement = True
@@ -138,9 +146,9 @@ class TestActionRequiredPrivacyMiddleware(TestBase):
         self.assertEqual(rv.status_code, 200)
 
     def test_allowed_urls(self):
-        form_url = reverse('action_required_privacy')
+        form_url = reverse("action_required_privacy")
         urls = [
-            reverse('logout'),
+            reverse("logout"),
         ]
         # ensure we're logged in
         self.client.force_login(self.neville)
@@ -149,16 +157,16 @@ class TestActionRequiredPrivacyMiddleware(TestBase):
             rv = self.client.get(url)
             # doesn't redirect to the form
             self.assertIn(rv.status_code, [200, 302])
-            if 'Location' in rv:
-                self.assertNotEqual(rv['Location'], form_url)
+            if "Location" in rv:
+                self.assertNotEqual(rv["Location"], form_url)
 
     def test_next_param(self):
         """Ensure a non-dispatch URL is reachable through `?next` query
         string."""
 
-        url = reverse('autoupdate_profile')
-        form_url = reverse('action_required_privacy')
-        form_url += '?{}'.format(urlencode({'next': url}))
+        url = reverse("autoupdate_profile")
+        form_url = reverse("action_required_privacy")
+        form_url += "?{}".format(urlencode({"next": url}))
 
         # ensure we're logged in
         self.client.force_login(self.neville)
@@ -167,4 +175,4 @@ class TestActionRequiredPrivacyMiddleware(TestBase):
         # submit form
         rv = self.client.post(form_url, data=dict(data_privacy_agreement=True))
         self.assertEqual(rv.status_code, 302)
-        self.assertEqual(rv['Location'], url)
+        self.assertEqual(rv["Location"], url)

--- a/amy/workshops/tests/test_airport.py
+++ b/amy/workshops/tests/test_airport.py
@@ -11,7 +11,7 @@ class TestAirport(TestBase):
 
     def test_airport_details(self):
         """Regression test: ensure airport details page renders correctly."""
-        rv = self.client.get(reverse('airport_details', args=['AAA']))
+        rv = self.client.get(reverse("airport_details", args=["AAA"]))
         self.assertEqual(rv.status_code, 200)
 
     def test_airport_delete(self):
@@ -42,13 +42,20 @@ class TestAirport(TestBase):
         # airports 0_0, 0_50, 50_100, 55_105 cannot be removed because they're
         # referenced by instructors and/or non-instructors
         for iata, remove in zip(airports, can_be_removed):
-            rv = self.client.post(reverse('airport_delete', args=[iata, ]))
+            rv = self.client.post(
+                reverse(
+                    "airport_delete",
+                    args=[
+                        iata,
+                    ],
+                )
+            )
             if remove:
                 self.assertEqual(rv.status_code, 302)
             else:
                 self.assertEqual(rv.status_code, 200)
-                content = rv.content.decode('utf-8')
-                self.assertIn('Failed to delete', content)
+                content = rv.content.decode("utf-8")
+                self.assertIn("Failed to delete", content)
 
         # unassign airports from people
         Person.objects.filter(pk__in=people).update(airport=None)
@@ -59,7 +66,14 @@ class TestAirport(TestBase):
             if remove:
                 continue
 
-            rv = self.client.post(reverse('airport_delete', args=[iata, ]))
+            rv = self.client.post(
+                reverse(
+                    "airport_delete",
+                    args=[
+                        iata,
+                    ],
+                )
+            )
             self.assertEqual(rv.status_code, 302)
 
             with self.assertRaises(Airport.DoesNotExist):
@@ -69,4 +83,4 @@ class TestAirport(TestBase):
         """Make sure that airports are listed in alphabetical order.
         See #1193."""
         first_airport = Airport.objects.all()[0]
-        assert first_airport.iata == 'AAA'
+        assert first_airport.iata == "AAA"

--- a/amy/workshops/tests/test_assignments.py
+++ b/amy/workshops/tests/test_assignments.py
@@ -17,8 +17,7 @@ class TestAssignments(TestBase):
 
         assert event.assigned_to is None
 
-        self.client.get(reverse('event_assign',
-                                args=[event.slug, user.pk]))
+        self.client.get(reverse("event_assign", args=[event.slug, user.pk]))
         event.refresh_from_db()
         assert event.assigned_to == user
 
@@ -33,8 +32,8 @@ class TestAssignments(TestBase):
         fake_user_pk = 0
 
         self.client.post(
-            reverse('event_assign', args=[event.slug, fake_user_pk]),
-            {'person': user.pk},
+            reverse("event_assign", args=[event.slug, fake_user_pk]),
+            {"person": user.pk},
         )
         event.refresh_from_db()
         assert event.assigned_to == user
@@ -48,6 +47,6 @@ class TestAssignments(TestBase):
         event.save()
 
         assert event.assigned_to == user
-        self.client.get(reverse('event_assign', args=[event.slug]))
+        self.client.get(reverse("event_assign", args=[event.slug]))
         event.refresh_from_db()
         assert event.assigned_to is None

--- a/amy/workshops/tests/test_badge.py
+++ b/amy/workshops/tests/test_badge.py
@@ -51,7 +51,8 @@ class TestBadge(TestBase):
 
         rv = self.client.post(
             "{}?next={}".format(
-                reverse("award_delete", args=[award.pk]), reverse("admin-dashboard"),
+                reverse("award_delete", args=[award.pk]),
+                reverse("admin-dashboard"),
             ),
             follow=True,
         )

--- a/amy/workshops/tests/test_bulk_add.py
+++ b/amy/workshops/tests/test_bulk_add.py
@@ -18,15 +18,14 @@ import workshops.views
 
 
 class UploadPersonTaskCSVTestCase(TestBase):
-
     def compute_from_string(self, csv_str):
-        ''' wrap up buffering the raw string & parsing '''
+        """ wrap up buffering the raw string & parsing """
         csv_buf = StringIO(csv_str)
         # compute and return
         return upload_person_task_csv(csv_buf)
 
     def test_basic_parsing(self):
-        ''' See Person.PERSON_UPLOAD_FIELDS for field ordering '''
+        """ See Person.PERSON_UPLOAD_FIELDS for field ordering """
         csv = """personal,family,email
 john,doe,johndoe@email.com
 jane,doe,janedoe@email.com"""
@@ -36,23 +35,21 @@ jane,doe,janedoe@email.com"""
         self.assertEqual(len(person_tasks), 2)
 
         person = person_tasks[0]
-        self.assertTrue(
-            set(person.keys()).issuperset(set(Person.PERSON_UPLOAD_FIELDS))
-        )
+        self.assertTrue(set(person.keys()).issuperset(set(Person.PERSON_UPLOAD_FIELDS)))
 
     def test_csv_without_required_field(self):
-        ''' All fields in Person.PERSON_UPLOAD_FIELDS must be in csv '''
+        """ All fields in Person.PERSON_UPLOAD_FIELDS must be in csv """
         bad_csv = """personal,family
 john,doe"""
         person_tasks, empty_fields = self.compute_from_string(bad_csv)
-        self.assertTrue('email' in empty_fields)
+        self.assertTrue("email" in empty_fields)
 
     def test_csv_with_mislabeled_field(self):
-        ''' It pays to be strict '''
+        """ It pays to be strict """
         bad_csv = """personal,family,emailaddress
 john,doe,john@doe.com"""
         person_tasks, empty_fields = self.compute_from_string(bad_csv)
-        self.assertTrue('email' in empty_fields)
+        self.assertTrue("email" in empty_fields)
 
     def test_csv_with_empty_lines(self):
         csv = """personal,family,emailaddress
@@ -61,15 +58,15 @@ john,doe,john@doe.com
         person_tasks, empty_fields = self.compute_from_string(csv)
         self.assertEqual(len(person_tasks), 1)
         person = person_tasks[0]
-        self.assertEqual(person['personal'], 'john')
+        self.assertEqual(person["personal"], "john")
 
     def test_empty_field(self):
-        ''' Ensure we don't mis-order fields given blank data '''
+        """ Ensure we don't mis-order fields given blank data """
         csv = """personal,family,email
 john,,johndoe@email.com"""
         person_tasks, _ = self.compute_from_string(csv)
         person = person_tasks[0]
-        self.assertEqual(person['family'], '')
+        self.assertEqual(person["family"], "")
 
     def test_serializability_of_parsed(self):
         csv = """personal,family,email
@@ -81,17 +78,15 @@ jane,doe,janedoe@email.com"""
             serializer = JSONSerializer()
             serializer.dumps(person_tasks)
         except TypeError:
-            self.fail('Dumping person_tasks to JSON unexpectedly failed!')
+            self.fail("Dumping person_tasks to JSON unexpectedly failed!")
 
     def test_malformed_CSV_with_proper_header_row(self):
         csv = """personal,family,email
 This is a malformed CSV
         """
         person_tasks, empty_fields = self.compute_from_string(csv)
-        self.assertEqual(person_tasks[0]["personal"],
-                         "This is a malformed CSV")
-        self.assertEqual(set(empty_fields),
-                         set(["family", "email"]))
+        self.assertEqual(person_tasks[0]["personal"], "This is a malformed CSV")
+        self.assertEqual(set(empty_fields), set(["family", "email"]))
 
 
 class CSVBulkUploadTestBase(TestBase):
@@ -102,14 +97,13 @@ class CSVBulkUploadTestBase(TestBase):
 
     def setUp(self):
         super(CSVBulkUploadTestBase, self).setUp()
-        test_host = Organization.objects.create(domain='example.com',
-                                                fullname='Test Organization')
+        test_host = Organization.objects.create(
+            domain="example.com", fullname="Test Organization"
+        )
 
-        Role.objects.create(name='instructor')
-        Role.objects.create(name='learner')
-        Event.objects.create(start=date.today(),
-                             host=test_host,
-                             slug='foobar')
+        Role.objects.create(name="instructor")
+        Role.objects.create(name="learner")
+        Event.objects.create(start=date.today(), host=test_host, slug="foobar")
 
         self._setUpUsersAndLogin()
 
@@ -131,13 +125,13 @@ John,Doe,notin@db.com,foobar,instructor
 
 class VerifyUploadPersonTask(CSVBulkUploadTestBase):
 
-    ''' Scenarios to test:
-        - Everything is good
-        - no 'person' key
-        - event DNE
-        - role DNE
-        - email already exists
-    '''
+    """Scenarios to test:
+    - Everything is good
+    - no 'person' key
+    - event DNE
+    - role DNE
+    - email already exists
+    """
 
     def test_verify_with_good_data(self):
         good_data = self.make_data()
@@ -145,39 +139,39 @@ class VerifyUploadPersonTask(CSVBulkUploadTestBase):
         self.assertFalse(has_errors)
         # make sure 'errors' wasn't set
         # 'errors' may be an empty list, which evaluates to False
-        self.assertFalse(good_data[0]['errors'])
+        self.assertFalse(good_data[0]["errors"])
 
     def test_verify_event_doesnt_exist(self):
         bad_data = self.make_data()
-        bad_data[0]['event'] = 'no-such-event'
+        bad_data[0]["event"] = "no-such-event"
         has_errors = verify_upload_person_task(bad_data, match=True)
         self.assertTrue(has_errors)
 
-        errors = bad_data[0]['errors']
+        errors = bad_data[0]["errors"]
         self.assertEqual(len(errors), 1)
-        self.assertTrue('Event with slug' in errors[0])
+        self.assertTrue("Event with slug" in errors[0])
 
     def test_verify_role_doesnt_exist(self):
         bad_data = self.make_data()
-        bad_data[0]['role'] = 'foobar'
+        bad_data[0]["role"] = "foobar"
 
         has_errors = verify_upload_person_task(bad_data, match=True)
         self.assertTrue(has_errors)
 
-        errors = bad_data[0]['errors']
+        errors = bad_data[0]["errors"]
         self.assertTrue(len(errors) == 1)
-        self.assertTrue('Role with name' in errors[0])
+        self.assertTrue("Role with name" in errors[0])
 
     def test_verify_email_caseinsensitive_matches(self):
         bad_data = self.make_data()
         # test both matching and case-insensitive matching
-        for email in ('harry@hogwarts.edu', 'HARRY@hogwarts.edu'):
-            bad_data[0]['email'] = email
-            bad_data[0]['personal'] = 'Harry'
-            bad_data[0]['family'] = 'Potter'
+        for email in ("harry@hogwarts.edu", "HARRY@hogwarts.edu"):
+            bad_data[0]["email"] = email
+            bad_data[0]["personal"] = "Harry"
+            bad_data[0]["family"] = "Potter"
 
             has_errors = verify_upload_person_task(bad_data, match=True)
-            self.assertFalse(has_errors, 'Bad email: {}'.format(email))
+            self.assertFalse(has_errors, "Bad email: {}".format(email))
 
     def test_email_missing(self):
         """This tests against regression in:
@@ -189,30 +183,30 @@ class VerifyUploadPersonTask(CSVBulkUploadTestBase):
         UNIQUE constraint."""
 
         # make existing users loose their emails
-        usernames = ['potter_harry', 'granger_hermione', 'weasley_ron']
+        usernames = ["potter_harry", "granger_hermione", "weasley_ron"]
         Person.objects.filter(username__in=usernames).update(email=None)
 
         bad_data = [
             {
-                'email': None,
-                'personal': 'Harry',
-                'family': 'Potter',
-                'event': 'foobar',
-                'role': 'learner'
+                "email": None,
+                "personal": "Harry",
+                "family": "Potter",
+                "event": "foobar",
+                "role": "learner",
             },
             {
-                'email': None,
-                'personal': 'Hermione',
-                'family': 'Granger',
-                'event': 'foobar',
-                'role': 'learner'
+                "email": None,
+                "personal": "Hermione",
+                "family": "Granger",
+                "event": "foobar",
+                "role": "learner",
             },
             {
-                'email': None,
-                'personal': 'Ron',
-                'family': 'Weasley',
-                'event': 'foobar',
-                'role': 'learner'
+                "email": None,
+                "personal": "Ron",
+                "family": "Weasley",
+                "event": "foobar",
+                "role": "learner",
             },
         ]
         # test for first occurrence of the error
@@ -225,103 +219,98 @@ class VerifyUploadPersonTask(CSVBulkUploadTestBase):
     def test_verify_existing_user_has_workshop_role_provided(self):
         bad_data = [
             {
-                'email': 'harry@hogwarts.edu',
-                'personal': 'Harry',
-                'family': 'Potter',
-                'event': '',
-                'role': '',
+                "email": "harry@hogwarts.edu",
+                "personal": "Harry",
+                "family": "Potter",
+                "event": "",
+                "role": "",
             }
         ]
         has_errors = verify_upload_person_task(bad_data, match=True)
         self.assertTrue(has_errors)
-        errors = bad_data[0]['errors']
+        errors = bad_data[0]["errors"]
         self.assertEqual(len(errors), 2)
-        self.assertIn('Must have a role', errors[0])
-        self.assertIn('Must have an event', errors[1])
+        self.assertIn("Must have a role", errors[0])
+        self.assertIn("Must have an event", errors[1])
 
     def test_username_from_existing_person(self):
         """Make sure the username is being changed for correct one."""
         data = [
             {
-                'personal': 'Harry',
-                'family': 'Potter',
-                'username': 'wrong_username',
-                'email': 'harry@hogwarts.edu',
-                'event': '',
-                'role': '',
-                'existing_person_id': Person.objects
-                                            .get(email='harry@hogwarts.edu')
-                                            .pk,
+                "personal": "Harry",
+                "family": "Potter",
+                "username": "wrong_username",
+                "email": "harry@hogwarts.edu",
+                "event": "",
+                "role": "",
+                "existing_person_id": Person.objects.get(email="harry@hogwarts.edu").pk,
             }
         ]
         verify_upload_person_task(data)
-        self.assertEqual('potter_harry', data[0]['username'])
+        self.assertEqual("potter_harry", data[0]["username"])
 
     def test_username_from_nonexisting_person(self):
         """Make sure the username is not being changed."""
         data = [
             {
-                'personal': 'Harry',
-                'family': 'Frotter',
-                'username': 'supplied_username',
-                'email': 'h.frotter@hogwarts.edu',
-                'event': '',
-                'role': '',
-                'existing_person_id': None,
+                "personal": "Harry",
+                "family": "Frotter",
+                "username": "supplied_username",
+                "email": "h.frotter@hogwarts.edu",
+                "event": "",
+                "role": "",
+                "existing_person_id": None,
             }
         ]
         verify_upload_person_task(data)
-        self.assertEqual('supplied_username', data[0]['username'])
+        self.assertEqual("supplied_username", data[0]["username"])
 
     def test_matched_similar_persons(self):
         """Ensure function finds matching persons."""
         data = [
             {
-                'personal': 'Harry',
-                'family': 'Potter',
-                'username': 'supplied_username',
-                'email': 'h.frotter@hogwarts.edu',
-                'event': '',
-                'role': '',
+                "personal": "Harry",
+                "family": "Potter",
+                "username": "supplied_username",
+                "email": "h.frotter@hogwarts.edu",
+                "event": "",
+                "role": "",
             },
             {
-                'personal': 'Romuald',
-                'family': 'Weazel',
-                'username': '',
-                'email': 'rweasley@ministry.gov.uk',
-                'event': '',
-                'role': '',
-            }
+                "personal": "Romuald",
+                "family": "Weazel",
+                "username": "",
+                "email": "rweasley@ministry.gov.uk",
+                "event": "",
+                "role": "",
+            },
         ]
         verify_upload_person_task(data)
 
-        self.assertEqual(len(data[0]['similar_persons']), 1)
-        self.assertEqual(len(data[1]['similar_persons']), 1)
+        self.assertEqual(len(data[0]["similar_persons"]), 1)
+        self.assertEqual(len(data[1]["similar_persons"]), 1)
 
-        self.assertEqual(data[0]['similar_persons'][0][0],
-                         self.harry.pk)
-        self.assertEqual(data[1]['similar_persons'][0][0],
-                         self.ron.pk)
+        self.assertEqual(data[0]["similar_persons"][0][0], self.harry.pk)
+        self.assertEqual(data[1]["similar_persons"][0][0], self.ron.pk)
 
     def test_duplicate_errors(self):
         """Ensure errors about duplicate person in the database are present."""
         data = self.make_data()
-        data[0]['personal'] = 'Harry'
-        data[0]['family'] = 'Potter'
-        data[0]['email'] = 'harry@hogwarts.edu'
+        data[0]["personal"] = "Harry"
+        data[0]["family"] = "Potter"
+        data[0]["email"] = "harry@hogwarts.edu"
         verify_upload_person_task(data)
-        self.assertEqual(len(data[0]['errors']), 2)
-        self.assertIn('Person with this email address already exists.',
-                      data[0]['errors'])
-        self.assertIn('Person with this username already exists.',
-                      data[0]['errors'])
+        self.assertEqual(len(data[0]["errors"]), 2)
+        self.assertIn(
+            "Person with this email address already exists.", data[0]["errors"]
+        )
+        self.assertIn("Person with this username already exists.", data[0]["errors"])
 
 
 class BulkUploadUsersViewTestCase(CSVBulkUploadTestBase):
-
     def setUp(self):
         super().setUp()
-        Role.objects.create(name='Helper')
+        Role.objects.create(name="Helper")
 
     def test_event_name_dropped(self):
         """
@@ -333,26 +322,26 @@ class BulkUploadUsersViewTestCase(CSVBulkUploadTestBase):
 
         # self.client is authenticated user so we have access to the session
         store = self.client.session
-        store['bulk-add-people'] = data
+        store["bulk-add-people"] = data
         store.save()
 
         # send exactly what's in 'data', except for the 'event' field: leave
         # this one empty
         payload = {
-            "personal": data[0]['personal'],
-            "family": data[0]['family'],
-            "username": data[0]['username'],
-            "email": data[0]['email'],
+            "personal": data[0]["personal"],
+            "family": data[0]["family"],
+            "username": data[0]["username"],
+            "email": data[0]["email"],
             "event": "",
             "role": "",
             "verify": "Verify",
         }
-        rv = self.client.post(reverse('person_bulk_add_confirmation'), payload)
+        rv = self.client.post(reverse("person_bulk_add_confirmation"), payload)
         self.assertEqual(rv.status_code, 200)
-        _, params = cgi.parse_header(rv['content-type'])
-        charset = params['charset']
+        _, params = cgi.parse_header(rv["content-type"])
+        charset = params["charset"]
         content = rv.content.decode(charset)
-        self.assertNotIn('foobar', content)
+        self.assertNotIn("foobar", content)
 
     def test_upload_existing_user(self):
         """
@@ -368,35 +357,35 @@ Harry,Potter,harry@hogwarts.edu,foobar,Helper
         data, _ = upload_person_task_csv(StringIO(csv))
 
         # simulate user clicking "Use this user" next to matched person
-        data[0]['existing_person_id'] = \
-            Person.objects.get(email='harry@hogwarts.edu').pk
+        data[0]["existing_person_id"] = Person.objects.get(
+            email="harry@hogwarts.edu"
+        ).pk
 
         # self.client is authenticated user so we have access to the session
         store = self.client.session
-        store['bulk-add-people'] = data
+        store["bulk-add-people"] = data
         store.save()
 
         # send exactly what's in 'data'
         payload = {
-            "personal": data[0]['personal'],
-            "family": data[0]['family'],
-            "email": data[0]['email'],
-            "event": data[0]['event'],
-            "role": data[0]['role'],
+            "personal": data[0]["personal"],
+            "family": data[0]["family"],
+            "email": data[0]["email"],
+            "event": data[0]["event"],
+            "role": data[0]["role"],
             "confirm": "Confirm",
         }
 
         people_pre = set(Person.objects.all())
-        tasks_pre = set(Task.objects.filter(person=self.harry,
-                                            event__slug="foobar"))
+        tasks_pre = set(Task.objects.filter(person=self.harry, event__slug="foobar"))
 
-        rv = self.client.post(reverse('person_bulk_add_confirmation'), payload,
-                              follow=True)
+        rv = self.client.post(
+            reverse("person_bulk_add_confirmation"), payload, follow=True
+        )
         self.assertEqual(rv.status_code, 200)
 
         people_post = set(Person.objects.all())
-        tasks_post = set(Task.objects.filter(person=self.harry,
-                                             event__slug="foobar"))
+        tasks_post = set(Task.objects.filter(person=self.harry, event__slug="foobar"))
 
         # make sure no-one new was added
         self.assertSetEqual(people_pre, people_post)
@@ -420,28 +409,27 @@ Harry,Potter,harry@hogwarts.edu,foobar,instructor
 
         # self.client is authenticated user so we have access to the session
         store = self.client.session
-        store['bulk-add-people'] = data
+        store["bulk-add-people"] = data
         store.save()
 
         # send exactly what's in 'data'
         payload = {
-            "personal": data[0]['personal'],
-            "family": data[0]['family'],
-            "email": data[0]['email'],
-            "event": data[0]['event'],
-            "role": data[0]['role'],
+            "personal": data[0]["personal"],
+            "family": data[0]["family"],
+            "email": data[0]["email"],
+            "event": data[0]["event"],
+            "role": data[0]["role"],
             "confirm": "Confirm",
         }
 
-        tasks_pre = set(Task.objects.filter(person=self.harry,
-                                            event__slug="foobar"))
+        tasks_pre = set(Task.objects.filter(person=self.harry, event__slug="foobar"))
         users_pre = set(Person.objects.all())
 
-        rv = self.client.post(reverse('person_bulk_add_confirmation'), payload,
-                              follow=True)
+        rv = self.client.post(
+            reverse("person_bulk_add_confirmation"), payload, follow=True
+        )
 
-        tasks_post = set(Task.objects.filter(person=self.harry,
-                                             event__slug="foobar"))
+        tasks_post = set(Task.objects.filter(person=self.harry, event__slug="foobar"))
         users_post = set(Person.objects.all())
         self.assertEqual(tasks_pre, tasks_post)
         self.assertEqual(users_pre, users_post)
@@ -462,26 +450,26 @@ Harry,Potter,harry@hogwarts.edu,foobar,learner
         data, _ = upload_person_task_csv(StringIO(csv))
 
         # simulate user clicking "Use this user" next to matched person
-        data[0]['existing_person_id'] = \
-            Person.objects.get(email='harry@hogwarts.edu').pk
+        data[0]["existing_person_id"] = Person.objects.get(
+            email="harry@hogwarts.edu"
+        ).pk
 
         # self.client is authenticated user so we have access to the session
         store = self.client.session
-        store['bulk-add-people'] = data
+        store["bulk-add-people"] = data
         store.save()
 
         # send exactly what's in 'data'
         payload = {
-            "personal": data[0]['personal'],
-            "family": data[0]['family'],
-            "email": data[0]['email'],
-            "event": data[0]['event'],
-            "role": data[0]['role'],
+            "personal": data[0]["personal"],
+            "family": data[0]["family"],
+            "email": data[0]["email"],
+            "event": data[0]["event"],
+            "role": data[0]["role"],
             "confirm": "Confirm",
         }
 
-        self.client.post(reverse('person_bulk_add_confirmation'), payload,
-                         follow=True)
+        self.client.post(reverse("person_bulk_add_confirmation"), payload, follow=True)
 
         # instead of refreshing, we have to get a "fresh" object, because
         # `attendance` is a cached property
@@ -492,7 +480,7 @@ Harry,Potter,harry@hogwarts.edu,foobar,learner
 class BulkUploadRemoveEntryViewTestCase(CSVBulkUploadTestBase):
     def setUp(self):
         super().setUp()
-        Role.objects.create(name='Helper')
+        Role.objects.create(name="Helper")
         self.csv = """personal,family,email,event,role
 Harry,Potter,harry@hogwarts.edu,foobar,learner
 Hermione,Granger,hermione@hogwarts.edu,foobar,learner
@@ -505,18 +493,18 @@ Ron,Weasley,ron@hogwarts.edu,foobar,learner
 
         # self.client is authenticated user so we have access to the session
         store = self.client.session
-        store['bulk-add-people'] = data
+        store["bulk-add-people"] = data
         store.save()
 
-        self.client.get(reverse('person_bulk_add_remove_entry', args=[0]))
+        self.client.get(reverse("person_bulk_add_remove_entry", args=[0]))
 
         # need to recreate session
         store = self.client.session
-        data = store['bulk-add-people']
+        data = store["bulk-add-people"]
 
         self.assertEqual(2, len(data))
-        self.assertEqual(data[0]['personal'], 'Hermione')
-        self.assertEqual(data[1]['personal'], 'Ron')
+        self.assertEqual(data[0]["personal"], "Hermione")
+        self.assertEqual(data[1]["personal"], "Ron")
 
     def test_removing_entry1(self):
         """Make sure entries are removed by the view."""
@@ -524,18 +512,18 @@ Ron,Weasley,ron@hogwarts.edu,foobar,learner
 
         # self.client is authenticated user so we have access to the session
         store = self.client.session
-        store['bulk-add-people'] = data
+        store["bulk-add-people"] = data
         store.save()
 
-        self.client.get(reverse('person_bulk_add_remove_entry', args=[1]))
+        self.client.get(reverse("person_bulk_add_remove_entry", args=[1]))
 
         # need to recreate session
         store = self.client.session
-        data = store['bulk-add-people']
+        data = store["bulk-add-people"]
 
         self.assertEqual(2, len(data))
-        self.assertEqual(data[0]['personal'], 'Harry')
-        self.assertEqual(data[1]['personal'], 'Ron')
+        self.assertEqual(data[0]["personal"], "Harry")
+        self.assertEqual(data[1]["personal"], "Ron")
 
     def test_removing_entry2(self):
         """Make sure entries are removed by the view."""
@@ -543,24 +531,24 @@ Ron,Weasley,ron@hogwarts.edu,foobar,learner
 
         # self.client is authenticated user so we have access to the session
         store = self.client.session
-        store['bulk-add-people'] = data
+        store["bulk-add-people"] = data
         store.save()
 
-        self.client.get(reverse('person_bulk_add_remove_entry', args=[2]))
+        self.client.get(reverse("person_bulk_add_remove_entry", args=[2]))
 
         # need to recreate session
         store = self.client.session
-        data = store['bulk-add-people']
+        data = store["bulk-add-people"]
 
         self.assertEqual(2, len(data))
-        self.assertEqual(data[0]['personal'], 'Harry')
-        self.assertEqual(data[1]['personal'], 'Hermione')
+        self.assertEqual(data[0]["personal"], "Harry")
+        self.assertEqual(data[1]["personal"], "Hermione")
 
 
 class BulkUploadMatchPersonViewTestCase(CSVBulkUploadTestBase):
     def setUp(self):
         super().setUp()
-        Role.objects.create(name='Helper')
+        Role.objects.create(name="Helper")
         self.csv = """personal,family,email,event,role
 Harry,Potter,harry@hogwarts.edu,foobar,learner
 Hermione,Granger,hermione@hogwarts.edu,foobar,learner
@@ -568,55 +556,54 @@ Ron,Weasley,ron@hogwarts.edu,foobar,learner
 """
 
 
-class TestBulkUploadAddsEmailAction(FakeRedisTestCaseMixin,
-                                    CSVBulkUploadTestBase):
+class TestBulkUploadAddsEmailAction(FakeRedisTestCaseMixin, CSVBulkUploadTestBase):
     def setUp(self):
         super().setUp()
-        Role.objects.create(name='host')
+        Role.objects.create(name="host")
 
-        Tag.objects.bulk_create([
-            Tag(name='SWC'),
-            Tag(name='DC'),
-            Tag(name='LC'),
-            Tag(name='automated-email'),
-        ])
-        Organization.objects.bulk_create([
-            Organization(domain='librarycarpentry.org',
-                         fullname='Library Carpentry'),
-            Organization(domain='carpentries.org',
-                         fullname='Instructor Training'),
-        ])
+        Tag.objects.bulk_create(
+            [
+                Tag(name="SWC"),
+                Tag(name="DC"),
+                Tag(name="LC"),
+                Tag(name="automated-email"),
+            ]
+        )
+        Organization.objects.bulk_create(
+            [
+                Organization(
+                    domain="librarycarpentry.org", fullname="Library Carpentry"
+                ),
+                Organization(domain="carpentries.org", fullname="Instructor Training"),
+            ]
+        )
         test_event_1 = Event.objects.create(
-            slug='test-event',
+            slug="test-event",
             host=Organization.objects.first(),
-            administrator=Organization.objects.get(
-                domain='librarycarpentry.org'),
+            administrator=Organization.objects.get(domain="librarycarpentry.org"),
             start=date.today() + timedelta(days=7),
             end=date.today() + timedelta(days=8),
-            country='GB',
-            venue='Ministry of Magic',
-            address='Underground',
+            country="GB",
+            venue="Ministry of Magic",
+            address="Underground",
             latitude=20.0,
             longitude=20.0,
-            url='https://test-event.example.com',
+            url="https://test-event.example.com",
         )
         test_event_1.tags.set(
-            Tag.objects.filter(
-                name__in=['SWC', 'DC', 'LC','automated-email']
-            )
+            Tag.objects.filter(name__in=["SWC", "DC", "LC", "automated-email"])
         )
         template = EmailTemplate.objects.create(
-            slug='sample-template',
-            subject='Welcome!',
-            to_header='',
-            from_header='test@address.com',
-            cc_header='copy@example.org',
-            bcc_header='bcc@example.org',
-            reply_to_header='',
-            body_template='# Welcome',
+            slug="sample-template",
+            subject="Welcome!",
+            to_header="",
+            from_header="test@address.com",
+            cc_header="copy@example.org",
+            bcc_header="bcc@example.org",
+            reply_to_header="",
+            body_template="# Welcome",
         )
-        trigger = Trigger.objects.create(action='new-instructor',
-                                         template=template)
+        trigger = Trigger.objects.create(action="new-instructor", template=template)
 
         # save scheduler and connection data
         self._saved_scheduler = workshops.views.scheduler
@@ -640,45 +627,40 @@ Ron,Weasley,ron@hogwarts.edu,test-event,instructor
         data, _ = upload_person_task_csv(StringIO(self.csv))
 
         # simulate user clicking "Use this user" next to matched person
-        data[0]['existing_person_id'] = \
-            Person.objects.get(email='harry@hogwarts.edu').pk
-        data[1]['existing_person_id'] = \
-            Person.objects.get(email='hermione@granger.co.uk').pk
-        data[2]['existing_person_id'] = \
-            Person.objects.get(email='rweasley@ministry.gov.uk').pk
+        data[0]["existing_person_id"] = Person.objects.get(
+            email="harry@hogwarts.edu"
+        ).pk
+        data[1]["existing_person_id"] = Person.objects.get(
+            email="hermione@granger.co.uk"
+        ).pk
+        data[2]["existing_person_id"] = Person.objects.get(
+            email="rweasley@ministry.gov.uk"
+        ).pk
 
         # self.client is authenticated user so we have access to the session
         store = self.client.session
-        store['bulk-add-people'] = data
+        store["bulk-add-people"] = data
         store.save()
 
         # send exactly what's in 'data'
         payload = {
-            "personal": [
-                data[0]['personal'], data[1]['personal'], data[2]['personal']
-            ],
-            "family": [
-                data[0]['family'], data[1]['family'], data[2]['family']
-            ],
-            "email": [
-                data[0]['email'], data[1]['email'], data[2]['email']
-            ],
-            "event": [
-                data[0]['event'], data[1]['event'], data[2]['event']
-            ],
-            "role": [
-                data[0]['role'], data[1]['role'], data[2]['role']
-            ],
+            "personal": [data[0]["personal"], data[1]["personal"], data[2]["personal"]],
+            "family": [data[0]["family"], data[1]["family"], data[2]["family"]],
+            "email": [data[0]["email"], data[1]["email"], data[2]["email"]],
+            "event": [data[0]["event"], data[1]["event"], data[2]["event"]],
+            "role": [data[0]["role"], data[1]["role"], data[2]["role"]],
             "confirm": "Confirm",
         }
 
         # empty tasks and no jobs scheduled
         tasks_pre = Task.objects.filter(
-            person__in=Person.objects.filter(email__in=[
-                'harry@hogwarts.edu',
-                'hermione@granger.co.uk',
-                'rweasley@ministry.gov.uk',
-            ]),
+            person__in=Person.objects.filter(
+                email__in=[
+                    "harry@hogwarts.edu",
+                    "hermione@granger.co.uk",
+                    "rweasley@ministry.gov.uk",
+                ]
+            ),
             event__slug="test-event",
         )
         self.assertQuerysetEqual(tasks_pre, [])
@@ -686,17 +668,20 @@ Ron,Weasley,ron@hogwarts.edu,test-event,instructor
         self.assertQuerysetEqual(rqjobs_pre, [])
 
         # send data in
-        rv = self.client.post(reverse('person_bulk_add_confirmation'), payload,
-                              follow=True)
+        rv = self.client.post(
+            reverse("person_bulk_add_confirmation"), payload, follow=True
+        )
         self.assertEqual(rv.status_code, 200)
 
         # 3 tasks created
         tasks_post = Task.objects.filter(
-            person__in=Person.objects.filter(email__in=[
-                'harry@hogwarts.edu',
-                'hermione@granger.co.uk',
-                'rweasley@ministry.gov.uk',
-            ]),
+            person__in=Person.objects.filter(
+                email__in=[
+                    "harry@hogwarts.edu",
+                    "hermione@granger.co.uk",
+                    "rweasley@ministry.gov.uk",
+                ]
+            ),
             event__slug="test-event",
         )
         self.assertEqual(len(tasks_post), 3)
@@ -705,6 +690,6 @@ Ron,Weasley,ron@hogwarts.edu,test-event,instructor
         self.assertEqual(len(rqjobs_post), 2)
 
         # ensure the job ids are mentioned in the page output
-        content = rv.content.decode('utf-8')
+        content = rv.content.decode("utf-8")
         for job in rqjobs_post:
             self.assertIn(job.job_id, content)

--- a/amy/workshops/tests/test_bulk_add.py
+++ b/amy/workshops/tests/test_bulk_add.py
@@ -603,7 +603,7 @@ class TestBulkUploadAddsEmailAction(FakeRedisTestCaseMixin, CSVBulkUploadTestBas
             reply_to_header="",
             body_template="# Welcome",
         )
-        trigger = Trigger.objects.create(action="new-instructor", template=template)
+        Trigger.objects.create(action="new-instructor", template=template)
 
         # save scheduler and connection data
         self._saved_scheduler = workshops.views.scheduler

--- a/amy/workshops/tests/test_commands.py
+++ b/amy/workshops/tests/test_commands.py
@@ -16,12 +16,14 @@ from workshops.management.commands.fake_database import (
     Command as FakeDatabaseCommand,
 )
 from workshops.management.commands.instructors_activity import (
-    Command as InstructorsActivityCommand)
+    Command as InstructorsActivityCommand,
+)
 from workshops.management.commands.check_for_workshop_websites_updates import (
     Command as WebsiteUpdatesCommand,
     WrongWorkshopURL,
     datetime_match,
-    datetime_decode)
+    datetime_decode,
+)
 from workshops.models import (
     Role,
     Badge,
@@ -47,23 +49,25 @@ class TestInstructorsActivityCommand(TestBase):
         # add one event that some instructors took part in
         self._setUpOrganizations()
         self.event = Event.objects.create(
-            slug='event-with-tasks',
+            slug="event-with-tasks",
             host=self.org_alpha,
             start=date(2015, 8, 30),
         )
         self._setUpRoles()
-        self.instructor = Role.objects.get(name='instructor')
-        self.helper = Role.objects.get(name='helper')
-        self.learner = Role.objects.get(name='learner')
+        self.instructor = Role.objects.get(name="instructor")
+        self.helper = Role.objects.get(name="helper")
+        self.learner = Role.objects.get(name="learner")
 
-        Task.objects.bulk_create([
-            Task(event=self.event, person=self.hermione, role=self.instructor),
-            Task(event=self.event, person=self.ron, role=self.instructor),
-            Task(event=self.event, person=self.ron, role=self.helper),
-            Task(event=self.event, person=self.harry, role=self.helper),
-            Task(event=self.event, person=self.spiderman, role=self.learner),
-            Task(event=self.event, person=self.blackwidow, role=self.learner),
-        ])
+        Task.objects.bulk_create(
+            [
+                Task(event=self.event, person=self.hermione, role=self.instructor),
+                Task(event=self.event, person=self.ron, role=self.instructor),
+                Task(event=self.event, person=self.ron, role=self.helper),
+                Task(event=self.event, person=self.harry, role=self.helper),
+                Task(event=self.event, person=self.spiderman, role=self.learner),
+                Task(event=self.event, person=self.blackwidow, role=self.learner),
+            ]
+        )
 
     def test_getting_foreign_tasks(self):
         """Make sure we get tasks for other people (per event)."""
@@ -75,14 +79,15 @@ class TestInstructorsActivityCommand(TestBase):
         fg_tasks = self.cmd.foreign_tasks(tasks, person, roles)[0]
 
         # we should receive other instructors and helpers for self.event
-        expecting = set([
-            Task.objects.get(event=self.event, person=self.ron,
-                             role=self.instructor),
-            Task.objects.get(event=self.event, person=self.ron,
-                             role=self.helper),
-            Task.objects.get(event=self.event, person=self.harry,
-                             role=self.helper),
-        ])
+        expecting = set(
+            [
+                Task.objects.get(
+                    event=self.event, person=self.ron, role=self.instructor
+                ),
+                Task.objects.get(event=self.event, person=self.ron, role=self.helper),
+                Task.objects.get(event=self.event, person=self.harry, role=self.helper),
+            ]
+        )
 
         self.assertEqual(expecting, set(fg_tasks))
 
@@ -93,15 +98,17 @@ class TestInstructorsActivityCommand(TestBase):
         results = self.cmd.fetch_activity(may_contact_only=False)
         instructor_badges = Badge.objects.instructor_badges()
 
-        persons = [d['person'] for d in results]
-        lessons = [list(d['lessons']) for d in results]
-        instructor_awards = [list(d['instructor_awards']) for d in results]
-        tasks = [d['tasks'] for d in results]
+        persons = [d["person"] for d in results]
+        lessons = [list(d["lessons"]) for d in results]
+        instructor_awards = [list(d["instructor_awards"]) for d in results]
+        tasks = [d["tasks"] for d in results]
 
         expecting_persons = [self.hermione, self.harry, self.ron]
-        expecting_lessons = [list(self.hermione.lessons.all()),
-                             list(self.harry.lessons.all()),
-                             list(self.ron.lessons.all())]
+        expecting_lessons = [
+            list(self.hermione.lessons.all()),
+            list(self.harry.lessons.all()),
+            list(self.ron.lessons.all()),
+        ]
         expecting_awards = [
             list(person.award_set.filter(badge__in=instructor_badges))
             for person in expecting_persons
@@ -118,8 +125,8 @@ class TestInstructorsActivityCommand(TestBase):
                 self.assertIn(
                     own_task,
                     own_task.person.task_set.filter(
-                        role__name__in=['instructor', 'helper']
-                    )
+                        role__name__in=["instructor", "helper"]
+                    ),
                 )
 
     def test_fetching_activity_may_contact_only(self):
@@ -133,7 +140,7 @@ class TestInstructorsActivityCommand(TestBase):
         self.ron.save()
 
         results = self.cmd.fetch_activity(may_contact_only=True)
-        persons = [d['person'] for d in results]
+        persons = [d["person"] for d in results]
         expecting_persons = [self.harry]
         self.assertEqual(set(persons), set(expecting_persons))
 
@@ -172,39 +179,36 @@ class TestWebsiteUpdatesCommand(TestBase):
 </body></html>
 """
         self.expected_metadata_parsed = {
-            'slug': '2015-07-13-test',
-            'language': 'US',
-            'start': date(2015, 7, 13),
-            'end': date(2015, 7, 14),
-            'country': 'US',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latitude': 36.998977,
-            'longitude': -109.045173,
-            'reg_key': 10000000,
-            'instructors': ['Hermione Granger', 'Ron Weasley'],
-            'helpers': ['Peter Parker', 'Tony Stark', 'Natasha Romanova'],
-            'contact': ['hermione@granger.co.uk', 'rweasley@ministry.gov'],
+            "slug": "2015-07-13-test",
+            "language": "US",
+            "start": date(2015, 7, 13),
+            "end": date(2015, 7, 14),
+            "country": "US",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latitude": 36.998977,
+            "longitude": -109.045173,
+            "reg_key": 10000000,
+            "instructors": ["Hermione Granger", "Ron Weasley"],
+            "helpers": ["Peter Parker", "Tony Stark", "Natasha Romanova"],
+            "contact": ["hermione@granger.co.uk", "rweasley@ministry.gov"],
         }
 
         self.date_serialization_tests = [
             # simple tests
-            ('', ''),
-            ('empty string', 'empty string'),
-
+            ("", ""),
+            ("empty string", "empty string"),
             # format-matching
-            ('2016-04-18', date(2016, 4, 18)),
-            ('2016-04-18T16:41:30', datetime(2016, 4, 18, 16, 41, 30)),
-            ('2016-04-18T16:41:30.123',
-             datetime(2016, 4, 18, 16, 41, 30, 123000)),
-            ('16:41:30', time(16, 41, 30)),
-            ('16:41:30.123', time(16, 41, 30, 123000)),
-
+            ("2016-04-18", date(2016, 4, 18)),
+            ("2016-04-18T16:41:30", datetime(2016, 4, 18, 16, 41, 30)),
+            ("2016-04-18T16:41:30.123", datetime(2016, 4, 18, 16, 41, 30, 123000)),
+            ("16:41:30", time(16, 41, 30)),
+            ("16:41:30.123", time(16, 41, 30, 123000)),
             # format not matching (ie. timezone-aware)
-            ('2016-04-18T16:41:30+02:00', '2016-04-18T16:41:30+02:00'),
-            ('2016-04-18T14:41:30Z', '2016-04-18T14:41:30Z'),
-            ('16:41:30+02:00', '16:41:30+02:00'),
-            ('14:41:30Z', '14:41:30Z'),
+            ("2016-04-18T16:41:30+02:00", "2016-04-18T16:41:30+02:00"),
+            ("2016-04-18T14:41:30Z", "2016-04-18T14:41:30Z"),
+            ("16:41:30+02:00", "16:41:30+02:00"),
+            ("14:41:30Z", "14:41:30Z"),
         ]
 
     def test_getting_events(self):
@@ -216,7 +220,7 @@ class TestWebsiteUpdatesCommand(TestBase):
 
         # one active event with URL and one without
         e1.completed = False  # completed == !active
-        e1.url = 'https://swcarpentry.github.io/workshop-template/'
+        e1.url = "https://swcarpentry.github.io/workshop-template/"
         e1.save()
         e2.completed = False
         e2.url = None
@@ -224,7 +228,7 @@ class TestWebsiteUpdatesCommand(TestBase):
 
         # one inactive event with URL and one without
         e3.completed = True
-        e3.url = 'https://datacarpentry.github.io/workshop-template/'
+        e3.url = "https://datacarpentry.github.io/workshop-template/"
         e3.save()
         e4.completed = True
         e4.url = None
@@ -232,11 +236,11 @@ class TestWebsiteUpdatesCommand(TestBase):
 
         # both active but one very old
         e5.completed = False
-        e5.url = 'https://swcarpentry.github.io/workshop-template2/'
+        e5.url = "https://swcarpentry.github.io/workshop-template2/"
         e5.start = date(2014, 1, 1)
         e5.save()
         e6.completed = False
-        e6.url = 'https://datacarpentry.github.io/workshop-template2/'
+        e6.url = "https://datacarpentry.github.io/workshop-template2/"
         e6.save()
 
         # check
@@ -245,12 +249,12 @@ class TestWebsiteUpdatesCommand(TestBase):
 
     def test_parsing_github_url(self):
         """Ensure `parse_github_url()` correctly parses repository URL."""
-        url = 'https://github.com/swcarpentry/workshop-template'
-        expected = 'swcarpentry', 'workshop-template'
+        url = "https://github.com/swcarpentry/workshop-template"
+        expected = "swcarpentry", "workshop-template"
         self.assertEqual(expected, self.cmd.parse_github_url(url))
 
         with self.assertRaises(WrongWorkshopURL):
-            url = 'https://swcarpentry.github.io/workshop-template'
+            url = "https://swcarpentry.github.io/workshop-template"
             self.cmd.parse_github_url(url)
 
     @requests_mock.Mocker()
@@ -259,7 +263,7 @@ class TestWebsiteUpdatesCommand(TestBase):
         # underlying `fetch_event_metadata` and `parse_metadata_from_event_website`
         # are tested in great detail in `test_util.py`, so here's just a short
         # test
-        website_url = 'https://github.com/swcarpentry/workshop-template'
+        website_url = "https://github.com/swcarpentry/workshop-template"
         mock_text = self.mocked_event_page
         mock.get(website_url, text=mock_text, status_code=200)
         # mock placed, let's test `get_event_metadata`
@@ -291,15 +295,14 @@ class TestWebsiteUpdatesCommand(TestBase):
         """Ensure our datetime matching function works correctly for nested
         objects/lists."""
         # this test uses simpler format
-        dict_test = {'2016-04-18': '2016-04-18'}
-        dict_expected = {'2016-04-18': date(2016, 4, 18)}
+        dict_test = {"2016-04-18": "2016-04-18"}
+        dict_expected = {"2016-04-18": date(2016, 4, 18)}
         test = [dict_test.copy(), dict_test.copy(), dict_test.copy()]
-        expected = [dict_expected.copy(), dict_expected.copy(),
-                    dict_expected.copy()]
+        expected = [dict_expected.copy(), dict_expected.copy(), dict_expected.copy()]
         self.assertEqual(datetime_decode(test), expected)
 
-        test = {'1': test[:]}
-        expected = {'1': expected[:]}
+        test = {"1": test[:]}
+        expected = {"1": expected[:]}
         self.assertEqual(datetime_decode(test), expected)
 
     def test_serialization(self):
@@ -309,18 +312,19 @@ class TestWebsiteUpdatesCommand(TestBase):
         datetimes and times."""
         serialized_json = self.cmd.serialize(self.expected_metadata_parsed)
 
-        self.assertIn('2015-07-13', serialized_json)
-        self.assertIn('2015-07-14', serialized_json)
-        self.assertIn('2015-07-13-test', serialized_json)
-        self.assertIn('-109.045173', serialized_json)
-        self.assertIn('36.998977', serialized_json)
-        self.assertIn('["hermione@granger.co.uk", "rweasley@ministry.gov"]',
-                      serialized_json)
+        self.assertIn("2015-07-13", serialized_json)
+        self.assertIn("2015-07-14", serialized_json)
+        self.assertIn("2015-07-13-test", serialized_json)
+        self.assertIn("-109.045173", serialized_json)
+        self.assertIn("36.998977", serialized_json)
+        self.assertIn(
+            '["hermione@granger.co.uk", "rweasley@ministry.gov"]', serialized_json
+        )
 
         deserialized_data = self.cmd.deserialize(serialized_json)
         self.assertEqual(deserialized_data, self.expected_metadata_parsed)
 
-    @unittest.skip('Don\'t know how to test it')
+    @unittest.skip("Don't know how to test it")
     def test_loading_from_github(self):
         """Not sure how to test it, so for now leaving this blank."""
         # TODO: mock up github response?
@@ -329,13 +333,15 @@ class TestWebsiteUpdatesCommand(TestBase):
     @requests_mock.Mocker()
     def test_detecting_changes(self, mock):
         """Make sure metadata changes are detected."""
-        hash_ = 'abcdefghijklmnopqrstuvwxyz'
+        hash_ = "abcdefghijklmnopqrstuvwxyz"
         e = Event.objects.create(
-            slug='with-changes', host=Organization.objects.first(),
-            url='https://swcarpentry.github.io/workshop-template/',
+            slug="with-changes",
+            host=Organization.objects.first(),
+            url="https://swcarpentry.github.io/workshop-template/",
             repository_last_commit_hash=hash_,
-            repository_metadata='',
-            metadata_changed=False)
+            repository_metadata="",
+            metadata_changed=False,
+        )
 
         branch = MagicMock()
         branch.commit = MagicMock()
@@ -350,22 +356,22 @@ class TestWebsiteUpdatesCommand(TestBase):
         mock_text = self.mocked_event_page
         mock.get(e.url, text=mock_text, status_code=200)
         metadata = self.cmd.empty_metadata()
-        metadata['instructors'] = self.expected_metadata_parsed['instructors']
-        metadata['latitude'] = self.expected_metadata_parsed['latitude']
-        metadata['longitude'] = self.expected_metadata_parsed['longitude']
+        metadata["instructors"] = self.expected_metadata_parsed["instructors"]
+        metadata["latitude"] = self.expected_metadata_parsed["latitude"]
+        metadata["longitude"] = self.expected_metadata_parsed["longitude"]
         e.repository_metadata = self.cmd.serialize(metadata)
         e.save()
 
         changes = self.cmd.detect_changes(branch, e)
         expected = [
-            'Helpers changed',
-            'Start date changed',
-            'End date changed',
-            'Country changed',
-            'Venue changed',
-            'Address changed',
-            'Contact details changed',
-            'Eventbrite key changed',
+            "Helpers changed",
+            "Start date changed",
+            "End date changed",
+            "Country changed",
+            "Venue changed",
+            "Address changed",
+            "Contact details changed",
+            "Eventbrite key changed",
         ]
         self.assertEqual(changes, expected)
 
@@ -373,12 +379,16 @@ class TestWebsiteUpdatesCommand(TestBase):
     def test_initialization(self, mock):
         """Make sure events are initialized to sane values."""
         e = Event.objects.create(
-            slug='with-changes', host=Organization.objects.first(),
-            url='https://swcarpentry.github.io/workshop-template/',
-            repository_last_commit_hash='', repository_metadata='',
-            metadata_changed=False, metadata_all_changes='')
+            slug="with-changes",
+            host=Organization.objects.first(),
+            url="https://swcarpentry.github.io/workshop-template/",
+            repository_last_commit_hash="",
+            repository_metadata="",
+            metadata_changed=False,
+            metadata_all_changes="",
+        )
 
-        hash_ = 'abcdefghijklmnopqrstuvwxyz'
+        hash_ = "abcdefghijklmnopqrstuvwxyz"
         branch = MagicMock()
         branch.commit = MagicMock()
         branch.commit.sha = hash_
@@ -390,13 +400,14 @@ class TestWebsiteUpdatesCommand(TestBase):
         e.refresh_from_db()
         # metadata updated
         self.assertEqual(e.repository_last_commit_hash, hash_)
-        self.assertEqual(self.cmd.deserialize(e.repository_metadata),
-                         self.expected_metadata_parsed)
+        self.assertEqual(
+            self.cmd.deserialize(e.repository_metadata), self.expected_metadata_parsed
+        )
 
-        self.assertEqual(e.metadata_all_changes, '')
+        self.assertEqual(e.metadata_all_changes, "")
         self.assertEqual(e.metadata_changed, False)
 
-    @unittest.skip('This command requires internet connection')
+    @unittest.skip("This command requires internet connection")
     def test_running(self):
         """Test running whole command."""
-        call_command('check_for_workshop_websites_updates')
+        call_command("check_for_workshop_websites_updates")

--- a/amy/workshops/tests/test_diff.py
+++ b/amy/workshops/tests/test_diff.py
@@ -15,13 +15,12 @@ class TestRevisions(TestBase):
         self.tag2, _ = Tag.objects.get_or_create(pk=2)
 
         with create_revision():
-            self.event = Event.objects.create(host=self.org_alpha,
-                                              slug='event')
+            self.event = Event.objects.create(host=self.org_alpha, slug="event")
             self.event.tags.add(self.tag1)
             self.event.save()
 
         with create_revision():
-            self.event.slug = 'better-event'
+            self.event.slug = "better-event"
             self.event.host = self.org_beta
             self.event.tags.add(self.tag2)
             self.event.save()
@@ -33,48 +32,44 @@ class TestRevisions(TestBase):
 
     def test_showing_diff_event(self):
         # get newer revision page
-        rv = self.client.get(reverse('object_changes',
-                                     args=[self.newer.pk]))
+        rv = self.client.get(reverse("object_changes", args=[self.newer.pk]))
 
         self.assertEqual(rv.status_code, 200)
-        assert rv.context['version1'] == self.older
-        assert rv.context['version2'] == self.newer
-        assert rv.context['revision'] == self.newer.revision
-        assert rv.context['object'] == self.event
+        assert rv.context["version1"] == self.older
+        assert rv.context["version2"] == self.newer
+        assert rv.context["revision"] == self.newer.revision
+        assert rv.context["object"] == self.event
 
     def test_diff_shows_coloured_labels(self):
         # get newer revision page
-        rv = self.client.get(reverse('object_changes',
-                                     args=[self.newer.pk]))
+        rv = self.client.get(reverse("object_changes", args=[self.newer.pk]))
         # Red label for removed host
-        self.assertContains(rv,
+        self.assertContains(
+            rv,
             '<a class="label label-danger" href="{}">-{}</a>'.format(
-                self.org_alpha.get_absolute_url(),
-                self.org_alpha
+                self.org_alpha.get_absolute_url(), self.org_alpha
             ),
-            html=True
+            html=True,
         )
         # Green label for assigned host
-        self.assertContains(rv,
+        self.assertContains(
+            rv,
             '<a class="label label-success" href="{}">+{}</a>'.format(
-                self.org_beta.get_absolute_url(),
-                self.org_beta
+                self.org_beta.get_absolute_url(), self.org_beta
             ),
-            html=True
+            html=True,
         )
         # Grey label for pre-assigned tag
-        self.assertContains(rv,
-            '<a class="label label-default" href="#">{}</a>'.format(
-                self.tag1
-            ),
-            html=True
+        self.assertContains(
+            rv,
+            '<a class="label label-default" href="#">{}</a>'.format(self.tag1),
+            html=True,
         )
         # Green label for additionally assigned tag
-        self.assertContains(rv,
-            '<a class="label label-success" href="#">+{}</a>'.format(
-                self.tag2
-            ),
-            html=True
+        self.assertContains(
+            rv,
+            '<a class="label label-success" href="#">+{}</a>'.format(self.tag2),
+            html=True,
         )
 
     def test_diff_shows_PK_for_deleted_relationships(self):
@@ -82,15 +77,12 @@ class TestRevisions(TestBase):
         self.tag1.delete()
         self.tag2.delete()
         # get newer revision page
-        rv = self.client.get(reverse('object_changes',
-                                     args=[self.newer.pk]))
-        self.assertContains(rv,
-            '<a class="label label-default" href="#">1</a>',
-            html=True
+        rv = self.client.get(reverse("object_changes", args=[self.newer.pk]))
+        self.assertContains(
+            rv, '<a class="label label-default" href="#">1</a>', html=True
         )
-        self.assertContains(rv,
-            '<a class="label label-success" href="#">+2</a>',
-            html=True
+        self.assertContains(
+            rv, '<a class="label label-success" href="#">+2</a>', html=True
         )
 
 
@@ -101,25 +93,28 @@ class TestRegression1083(TestBase):
     def test_regression_1083(self):
         with reversion.create_revision():
             alice = Person.objects.create_user(
-                username='alice', personal='Alice', family='Jones',
-                email='alice@jones.pl')
+                username="alice",
+                personal="Alice",
+                family="Jones",
+                email="alice@jones.pl",
+            )
 
         with reversion.create_revision():
             bob = Person.objects.create_user(
-                username='bob', personal='Bob', family='Smith',
-                email='bob@smith.pl')
+                username="bob", personal="Bob", family="Smith", email="bob@smith.pl"
+            )
 
         with reversion.create_revision():
-            alice.family = 'Williams'
+            alice.family = "Williams"
             alice.save()
-            bob.family = 'Brown'
+            bob.family = "Brown"
             bob.save()
 
-        res = self.app.get(reverse('person_details', args=[bob.pk]), user='admin')
+        res = self.app.get(reverse("person_details", args=[bob.pk]), user="admin")
 
-        revision = res.click('Last modified on')
-        self.assertIn('Smith', revision)
-        self.assertIn('Brown', revision)
+        revision = res.click("Last modified on")
+        self.assertIn("Smith", revision)
+        self.assertIn("Brown", revision)
 
-        back_to_person_view = revision.click('View newest')
-        self.assertIn('Brown', back_to_person_view)
+        back_to_person_view = revision.click("View newest")
+        self.assertIn("Brown", back_to_person_view)

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta, date, timezone
 from urllib.parse import urlencode
-import unittest
 import sys
 
 from django.contrib.sites.models import Site

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -239,7 +239,10 @@ class TestEvent(TestBase):
         assert event.website_url == link
 
     def test_open_TTT_applications_validation(self):
-        event = Event.objects.create(slug="test-event", host=self.org_alpha,)
+        event = Event.objects.create(
+            slug="test-event",
+            host=self.org_alpha,
+        )
 
         # without TTT tag, the validation fails
         event.open_TTT_applications = True
@@ -463,13 +466,13 @@ class TestEventViews(TestBase):
         response = self.client.post(reverse("event_add"), data, follow=True)
         event = Event.objects.get(slug="2016-07-09-test")
         self.assertRedirects(
-            response, reverse("event_details", kwargs={"slug": event.slug}),
+            response,
+            reverse("event_details", kwargs={"slug": event.slug}),
         )
         self.assertEqual(event.assigned_to, self.admin)
 
     def test_unique_non_empty_slug(self):
-        """Ensure events with no slugs are *not* saved to the DB.
-        """
+        """Ensure events with no slugs are *not* saved to the DB."""
         data = {
             "host": self.test_host.id,
             "tags": [self.test_tag.id],
@@ -1292,7 +1295,8 @@ class TestEventCreatePostWorkshopAction(
         )
 
         self.LC_org = Organization.objects.create(
-            domain="librarycarpentry.org", fullname="Library Carpentry",
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
         )
 
         template = EmailTemplate.objects.create(
@@ -1306,7 +1310,8 @@ class TestEventCreatePostWorkshopAction(
             body_template="# Welcome",
         )
         Trigger.objects.create(
-            action="week-after-workshop-completion", template=template,
+            action="week-after-workshop-completion",
+            template=template,
         )
 
     def test_job_scheduled(self):
@@ -1388,7 +1393,8 @@ class TestEventUpdatePostWorkshopAction(
         )
 
         self.LC_org = Organization.objects.create(
-            domain="librarycarpentry.org", fullname="Library Carpentry",
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
         )
 
         template = EmailTemplate.objects.create(
@@ -1402,7 +1408,8 @@ class TestEventUpdatePostWorkshopAction(
             body_template="# Welcome",
         )
         Trigger.objects.create(
-            action="week-after-workshop-completion", template=template,
+            action="week-after-workshop-completion",
+            template=template,
         )
 
     def test_job_scheduled(self):
@@ -1576,7 +1583,8 @@ class TestEventDeletePostWorkshopAction(
         )
 
         self.LC_org = Organization.objects.create(
-            domain="librarycarpentry.org", fullname="Library Carpentry",
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
         )
 
         template = EmailTemplate.objects.create(
@@ -1590,7 +1598,8 @@ class TestEventDeletePostWorkshopAction(
             body_template="# Welcome",
         )
         Trigger.objects.create(
-            action="week-after-workshop-completion", template=template,
+            action="week-after-workshop-completion",
+            template=template,
         )
 
     def test_job_unscheduled(self):
@@ -1693,7 +1702,8 @@ class TestEventUpdateInstructorsHostIntroduction(
         )
 
         self.LC_org = Organization.objects.create(
-            domain="librarycarpentry.org", fullname="Library Carpentry",
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
         )
 
         self.instructor = Role.objects.create(name="instructor")
@@ -1710,7 +1720,8 @@ class TestEventUpdateInstructorsHostIntroduction(
             body_template="# Welcome",
         )
         Trigger.objects.create(
-            action="instructors-host-introduction", template=template,
+            action="instructors-host-introduction",
+            template=template,
         )
 
         self.instructor1 = Person.objects.create(
@@ -1919,7 +1930,8 @@ class TestEventDeleteInstructorsHostIntroduction(
         )
 
         self.LC_org = Organization.objects.create(
-            domain="librarycarpentry.org", fullname="Library Carpentry",
+            domain="librarycarpentry.org",
+            fullname="Library Carpentry",
         )
 
         self.instructor = Role.objects.create(name="instructor")
@@ -1936,7 +1948,8 @@ class TestEventDeleteInstructorsHostIntroduction(
             body_template="# Welcome",
         )
         Trigger.objects.create(
-            action="instructors-host-introduction", template=template,
+            action="instructors-host-introduction",
+            template=template,
         )
 
         self.instructor1 = Person.objects.create(
@@ -2048,9 +2061,7 @@ class TestEventCreateAskForWebsite(TestCase):
     pass
 
 
-class TestEventUpdateAskForWebsite(
-    FakeRedisTestCaseMixin, SuperuserMixin, TestCase
-):
+class TestEventUpdateAskForWebsite(FakeRedisTestCaseMixin, SuperuserMixin, TestCase):
     def setUp(self):
         super().setUp()
 
@@ -2107,7 +2118,9 @@ class TestEventUpdateAskForWebsite(
         )
         event.tags.set(Tag.objects.filter(name__in=["LC", "automated-email"]))
         Task.objects.create(
-            event=event, person=self.instructor, role=self.instructor_role,
+            event=event,
+            person=self.instructor,
+            role=self.instructor_role,
         )
         self.assertFalse(AskForWebsiteAction.check(event))
 
@@ -2167,7 +2180,9 @@ class TestEventUpdateAskForWebsite(
         )
         event.tags.set(Tag.objects.filter(name__in=["LC", "automated-email"]))
         Task.objects.create(
-            event=event, person=self.instructor, role=self.instructor_role,
+            event=event,
+            person=self.instructor,
+            role=self.instructor_role,
         )
         self.assertFalse(AskForWebsiteAction.check(event))
 
@@ -2241,9 +2256,7 @@ class TestEventUpdateAskForWebsite(
         self.assertEqual(RQJob.objects.count(), 0)
 
 
-class TestEventDeleteAskForWebsite(
-    FakeRedisTestCaseMixin, SuperuserMixin, TestCase
-):
+class TestEventDeleteAskForWebsite(FakeRedisTestCaseMixin, SuperuserMixin, TestCase):
     def setUp(self):
         super().setUp()
 
@@ -2300,7 +2313,9 @@ class TestEventDeleteAskForWebsite(
         )
         event.tags.set(Tag.objects.filter(name__in=["LC", "automated-email"]))
         Task.objects.create(
-            event=event, person=self.instructor, role=self.instructor_role,
+            event=event,
+            person=self.instructor,
+            role=self.instructor_role,
         )
         self.assertFalse(AskForWebsiteAction.check(event))
 
@@ -2374,9 +2389,7 @@ class TestEventCreateRecruitHelpers(TestCase):
     pass
 
 
-class TestEventUpdateRecruitHelpers(
-    FakeRedisTestCaseMixin, SuperuserMixin, TestCase
-):
+class TestEventUpdateRecruitHelpers(FakeRedisTestCaseMixin, SuperuserMixin, TestCase):
     def setUp(self):
         super().setUp()
 
@@ -2436,7 +2449,9 @@ class TestEventUpdateRecruitHelpers(
         )
         event.tags.set(Tag.objects.filter(name__in=["LC", "automated-email"]))
         Task.objects.create(
-            event=event, person=self.instructor, role=self.instructor_role,
+            event=event,
+            person=self.instructor,
+            role=self.instructor_role,
         )
         self.assertFalse(RecruitHelpersAction.check(event))
 
@@ -2497,7 +2512,9 @@ class TestEventUpdateRecruitHelpers(
         )
         event.tags.set(Tag.objects.filter(name__in=["LC", "automated-email"]))
         Task.objects.create(
-            event=event, person=self.instructor, role=self.instructor_role,
+            event=event,
+            person=self.instructor,
+            role=self.instructor_role,
         )
         self.assertFalse(RecruitHelpersAction.check(event))
 
@@ -2573,9 +2590,7 @@ class TestEventUpdateRecruitHelpers(
         self.assertEqual(RQJob.objects.count(), 0)
 
 
-class TestEventDeleteRecruitHelpers(
-    FakeRedisTestCaseMixin, SuperuserMixin, TestCase
-):
+class TestEventDeleteRecruitHelpers(FakeRedisTestCaseMixin, SuperuserMixin, TestCase):
     def setUp(self):
         super().setUp()
 
@@ -2635,7 +2650,9 @@ class TestEventDeleteRecruitHelpers(
         )
         event.tags.set(Tag.objects.filter(name__in=["LC", "automated-email"]))
         Task.objects.create(
-            event=event, person=self.instructor, role=self.instructor_role,
+            event=event,
+            person=self.instructor,
+            role=self.instructor_role,
         )
         self.assertFalse(RecruitHelpersAction.check(event))
 

--- a/amy/workshops/tests/test_fields.py
+++ b/amy/workshops/tests/test_fields.py
@@ -50,7 +50,14 @@ class TestSelect2TagWidget(TestBase):
         # correct input (1 value)
         option1 = self.widget.create_option("name", "Harry", "Harry", set(["Harry"]), 0)
         self.assertEqual(
-            self.widget.optgroups("name", ["Harry"]), [(None, [option1], 0,)],
+            self.widget.optgroups("name", ["Harry"]),
+            [
+                (
+                    None,
+                    [option1],
+                    0,
+                )
+            ],
         )
 
         # correct input (2 values)
@@ -62,5 +69,11 @@ class TestSelect2TagWidget(TestBase):
         )
         self.assertEqual(
             self.widget.optgroups("name", ["Harry;Ron"]),
-            [(None, [option1, option2], 0,)],
+            [
+                (
+                    None,
+                    [option1, option2],
+                    0,
+                )
+            ],
         )

--- a/amy/workshops/tests/test_github_auth.py
+++ b/amy/workshops/tests/test_github_auth.py
@@ -15,4 +15,4 @@ class TestGithubUsernameToUid(TestBase):
         get_user_mock.side_effect = ConnectionResetError
 
         with self.assertRaises(ValueError):
-            got = github_username_to_uid("asdf qwer")
+            github_username_to_uid("asdf qwer")

--- a/amy/workshops/tests/test_github_auth.py
+++ b/amy/workshops/tests/test_github_auth.py
@@ -5,7 +5,7 @@ from workshops.github_auth import github_username_to_uid
 
 
 class TestGithubUsernameToUid(TestBase):
-    @patch('workshops.github_auth.Github.get_user')
+    @patch("workshops.github_auth.Github.get_user")
     def test_regression_1141(self, get_user_mock):
         """
         Github.get_user(username) is buggy and raises ConnectionResetError when
@@ -15,4 +15,4 @@ class TestGithubUsernameToUid(TestBase):
         get_user_mock.side_effect = ConnectionResetError
 
         with self.assertRaises(ValueError):
-            got = github_username_to_uid('asdf qwer')
+            got = github_username_to_uid("asdf qwer")

--- a/amy/workshops/tests/test_lookups.py
+++ b/amy/workshops/tests/test_lookups.py
@@ -10,10 +10,9 @@ class TestLookups(TestBase):
     def setUp(self):
         # prepare urlpatterns; only include lookup views that are restricted
         # to logged-in users and/or admins
-        self.patterns_nonrestricted = ('language-lookup', )
+        self.patterns_nonrestricted = ("language-lookup",)
         self.urlpatterns = filter(
-            lambda pattern: pattern.name not in self.patterns_nonrestricted,
-            urlpatterns
+            lambda pattern: pattern.name not in self.patterns_nonrestricted, urlpatterns
         )
 
     def test_login_regression(self):

--- a/amy/workshops/tests/test_person.py
+++ b/amy/workshops/tests/test_person.py
@@ -56,7 +56,7 @@ class TestPerson(TestBase):
         self.assertEqual(p2.family, "")
 
     def test_login_with_email(self):
-        """ Make sure we can login with user's email too, not only with the
+        """Make sure we can login with user's email too, not only with the
         username."""
         self.client.logout()
         email = "sudo@example.org"  # admin's email
@@ -176,7 +176,8 @@ class TestPerson(TestBase):
         }
 
         response = self.client.post(
-            reverse("person_permissions", args=[self.hermione.id]), data,
+            reverse("person_permissions", args=[self.hermione.id]),
+            data,
         )
 
         assert response.status_code == 302
@@ -239,8 +240,8 @@ class TestPerson(TestBase):
         assert set(self.hermione.lessons.all()) == {self.git}
 
     def test_person_add_lessons(self):
-        """ Check if it's still possible to add lessons via PersonCreate
-        view. """
+        """Check if it's still possible to add lessons via PersonCreate
+        view."""
         data = {
             "username": "test",
             "personal": "Test",
@@ -283,7 +284,9 @@ class TestPerson(TestBase):
         for username in invalid_usernames:
             with self.subTest(username=username):
                 person = Person.objects.create(
-                    personal="Testing", family="Testing", username=username,
+                    personal="Testing",
+                    family="Testing",
+                    username=username,
                 )
                 with self.assertRaises(ValidationError) as cm:
                     person.clean_fields(exclude=["password"])
@@ -291,7 +294,9 @@ class TestPerson(TestBase):
 
         valid_username = "blanking-crush_andy"
         person = Person.objects.create(
-            personal="Andy", family="Blanking-Crush", username=valid_username,
+            personal="Andy",
+            family="Blanking-Crush",
+            username=valid_username,
         )
         person.clean_fields(exclude=["password"])
 
@@ -352,7 +357,8 @@ class TestPerson(TestBase):
         }
 
         response = self.client.post(
-            reverse("person_permissions", args=[str(p.id)]), data,
+            reverse("person_permissions", args=[str(p.id)]),
+            data,
         )
         assert response.status_code == 302
 
@@ -1280,14 +1286,16 @@ class TestPersonUpdateViewPermissions(TestBase):
 
     def test_trainer_can_edit_self_profile(self):
         profile_edit = self.app.get(
-            reverse("person_edit", args=[self.trainer.pk]), user=self.trainer,
+            reverse("person_edit", args=[self.trainer.pk]),
+            user=self.trainer,
         )
         self.assertEqual(profile_edit.status_code, 200)
 
     def test_trainer_cannot_edit_stray_profile(self):
         with self.assertRaises(webtest.app.AppError):
             self.app.get(
-                reverse("person_edit", args=[self.trainee.pk]), user=self.trainer,
+                reverse("person_edit", args=[self.trainee.pk]),
+                user=self.trainer,
             )
 
 

--- a/amy/workshops/tests/test_security.py
+++ b/amy/workshops/tests/test_security.py
@@ -11,8 +11,13 @@ from markdownx.views import MarkdownifyView, ImageUploadView
 from config import urls
 from workshops.models import Person
 from workshops.tests.base import TestBase
-from workshops.util import OnlyForAdminsMixin, LoginNotRequiredMixin, \
-    admin_required, login_required, login_not_required
+from workshops.util import (
+    OnlyForAdminsMixin,
+    LoginNotRequiredMixin,
+    admin_required,
+    login_required,
+    login_not_required,
+)
 
 
 def get_resolved_urls(url_patterns):
@@ -20,9 +25,8 @@ def get_resolved_urls(url_patterns):
     http://stackoverflow.com/questions/1275486/django-how-can-i-see-a-list-of-urlpatterns"""
     url_patterns_resolved = []
     for entry in url_patterns:
-        if hasattr(entry, 'url_patterns'):
-            url_patterns_resolved += get_resolved_urls(
-                entry.url_patterns)
+        if hasattr(entry, "url_patterns"):
+            url_patterns_resolved += get_resolved_urls(entry.url_patterns)
         else:
             url_patterns_resolved.append(entry)
     return url_patterns_resolved
@@ -33,39 +37,50 @@ def get_view_by_name(name):
     try:
         return next(v.callback for v in views if v.name == name)
     except StopIteration:
-        raise ValueError('No view named {}'.format(name))
+        raise ValueError("No view named {}".format(name))
 
 
 class TestViews(TestBase):
     def setUp(self):
         super().setUp()
 
-        admins, _ = Group.objects.get_or_create(name='administrators')
-        steering_committee, _ = Group.objects.get_or_create(name='steering committee')
-        invoicing_group, _ = Group.objects.get_or_create(name='invoicing')
-        trainer_group, _ = Group.objects.get_or_create(name='trainers')
+        admins, _ = Group.objects.get_or_create(name="administrators")
+        steering_committee, _ = Group.objects.get_or_create(name="steering committee")
+        invoicing_group, _ = Group.objects.get_or_create(name="invoicing")
+        trainer_group, _ = Group.objects.get_or_create(name="trainers")
 
         # superuser who doesn't belong to Admin group should have access to
         # admin dashboard
         self.admin = Person.objects.create_superuser(
-            username='superuser', personal='Super', family='User',
-            email='superuser@example.org', password='superuser')
+            username="superuser",
+            personal="Super",
+            family="User",
+            email="superuser@example.org",
+            password="superuser",
+        )
         self.admin.data_privacy_agreement = True
         self.admin.save()
         assert admins not in self.admin.groups.all()
 
         # user belonging to Admin group should have access to admin dashboard
         self.mentor = Person.objects.create_user(
-            username='admin', personal='Bob', family='Admin',
-            email='admin@example.org', password='admin')
+            username="admin",
+            personal="Bob",
+            family="Admin",
+            email="admin@example.org",
+            password="admin",
+        )
         self.mentor.data_privacy_agreement = True
         self.mentor.save()
         self.mentor.groups.add(admins)
 
         # steering committee members should have access to admin dashboard too
         self.committee = Person.objects.create_user(
-            username='committee', personal='Bob', family='Committee',
-            email='committee@example.org', password='committee',
+            username="committee",
+            personal="Bob",
+            family="Committee",
+            email="committee@example.org",
+            password="committee",
         )
         self.committee.data_privacy_agreement = True
         self.committee.save()
@@ -73,8 +88,11 @@ class TestViews(TestBase):
 
         # members of invoicing group should have access to admin dashboard too
         self.invoicing = Person.objects.create_user(
-            username='invoicing', personal='Bob', family='Invoicing',
-            email='invoicing@example.org', password='invoicing',
+            username="invoicing",
+            personal="Bob",
+            family="Invoicing",
+            email="invoicing@example.org",
+            password="invoicing",
         )
         self.invoicing.data_privacy_agreement = True
         self.invoicing.save()
@@ -82,8 +100,11 @@ class TestViews(TestBase):
 
         # trainers should have access to admin dashboard too
         self.trainer = Person.objects.create_user(
-            username='trainer', personal='Bob', family='Trainer',
-            email='trainer@example.org', password='trainer',
+            username="trainer",
+            personal="Bob",
+            family="Trainer",
+            email="trainer@example.org",
+            password="trainer",
         )
         self.trainer.data_privacy_agreement = True
         self.trainer.save()
@@ -91,8 +112,12 @@ class TestViews(TestBase):
 
         # user with access only to trainee dashboard
         self.trainee = Person.objects.create_user(
-            username='trainee', personal='Bob', family='Trainee',
-            email='trainee@example.org', password='trainee')
+            username="trainee",
+            personal="Bob",
+            family="Trainee",
+            email="trainee@example.org",
+            password="trainee",
+        )
         self.trainee.data_privacy_agreement = True
         self.trainee.save()
         assert admins not in self.trainee.groups.all()
@@ -114,7 +139,7 @@ class TestViews(TestBase):
 
         # We should get 403 page (forbidden) or be redirected to login page.
         if response.status_code != 403:
-            login_url = '{}?next={}'.format(reverse('login'), url)
+            login_url = "{}?next={}".format(reverse("login"), url)
             self.assertRedirects(response, login_url)
 
     def test_function_based_view_restricted_to_admins(self):
@@ -122,17 +147,17 @@ class TestViews(TestBase):
         Test that a view decorated with @admin_required is accessible only
         for Admins.
         """
-        view_name = 'admin-dashboard'
+        view_name = "admin-dashboard"
         view = get_view_by_name(view_name)
         assert view._access_control_list == [admin_required]
         url = reverse(view_name)
 
-        self.assert_accessible(url, user='superuser')
-        self.assert_accessible(url, user='admin')
-        self.assert_accessible(url, user='committee')
-        self.assert_accessible(url, user='invoicing')
-        self.assert_accessible(url, user='trainer')
-        self.assert_inaccessible(url, user='trainee')
+        self.assert_accessible(url, user="superuser")
+        self.assert_accessible(url, user="admin")
+        self.assert_accessible(url, user="committee")
+        self.assert_accessible(url, user="invoicing")
+        self.assert_accessible(url, user="trainer")
+        self.assert_inaccessible(url, user="trainee")
         self.assert_inaccessible(url, user=None)
 
     def test_function_based_view_restricted_to_authorized_users(self):
@@ -140,17 +165,17 @@ class TestViews(TestBase):
         Test that a view decorated with @login_required is accessible
         only for Admins and Trainees.
         """
-        view_name = 'trainee-dashboard'
+        view_name = "trainee-dashboard"
         view = get_view_by_name(view_name)
         assert view._access_control_list == [login_required]
         url = reverse(view_name)
 
-        self.assert_accessible(url, user='superuser')
-        self.assert_accessible(url, user='admin')
-        self.assert_accessible(url, user='committee')
-        self.assert_accessible(url, user='invoicing')
-        self.assert_accessible(url, user='trainer')
-        self.assert_accessible(url, user='trainee')
+        self.assert_accessible(url, user="superuser")
+        self.assert_accessible(url, user="admin")
+        self.assert_accessible(url, user="committee")
+        self.assert_accessible(url, user="invoicing")
+        self.assert_accessible(url, user="trainer")
+        self.assert_accessible(url, user="trainee")
         self.assert_inaccessible(url, user=None)
 
     @unittest.expectedFailure
@@ -159,86 +184,84 @@ class TestViews(TestBase):
         Test that a view decorated with @login_not_required is accessible to
         everyone.
         """
-        view_name = 'profileupdate_request'
+        view_name = "profileupdate_request"
         view = get_view_by_name(view_name)
         assert view._access_control_list == [login_not_required]
         url = reverse(view_name)
 
-        self.assert_accessible(url, user='superuser')
-        self.assert_accessible(url, user='admin')
-        self.assert_accessible(url, user='committee')
-        self.assert_accessible(url, user='invoicing')
-        self.assert_accessible(url, user='trainer')
-        self.assert_accessible(url, user='trainee')
+        self.assert_accessible(url, user="superuser")
+        self.assert_accessible(url, user="admin")
+        self.assert_accessible(url, user="committee")
+        self.assert_accessible(url, user="invoicing")
+        self.assert_accessible(url, user="trainer")
+        self.assert_accessible(url, user="trainee")
         self.assert_accessible(url, user=None)
 
     def test_class_based_view_restricted_to_admins(self):
         """
         Test that a view with OnlyForAdminsMixin is accessible only for Admins.
         """
-        view_name = 'all_workshoprequests'
+        view_name = "all_workshoprequests"
         view = get_view_by_name(view_name)
         assert OnlyForAdminsMixin in view.view_class.__mro__
         url = reverse(view_name)
 
-        self.assert_accessible(url, user='superuser')
-        self.assert_accessible(url, user='admin')
-        self.assert_accessible(url, user='committee')
-        self.assert_accessible(url, user='invoicing')
-        self.assert_accessible(url, user='trainer')
-        self.assert_inaccessible(url, user='trainee')
+        self.assert_accessible(url, user="superuser")
+        self.assert_accessible(url, user="admin")
+        self.assert_accessible(url, user="committee")
+        self.assert_accessible(url, user="invoicing")
+        self.assert_accessible(url, user="trainer")
+        self.assert_inaccessible(url, user="trainee")
         self.assert_inaccessible(url, user=None)
 
     def test_class_based_view_accessible_to_unauthorized_users(self):
         """
         Test that a view with LoginNotRequiredMixin is accessible to everyone.
         """
-        view_name = 'workshop_request'
+        view_name = "workshop_request"
         view = get_view_by_name(view_name)
         assert LoginNotRequiredMixin in view.view_class.__mro__
         url = reverse(view_name)
 
-        self.assert_accessible(url, user='superuser')
-        self.assert_accessible(url, user='admin')
-        self.assert_accessible(url, user='committee')
-        self.assert_accessible(url, user='invoicing')
-        self.assert_accessible(url, user='trainer')
-        self.assert_accessible(url, user='trainee')
+        self.assert_accessible(url, user="superuser")
+        self.assert_accessible(url, user="admin")
+        self.assert_accessible(url, user="committee")
+        self.assert_accessible(url, user="invoicing")
+        self.assert_accessible(url, user="trainer")
+        self.assert_accessible(url, user="trainee")
         self.assert_accessible(url, user=None)
 
     IGNORED_VIEWS = [
         # auth
-        'login',
-        'logout',
-        'password_reset',
-        'password_reset_done',
-        'password_reset_confirm',
-        'password_reset_complete',
+        "login",
+        "logout",
+        "password_reset",
+        "password_reset_done",
+        "password_reset_confirm",
+        "password_reset_complete",
         # 'password_change',
         # 'password_change_done',
-
         # python-social-auth
-        'begin',
-        'complete',
-        'disconnect',
-        'disconnect_individual',
-
+        "begin",
+        "complete",
+        "disconnect",
+        "disconnect_individual",
         # anymail
-        'amazon_ses_inbound_webhook',
-        'mailgun_inbound_webhook',
-        'mailjet_inbound_webhook',
-        'postmark_inbound_webhook',
-        'sendgrid_inbound_webhook',
-        'sparkpost_inbound_webhook',
-        'amazon_ses_tracking_webhook',
-        'mailgun_tracking_webhook',
-        'mailjet_tracking_webhook',
-        'postmark_tracking_webhook',
-        'sendgrid_tracking_webhook',
-        'sendinblue_tracking_webhook',
-        'sparkpost_tracking_webhook',
-        'mandrill_webhook',
-        'mandrill_tracking_webhook',
+        "amazon_ses_inbound_webhook",
+        "mailgun_inbound_webhook",
+        "mailjet_inbound_webhook",
+        "postmark_inbound_webhook",
+        "sendgrid_inbound_webhook",
+        "sparkpost_inbound_webhook",
+        "amazon_ses_tracking_webhook",
+        "mailgun_tracking_webhook",
+        "mailjet_tracking_webhook",
+        "postmark_tracking_webhook",
+        "sendgrid_tracking_webhook",
+        "sendinblue_tracking_webhook",
+        "sparkpost_tracking_webhook",
+        "mandrill_webhook",
+        "mandrill_tracking_webhook",
     ]
 
     def test_all_views_have_explicit_access_control_defined(self):
@@ -264,56 +287,69 @@ class TestViews(TestBase):
         all_urls = get_resolved_urls(urls.urlpatterns)
 
         # ignore views listed on IGNORED_VIEWS list
-        all_urls = [u for u in all_urls
-                    if not hasattr(u, 'name') or u.name not in self.IGNORED_VIEWS]
+        all_urls = [
+            u
+            for u in all_urls
+            if not hasattr(u, "name") or u.name not in self.IGNORED_VIEWS
+        ]
 
         for url in all_urls:
             with self.subTest(view=url):
-                acl = getattr(url.callback, '_access_control_list', None)
-                model_admin = getattr(url.callback, 'model_admin', None)
-                admin_site = getattr(url.callback, 'admin_site', None)
+                acl = getattr(url.callback, "_access_control_list", None)
+                model_admin = getattr(url.callback, "model_admin", None)
+                admin_site = getattr(url.callback, "admin_site", None)
 
                 # v.callback is always a function, even when the view is
                 # class based. We try to find the class implementing the view.
-                view_class = getattr(url.callback, 'view_class', None)
-                cls = getattr(url.callback, 'cls', None)
+                view_class = getattr(url.callback, "view_class", None)
+                cls = getattr(url.callback, "cls", None)
                 class_ = view_class or cls or None
 
-                is_function_based_view = (model_admin is None and
-                                          admin_site is None and
-                                          class_ is None)
+                is_function_based_view = (
+                    model_admin is None and admin_site is None and class_ is None
+                )
 
                 if is_function_based_view:
                     self.assertTrue(
                         acl is not None,
-                        'You have a function based view with no access control'
-                        ' decorator. This view is probably accessible to every'
-                        ' user. If this is what you want, use '
-                        '@login_not_required decorator. Questionable view: '
-                        '"{}"'.format(url))
-                    self.assertEqual(len(acl), 1,
-                                     'You have more than one access control '
-                                     'decorator defined in this view.')
+                        "You have a function based view with no access control"
+                        " decorator. This view is probably accessible to every"
+                        " user. If this is what you want, use "
+                        "@login_not_required decorator. Questionable view: "
+                        '"{}"'.format(url),
+                    )
+                    self.assertEqual(
+                        len(acl),
+                        1,
+                        "You have more than one access control "
+                        "decorator defined in this view.",
+                    )
 
                 else:  # class based view
                     is_markdownx_view = class_ is not None and (
-                        issubclass(class_, MarkdownifyView) or
-                        issubclass(class_, ImageUploadView))
+                        issubclass(class_, MarkdownifyView)
+                        or issubclass(class_, ImageUploadView)
+                    )
 
                     if is_markdownx_view:
-                        self.assertTrue(acl is not None,
-                                        'Markdownx views must be decorated '
-                                        'with `login_required`.')
+                        self.assertTrue(
+                            acl is not None,
+                            "Markdownx views must be decorated "
+                            "with `login_required`.",
+                        )
                     else:
                         self.assertTrue(
                             acl is None,
-                            'It looks like you used access control decorator '
-                            'on a class based view. Use mixin instead.')
+                            "It looks like you used access control decorator "
+                            "on a class based view. Use mixin instead.",
+                        )
 
                         is_model_admin = isinstance(model_admin, ModelAdmin)
                         is_admin_site = isinstance(admin_site, AdminSite)
                         is_api_view = class_ is not None and issubclass(class_, APIView)
-                        is_redirect_view = class_ is not None and issubclass(class_, RedirectView)
+                        is_redirect_view = class_ is not None and issubclass(
+                            class_, RedirectView
+                        )
                         is_view = class_ is not None and issubclass(class_, View)
 
                         if is_model_admin or is_admin_site:
@@ -326,17 +362,20 @@ class TestViews(TestBase):
                             assert is_view
 
                             mixins = set(class_.__mro__)
-                            desired_mixins = {OnlyForAdminsMixin,
-                                              LoginNotRequiredMixin}
+                            desired_mixins = {OnlyForAdminsMixin, LoginNotRequiredMixin}
                             found = mixins & desired_mixins
 
                             self.assertNotEqual(
-                                len(found), 0,
-                                'The view {} ({}) lacks access control mixin '
-                                'and is probably accessible to every user. If '
-                                'this is what you want, use '
-                                'LoginNotRequiredMixin.'.format(class_.__name__, url))
+                                len(found),
+                                0,
+                                "The view {} ({}) lacks access control mixin "
+                                "and is probably accessible to every user. If "
+                                "this is what you want, use "
+                                "LoginNotRequiredMixin.".format(class_.__name__, url),
+                            )
                             self.assertEqual(
-                                len(found), 1,
-                                'You have more than one access control mixin '
-                                'defined in this view.')
+                                len(found),
+                                1,
+                                "You have more than one access control mixin "
+                                "defined in this view.",
+                            )

--- a/amy/workshops/tests/test_security.py
+++ b/amy/workshops/tests/test_security.py
@@ -22,7 +22,7 @@ from workshops.util import (
 
 def get_resolved_urls(url_patterns):
     """Copy-pasted from
-    http://stackoverflow.com/questions/1275486/django-how-can-i-see-a-list-of-urlpatterns"""
+    http://stackoverflow.com/questions/1275486/django-how-can-i-see-a-list-of-urlpatterns"""  # noqa: line too long
     url_patterns_resolved = []
     for entry in url_patterns:
         if hasattr(entry, "url_patterns"):

--- a/amy/workshops/tests/test_util.py
+++ b/amy/workshops/tests/test_util.py
@@ -89,33 +89,40 @@ Other content.
     @requests_mock.Mocker()
     def test_fetching_event_metadata_html(self, mock):
         "Ensure 'fetch_workshop_metadata' works correctly with HTML metadata provided."
-        website_url = 'https://pbanaszkiewicz.github.io/workshop'
-        repo_url = ('https://raw.githubusercontent.com/pbanaszkiewicz/'
-                    'workshop/gh-pages/index.html')
+        website_url = "https://pbanaszkiewicz.github.io/workshop"
+        repo_url = (
+            "https://raw.githubusercontent.com/pbanaszkiewicz/"
+            "workshop/gh-pages/index.html"
+        )
         mock.get(website_url, text=self.html_content, status_code=200)
-        mock.get(repo_url, text='', status_code=200)
+        mock.get(repo_url, text="", status_code=200)
         metadata = fetch_workshop_metadata(website_url)
-        self.assertEqual(metadata['slug'], '2015-07-13-test')
+        self.assertEqual(metadata["slug"], "2015-07-13-test")
 
     @requests_mock.Mocker()
     def test_fetching_event_metadata_yaml(self, mock):
         "Ensure 'fetch_workshop_metadata' works correctly with YAML metadata provided."
-        website_url = 'https://pbanaszkiewicz.github.io/workshop'
-        repo_url = ('https://raw.githubusercontent.com/pbanaszkiewicz/'
-                    'workshop/gh-pages/index.html')
-        mock.get(website_url, text='', status_code=200)
+        website_url = "https://pbanaszkiewicz.github.io/workshop"
+        repo_url = (
+            "https://raw.githubusercontent.com/pbanaszkiewicz/"
+            "workshop/gh-pages/index.html"
+        )
+        mock.get(website_url, text="", status_code=200)
         mock.get(repo_url, text=self.yaml_content, status_code=200)
         metadata = fetch_workshop_metadata(website_url)
-        self.assertEqual(metadata['slug'], 'workshop')
+        self.assertEqual(metadata["slug"], "workshop")
 
     @requests_mock.Mocker()
     def test_fetching_event_metadata_timeout(self, mock):
         "Ensure 'fetch_workshop_metadata' reacts to timeout."
-        website_url = 'https://pbanaszkiewicz.github.io/workshop'
-        repo_url = ('https://raw.githubusercontent.com/pbanaszkiewicz/'
-                    'workshop/gh-pages/index.html')
+        website_url = "https://pbanaszkiewicz.github.io/workshop"
+        repo_url = (
+            "https://raw.githubusercontent.com/pbanaszkiewicz/"
+            "workshop/gh-pages/index.html"
+        )
         mock.register_uri(
-            "GET", website_url,
+            "GET",
+            website_url,
             exc=requests.exceptions.ConnectTimeout,
         )
         with self.assertRaises(requests.exceptions.ConnectTimeout):
@@ -123,15 +130,17 @@ Other content.
 
     def test_generating_url_to_index(self):
         tests = [
-            'http://swcarpentry.github.io/workshop-template',
-            'https://swcarpentry.github.com/workshop-template',
-            'http://swcarpentry.github.com/workshop-template/',
-            'http://github.com/swcarpentry/workshop-template',
-            'https://github.com/swcarpentry/workshop-template',
+            "http://swcarpentry.github.io/workshop-template",
+            "https://swcarpentry.github.com/workshop-template",
+            "http://swcarpentry.github.com/workshop-template/",
+            "http://github.com/swcarpentry/workshop-template",
+            "https://github.com/swcarpentry/workshop-template",
         ]
-        expected_url = ('https://raw.githubusercontent.com/swcarpentry/'
-                        'workshop-template/gh-pages/index.html')
-        expected_repo = 'workshop-template'
+        expected_url = (
+            "https://raw.githubusercontent.com/swcarpentry/"
+            "workshop-template/gh-pages/index.html"
+        )
+        expected_repo = "workshop-template"
         for url in tests:
             with self.subTest(url=url):
                 url, repo = generate_url_to_event_index(url)
@@ -141,35 +150,35 @@ Other content.
     def test_finding_metadata_on_index(self):
         content = self.yaml_content
         expected = {
-            'startdate': '2015-07-13',
-            'enddate': '2015-07-14',
-            'country': 'us',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latlng': '36.998977, -109.045173',
-            'language': 'us',
-            'instructor': 'Hermione Granger|Ron Weasley',
-            'helper': 'Peter Parker|Tony Stark|Natasha Romanova',
-            'contact': 'hermione@granger.co.uk|rweasley@ministry.gov',
-            'eventbrite': '10000000',
+            "startdate": "2015-07-13",
+            "enddate": "2015-07-14",
+            "country": "us",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latlng": "36.998977, -109.045173",
+            "language": "us",
+            "instructor": "Hermione Granger|Ron Weasley",
+            "helper": "Peter Parker|Tony Stark|Natasha Romanova",
+            "contact": "hermione@granger.co.uk|rweasley@ministry.gov",
+            "eventbrite": "10000000",
         }
         self.assertEqual(expected, find_workshop_YAML_metadata(content))
 
     def test_finding_metadata_on_website(self):
         content = self.html_content
         expected = {
-            'slug': '2015-07-13-test',
-            'startdate': '2015-07-13',
-            'enddate': '2015-07-14',
-            'country': 'us',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latlng': '36.998977, -109.045173',
-            'language': 'us',
-            'instructor': 'Hermione Granger|Ron Weasley',
-            'helper': 'Peter Parker|Tony Stark|Natasha Romanova',
-            'contact': 'hermione@granger.co.uk|rweasley@ministry.gov',
-            'eventbrite': '10000000',
+            "slug": "2015-07-13-test",
+            "startdate": "2015-07-13",
+            "enddate": "2015-07-14",
+            "country": "us",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latlng": "36.998977, -109.045173",
+            "language": "us",
+            "instructor": "Hermione Granger|Ron Weasley",
+            "helper": "Peter Parker|Tony Stark|Natasha Romanova",
+            "contact": "hermione@granger.co.uk|rweasley@ministry.gov",
+            "eventbrite": "10000000",
         }
 
         self.assertEqual(expected, find_workshop_HTML_metadata(content))
@@ -197,18 +206,18 @@ Other content.
             </body></html>
         """
         expected = {
-            'slug': '',
-            'startdate': '',
-            'enddate': '',
-            'country': '',
-            'venue': '',
-            'address': '',
-            'latlng': '',
-            'language': '',
-            'instructor': '',
-            'helper': '',
-            'contact': '',
-            'eventbrite': '',
+            "slug": "",
+            "startdate": "",
+            "enddate": "",
+            "country": "",
+            "venue": "",
+            "address": "",
+            "latlng": "",
+            "language": "",
+            "instructor": "",
+            "helper": "",
+            "contact": "",
+            "eventbrite": "",
         }
         self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
@@ -223,22 +232,22 @@ Other content.
             </body></html>
         """
         expected = {
-            'slug': '',
+            "slug": "",
         }
         self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
     def test_finding_metadata_single_line(self):
         content = (
-            '<html><head>'
+            "<html><head>"
             '<meta name="slug" content="" />'
             '<meta name="charset" content="utf-8" />'
-            '</head>'
-            '<body>'
-            '<h1>test</h1>'
-            '</body></html>'
+            "</head>"
+            "<body>"
+            "<h1>test</h1>"
+            "</body></html>"
         )
         expected = {
-            'slug': '',
+            "slug": "",
         }
         self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
@@ -252,249 +261,258 @@ Other content.
     def test_parsing_empty_metadata(self):
         empty_dict = {}
         expected = {
-            'slug': '',
-            'language': '',
-            'start': None,
-            'end': None,
-            'country': '',
-            'venue': '',
-            'address': '',
-            'latitude': None,
-            'longitude': None,
-            'reg_key': None,
-            'instructors': [],
-            'helpers': [],
-            'contact': [],
+            "slug": "",
+            "language": "",
+            "start": None,
+            "end": None,
+            "country": "",
+            "venue": "",
+            "address": "",
+            "latitude": None,
+            "longitude": None,
+            "reg_key": None,
+            "instructors": [],
+            "helpers": [],
+            "contact": [],
         }
         self.assertEqual(expected, parse_workshop_metadata(empty_dict))
 
     def test_parsing_correct_metadata(self):
         metadata = {
-            'slug': '2015-07-13-test',
-            'startdate': '2015-07-13',
-            'enddate': '2015-07-14',
-            'country': 'us',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latlng': '36.998977, -109.045173',
-            'language': 'us',
-            'instructor': 'Hermione Granger|Ron Weasley',
-            'helper': 'Peter Parker|Tony Stark|Natasha Romanova',
-            'contact': 'hermione@granger.co.uk|rweasley@ministry.gov',
-            'eventbrite': '10000000',
+            "slug": "2015-07-13-test",
+            "startdate": "2015-07-13",
+            "enddate": "2015-07-14",
+            "country": "us",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latlng": "36.998977, -109.045173",
+            "language": "us",
+            "instructor": "Hermione Granger|Ron Weasley",
+            "helper": "Peter Parker|Tony Stark|Natasha Romanova",
+            "contact": "hermione@granger.co.uk|rweasley@ministry.gov",
+            "eventbrite": "10000000",
         }
         expected = {
-            'slug': '2015-07-13-test',
-            'language': 'US',
-            'start': datetime.date(2015, 7, 13),
-            'end': datetime.date(2015, 7, 14),
-            'country': 'US',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latitude': 36.998977,
-            'longitude': -109.045173,
-            'reg_key': 10000000,
-            'instructors': ['Hermione Granger', 'Ron Weasley'],
-            'helpers': ['Peter Parker', 'Tony Stark', 'Natasha Romanova'],
-            'contact': ['hermione@granger.co.uk', 'rweasley@ministry.gov'],
+            "slug": "2015-07-13-test",
+            "language": "US",
+            "start": datetime.date(2015, 7, 13),
+            "end": datetime.date(2015, 7, 14),
+            "country": "US",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latitude": 36.998977,
+            "longitude": -109.045173,
+            "reg_key": 10000000,
+            "instructors": ["Hermione Granger", "Ron Weasley"],
+            "helpers": ["Peter Parker", "Tony Stark", "Natasha Romanova"],
+            "contact": ["hermione@granger.co.uk", "rweasley@ministry.gov"],
         }
         self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_country_language(self):
         """Ensure we always get a 2-char string or nothing."""
         tests = [
-            (('Usa', 'English'), ('US', 'EN')),
-            (('U', 'E'), ('', '')),
-            (('', ''), ('', '')),
+            (("Usa", "English"), ("US", "EN")),
+            (("U", "E"), ("", "")),
+            (("", ""), ("", "")),
         ]
         expected = {
-            'slug': '',
-            'language': '',
-            'start': None,
-            'end': None,
-            'country': '',
-            'venue': '',
-            'address': '',
-            'latitude': None,
-            'longitude': None,
-            'reg_key': None,
-            'instructors': [],
-            'helpers': [],
-            'contact': [],
+            "slug": "",
+            "language": "",
+            "start": None,
+            "end": None,
+            "country": "",
+            "venue": "",
+            "address": "",
+            "latitude": None,
+            "longitude": None,
+            "reg_key": None,
+            "instructors": [],
+            "helpers": [],
+            "contact": [],
         }
 
         for (country, language), (country_exp, language_exp) in tests:
             with self.subTest(iso_31661=(country, language)):
                 metadata = dict(country=country, language=language)
-                expected['country'] = country_exp
-                expected['language'] = language_exp
+                expected["country"] = country_exp
+                expected["language"] = language_exp
                 self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_dates(self):
         """Test if non-dates don't get parsed."""
         tests = [
-            (('wrong start date', 'wrong end date'), (None, None)),
-            (('11/19/2015', '11/19/2015'), (None, None)),
+            (("wrong start date", "wrong end date"), (None, None)),
+            (("11/19/2015", "11/19/2015"), (None, None)),
         ]
         expected = {
-            'slug': '',
-            'language': '',
-            'start': None,
-            'end': None,
-            'country': '',
-            'venue': '',
-            'address': '',
-            'latitude': None,
-            'longitude': None,
-            'reg_key': None,
-            'instructors': [],
-            'helpers': [],
-            'contact': [],
+            "slug": "",
+            "language": "",
+            "start": None,
+            "end": None,
+            "country": "",
+            "venue": "",
+            "address": "",
+            "latitude": None,
+            "longitude": None,
+            "reg_key": None,
+            "instructors": [],
+            "helpers": [],
+            "contact": [],
         }
 
         for (startdate, enddate), (start, end) in tests:
             with self.subTest(dates=(startdate, enddate)):
                 metadata = dict(startdate=startdate, enddate=enddate)
-                expected['start'] = start
-                expected['end'] = end
+                expected["start"] = start
+                expected["end"] = end
                 self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_list_of_names(self):
         """Ensure we always get a list."""
         tests = [
-            (('', ''), ([], [])),
-            (('Hermione Granger', 'Peter Parker'),
-             (['Hermione Granger'], ['Peter Parker'])),
-            (('Harry,Ron', 'Hermione,Ginny'),
-             (['Harry,Ron'], ['Hermione,Ginny'])),
-            (('Harry| Ron', 'Hermione |Ginny'),
-             (['Harry', 'Ron'], ['Hermione', 'Ginny'])),
+            (("", ""), ([], [])),
+            (
+                ("Hermione Granger", "Peter Parker"),
+                (["Hermione Granger"], ["Peter Parker"]),
+            ),
+            (("Harry,Ron", "Hermione,Ginny"), (["Harry,Ron"], ["Hermione,Ginny"])),
+            (
+                ("Harry| Ron", "Hermione |Ginny"),
+                (["Harry", "Ron"], ["Hermione", "Ginny"]),
+            ),
         ]
         expected = {
-            'slug': '',
-            'language': '',
-            'start': None,
-            'end': None,
-            'country': '',
-            'venue': '',
-            'address': '',
-            'latitude': None,
-            'longitude': None,
-            'reg_key': None,
-            'instructors': [],
-            'helpers': [],
-            'contact': [],
+            "slug": "",
+            "language": "",
+            "start": None,
+            "end": None,
+            "country": "",
+            "venue": "",
+            "address": "",
+            "latitude": None,
+            "longitude": None,
+            "reg_key": None,
+            "instructors": [],
+            "helpers": [],
+            "contact": [],
         }
 
         for (instructor, helper), (instructors, helpers) in tests:
             with self.subTest(people=(instructor, helper)):
                 metadata = dict(instructor=instructor, helper=helper)
-                expected['instructors'] = instructors
-                expected['helpers'] = helpers
+                expected["instructors"] = instructors
+                expected["helpers"] = helpers
                 self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_latitude_longitude(self):
         tests = [
-            ('XYZ', (None, None)),
-            ('XYZ, ', (None, None)),
-            (',-123', (None, -123.0)),
-            (',', (None, None)),
+            ("XYZ", (None, None)),
+            ("XYZ, ", (None, None)),
+            (",-123", (None, -123.0)),
+            (",", (None, None)),
             (None, (None, None)),
         ]
         expected = {
-            'slug': '',
-            'language': '',
-            'start': None,
-            'end': None,
-            'country': '',
-            'venue': '',
-            'address': '',
-            'latitude': None,
-            'longitude': None,
-            'reg_key': None,
-            'instructors': [],
-            'helpers': [],
-            'contact': [],
+            "slug": "",
+            "language": "",
+            "start": None,
+            "end": None,
+            "country": "",
+            "venue": "",
+            "address": "",
+            "latitude": None,
+            "longitude": None,
+            "reg_key": None,
+            "instructors": [],
+            "helpers": [],
+            "contact": [],
         }
         for latlng, (latitude, longitude) in tests:
             with self.subTest(latlng=latlng):
                 metadata = dict(latlng=latlng)
-                expected['latitude'] = latitude
-                expected['longitude'] = longitude
+                expected["latitude"] = latitude
+                expected["longitude"] = longitude
                 self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_tricky_eventbrite_id(self):
         tests = [
-            ('', None),
-            ('string', None),
+            ("", None),
+            ("string", None),
             (None, None),
         ]
         expected = {
-            'slug': '',
-            'language': '',
-            'start': None,
-            'end': None,
-            'country': '',
-            'venue': '',
-            'address': '',
-            'latitude': None,
-            'longitude': None,
-            'reg_key': None,
-            'instructors': [],
-            'helpers': [],
-            'contact': [],
+            "slug": "",
+            "language": "",
+            "start": None,
+            "end": None,
+            "country": "",
+            "venue": "",
+            "address": "",
+            "latitude": None,
+            "longitude": None,
+            "reg_key": None,
+            "instructors": [],
+            "helpers": [],
+            "contact": [],
         }
         for eventbrite_id, reg_key in tests:
             with self.subTest(eventbrite_id=eventbrite_id):
                 metadata = dict(eventbrite=eventbrite_id)
-                expected['reg_key'] = reg_key
+                expected["reg_key"] = reg_key
                 self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_validating_invalid_metadata(self):
         metadata = {
-            'slug': 'WRONG FORMAT',
-            'language': 'ENGLISH',
-            'startdate': '07/13/2015',
-            'enddate': '07/14/2015',
-            'country': 'USA',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latlng': '3699e-4, -1.09e2',
-            'instructor': 'Hermione Granger, Ron Weasley',
-            'helper': 'Peter Parker, Tony Stark, Natasha Romanova',
-            'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
-            'eventbrite': 'bigmoney',
+            "slug": "WRONG FORMAT",
+            "language": "ENGLISH",
+            "startdate": "07/13/2015",
+            "enddate": "07/14/2015",
+            "country": "USA",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latlng": "3699e-4, -1.09e2",
+            "instructor": "Hermione Granger, Ron Weasley",
+            "helper": "Peter Parker, Tony Stark, Natasha Romanova",
+            "contact": "hermione@granger.co.uk, rweasley@ministry.gov",
+            "eventbrite": "bigmoney",
         }
         errors, warnings = validate_workshop_metadata(metadata)
         assert len(errors) == 7
         assert not warnings
-        assert all([error.startswith('Invalid value') for error in errors])
+        assert all([error.startswith("Invalid value") for error in errors])
 
     def test_validating_missing_metadata(self):
         metadata = {}
         errors, warnings = validate_workshop_metadata(metadata)
         assert len(errors) == 9  # There are nine required fields
         assert len(warnings) == 3  # There are three optional fields
-        assert all([issue.startswith('Missing')
-                    for issue in (errors + warnings)])
+        assert all([issue.startswith("Missing") for issue in (errors + warnings)])
 
     def test_validating_empty_metadata(self):
         metadata = {
-            'slug': '',
-            'language': '',
-            'startdate': '',
-            'enddate': '',
-            'country': '',
-            'venue': '',
-            'address': '',
-            'latlng': '',
-            'instructor': '',
-            'helper': '',
-            'contact': '',
-            'eventbrite': '',
+            "slug": "",
+            "language": "",
+            "startdate": "",
+            "enddate": "",
+            "country": "",
+            "venue": "",
+            "address": "",
+            "latlng": "",
+            "instructor": "",
+            "helper": "",
+            "contact": "",
+            "eventbrite": "",
         }
-        expected_errors = ['slug', 'startdate', 'country', 'latlng',
-                           'instructor', 'helper', 'contact']
+        expected_errors = [
+            "slug",
+            "startdate",
+            "country",
+            "latlng",
+            "instructor",
+            "helper",
+            "contact",
+        ]
         errors, warnings = validate_workshop_metadata(metadata)
         assert not warnings
         for error, key in zip(errors, expected_errors):
@@ -502,41 +520,38 @@ Other content.
 
     def test_validating_default_metadata(self):
         metadata = {
-            'slug': 'FIXME',
-            'language': 'FIXME',
-            'startdate': 'FIXME',
-            'enddate': 'FIXME',
-            'country': 'FIXME',
-            'venue': 'FIXME',
-            'address': 'FIXME',
-            'latlng': 'FIXME',
-            'eventbrite': 'FIXME',
-            'instructor': 'FIXME',
-            'helper': 'FIXME',
-            'contact': 'FIXME',
+            "slug": "FIXME",
+            "language": "FIXME",
+            "startdate": "FIXME",
+            "enddate": "FIXME",
+            "country": "FIXME",
+            "venue": "FIXME",
+            "address": "FIXME",
+            "latlng": "FIXME",
+            "eventbrite": "FIXME",
+            "instructor": "FIXME",
+            "helper": "FIXME",
+            "contact": "FIXME",
         }
         errors, warnings = validate_workshop_metadata(metadata)
         assert len(errors) == 12
         assert not warnings
-        assert all([
-            error.startswith('Placeholder value "FIXME"')
-            for error in errors
-        ])
+        assert all([error.startswith('Placeholder value "FIXME"') for error in errors])
 
     def test_validating_correct_metadata(self):
         metadata = {
-            'slug': '2015-07-13-test',
-            'language': 'us',
-            'startdate': '2015-07-13',
-            'enddate': '2015-07-14',
-            'country': 'us',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latlng': '36.998977, -109.045173',
-            'eventbrite': '10000000',
-            'instructor': 'Hermione Granger, Ron Weasley',
-            'helper': 'Peter Parker, Tony Stark, Natasha Romanova',
-            'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
+            "slug": "2015-07-13-test",
+            "language": "us",
+            "startdate": "2015-07-13",
+            "enddate": "2015-07-14",
+            "country": "us",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latlng": "36.998977, -109.045173",
+            "eventbrite": "10000000",
+            "instructor": "Hermione Granger, Ron Weasley",
+            "helper": "Peter Parker, Tony Stark, Natasha Romanova",
+            "contact": "hermione@granger.co.uk, rweasley@ministry.gov",
         }
         errors, warnings = validate_workshop_metadata(metadata)
         assert not warnings
@@ -547,30 +562,30 @@ Other content.
         or helpers aren't in the metadata or their values are None."""
         tests = [
             ((None, None), ([], [])),
-            ((None, ''), ([], [])),
-            (('', None), ([], [])),
+            ((None, ""), ([], [])),
+            (("", None), ([], [])),
         ]
         expected = {
-            'slug': '',
-            'language': '',
-            'start': None,
-            'end': None,
-            'country': '',
-            'venue': '',
-            'address': '',
-            'latitude': None,
-            'longitude': None,
-            'reg_key': None,
-            'instructors': [],
-            'helpers': [],
-            'contact': [],
+            "slug": "",
+            "language": "",
+            "start": None,
+            "end": None,
+            "country": "",
+            "venue": "",
+            "address": "",
+            "latitude": None,
+            "longitude": None,
+            "reg_key": None,
+            "instructors": [],
+            "helpers": [],
+            "contact": [],
         }
 
         for (instructor, helper), (instructors, helpers) in tests:
             with self.subTest(people=(instructor, helper)):
                 metadata = dict(instructor=instructor, helper=helper)
-                expected['instructors'] = instructors
-                expected['helpers'] = helpers
+                expected["instructors"] = instructors
+                expected["helpers"] = helpers
                 self.assertEqual(expected, parse_workshop_metadata(metadata))
 
 
@@ -613,111 +628,111 @@ Other content.
     def test_finding_metadata_on_index(self):
         content = self.yaml_content_old
         expected = {
-            'latlng': '36.998977, -109.045173',
+            "latlng": "36.998977, -109.045173",
         }
         self.assertEqual(expected, find_workshop_YAML_metadata(content))
 
         content = self.yaml_content_new
         expected = {
-            'lat': '36.998977',
-            'lng': '-109.045173',
+            "lat": "36.998977",
+            "lng": "-109.045173",
         }
         self.assertEqual(expected, find_workshop_YAML_metadata(content))
 
     def test_finding_metadata_on_website(self):
         content = self.html_content_old
         expected = {
-            'latlng': '36.998977, -109.045173',
+            "latlng": "36.998977, -109.045173",
         }
         self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
         content = self.html_content_new
         expected = {
-            'lat': '36.998977',
-            'lng': '-109.045173',
+            "lat": "36.998977",
+            "lng": "-109.045173",
         }
         self.assertEqual(expected, find_workshop_HTML_metadata(content))
 
     def test_parsing_old_latlng(self):
         metadata = {
-            'slug': '2015-07-13-test',
-            'startdate': '2015-07-13',
-            'enddate': '2015-07-14',
-            'country': 'us',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latlng': '36.998977, -109.045173',
-            'language': 'us',
-            'instructor': 'Hermione Granger|Ron Weasley',
-            'helper': 'Peter Parker|Tony Stark|Natasha Romanova',
-            'contact': 'hermione@granger.co.uk|rweasley@ministry.gov',
-            'eventbrite': '10000000',
+            "slug": "2015-07-13-test",
+            "startdate": "2015-07-13",
+            "enddate": "2015-07-14",
+            "country": "us",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latlng": "36.998977, -109.045173",
+            "language": "us",
+            "instructor": "Hermione Granger|Ron Weasley",
+            "helper": "Peter Parker|Tony Stark|Natasha Romanova",
+            "contact": "hermione@granger.co.uk|rweasley@ministry.gov",
+            "eventbrite": "10000000",
         }
         expected = {
-            'slug': '2015-07-13-test',
-            'language': 'US',
-            'start': datetime.date(2015, 7, 13),
-            'end': datetime.date(2015, 7, 14),
-            'country': 'US',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latitude': 36.998977,
-            'longitude': -109.045173,
-            'reg_key': 10000000,
-            'instructors': ['Hermione Granger', 'Ron Weasley'],
-            'helpers': ['Peter Parker', 'Tony Stark', 'Natasha Romanova'],
-            'contact': ['hermione@granger.co.uk', 'rweasley@ministry.gov'],
+            "slug": "2015-07-13-test",
+            "language": "US",
+            "start": datetime.date(2015, 7, 13),
+            "end": datetime.date(2015, 7, 14),
+            "country": "US",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latitude": 36.998977,
+            "longitude": -109.045173,
+            "reg_key": 10000000,
+            "instructors": ["Hermione Granger", "Ron Weasley"],
+            "helpers": ["Peter Parker", "Tony Stark", "Natasha Romanova"],
+            "contact": ["hermione@granger.co.uk", "rweasley@ministry.gov"],
         }
         self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_parsing_new_latlng(self):
         metadata = {
-            'slug': '2015-07-13-test',
-            'startdate': '2015-07-13',
-            'enddate': '2015-07-14',
-            'country': 'us',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'lat': '36.998977',
-            'lng': '-109.045173',
-            'language': 'us',
-            'instructor': 'Hermione Granger|Ron Weasley',
-            'helper': 'Peter Parker|Tony Stark|Natasha Romanova',
-            'contact': 'hermione@granger.co.uk|rweasley@ministry.gov',
-            'eventbrite': '10000000',
+            "slug": "2015-07-13-test",
+            "startdate": "2015-07-13",
+            "enddate": "2015-07-14",
+            "country": "us",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "lat": "36.998977",
+            "lng": "-109.045173",
+            "language": "us",
+            "instructor": "Hermione Granger|Ron Weasley",
+            "helper": "Peter Parker|Tony Stark|Natasha Romanova",
+            "contact": "hermione@granger.co.uk|rweasley@ministry.gov",
+            "eventbrite": "10000000",
         }
         expected = {
-            'slug': '2015-07-13-test',
-            'language': 'US',
-            'start': datetime.date(2015, 7, 13),
-            'end': datetime.date(2015, 7, 14),
-            'country': 'US',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'latitude': 36.998977,
-            'longitude': -109.045173,
-            'reg_key': 10000000,
-            'instructors': ['Hermione Granger', 'Ron Weasley'],
-            'helpers': ['Peter Parker', 'Tony Stark', 'Natasha Romanova'],
-            'contact': ['hermione@granger.co.uk', 'rweasley@ministry.gov'],
+            "slug": "2015-07-13-test",
+            "language": "US",
+            "start": datetime.date(2015, 7, 13),
+            "end": datetime.date(2015, 7, 14),
+            "country": "US",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "latitude": 36.998977,
+            "longitude": -109.045173,
+            "reg_key": 10000000,
+            "instructors": ["Hermione Granger", "Ron Weasley"],
+            "helpers": ["Peter Parker", "Tony Stark", "Natasha Romanova"],
+            "contact": ["hermione@granger.co.uk", "rweasley@ministry.gov"],
         }
         self.assertEqual(expected, parse_workshop_metadata(metadata))
 
     def test_validating_old_latlng(self):
         """"""
         metadata = {
-            'slug': '2015-07-13-test',
-            'language': 'us',
-            'startdate': '2015-07-13',
-            'enddate': '2015-07-14',
-            'country': 'us',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'eventbrite': '10000000',
-            'instructor': 'Hermione Granger, Ron Weasley',
-            'helper': 'Peter Parker, Tony Stark, Natasha Romanova',
-            'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
-            'latlng': '36.998977, -109.045173',
+            "slug": "2015-07-13-test",
+            "language": "us",
+            "startdate": "2015-07-13",
+            "enddate": "2015-07-14",
+            "country": "us",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "eventbrite": "10000000",
+            "instructor": "Hermione Granger, Ron Weasley",
+            "helper": "Peter Parker, Tony Stark, Natasha Romanova",
+            "contact": "hermione@granger.co.uk, rweasley@ministry.gov",
+            "latlng": "36.998977, -109.045173",
         }
         errors, warnings = validate_workshop_metadata(metadata)
         self.assertEqual(errors, [])
@@ -726,19 +741,19 @@ Other content.
     def test_validating_new_latlng(self):
         """"""
         metadata = {
-            'slug': '2015-07-13-test',
-            'language': 'us',
-            'startdate': '2015-07-13',
-            'enddate': '2015-07-14',
-            'country': 'us',
-            'venue': 'Euphoric State University',
-            'address': 'Highway to Heaven 42, Academipolis',
-            'eventbrite': '10000000',
-            'instructor': 'Hermione Granger, Ron Weasley',
-            'helper': 'Peter Parker, Tony Stark, Natasha Romanova',
-            'contact': 'hermione@granger.co.uk, rweasley@ministry.gov',
-            'lat': '36.998977',
-            'lng': '-109.045173',
+            "slug": "2015-07-13-test",
+            "language": "us",
+            "startdate": "2015-07-13",
+            "enddate": "2015-07-14",
+            "country": "us",
+            "venue": "Euphoric State University",
+            "address": "Highway to Heaven 42, Academipolis",
+            "eventbrite": "10000000",
+            "instructor": "Hermione Granger, Ron Weasley",
+            "helper": "Peter Parker, Tony Stark, Natasha Romanova",
+            "contact": "hermione@granger.co.uk, rweasley@ministry.gov",
+            "lat": "36.998977",
+            "lng": "-109.045173",
         }
         errors, warnings = validate_workshop_metadata(metadata)
         self.assertEqual(errors, [])
@@ -765,45 +780,39 @@ class TestMembership(TestBase):
             host=self.org_alpha,
             slug="in-past",
             start=today - three_years,
-            end=tomorrow - three_years
+            end=tomorrow - three_years,
         )
 
         present = Event.objects.create(
-            host=self.org_alpha,
-            slug="at-present",
-            start=today - one_month
+            host=self.org_alpha, slug="at-present", start=today - one_month
         )
 
         future = Event.objects.create(
             host=self.org_alpha,
             slug="in-future",
             start=today + one_month,
-            end=tomorrow + one_month
+            end=tomorrow + one_month,
         )
 
         # Roles and badges.
-        instructor_role = Role.objects.create(name='instructor')
-        member_badge = Badge.objects.create(name='member')
+        instructor_role = Role.objects.create(name="instructor")
+        member_badge = Badge.objects.create(name="member")
 
         # Spiderman is an explicit member.
-        Award.objects.create(person=self.spiderman, badge=member_badge,
-                             awarded=yesterday)
+        Award.objects.create(
+            person=self.spiderman, badge=member_badge, awarded=yesterday
+        )
 
         # Hermione teaches in the past, now, and in future, so she's a member.
-        Task.objects.create(event=past, person=self.hermione,
-                            role=instructor_role)
-        Task.objects.create(event=present, person=self.hermione,
-                            role=instructor_role)
-        Task.objects.create(event=future, person=self.hermione,
-                            role=instructor_role)
+        Task.objects.create(event=past, person=self.hermione, role=instructor_role)
+        Task.objects.create(event=present, person=self.hermione, role=instructor_role)
+        Task.objects.create(event=future, person=self.hermione, role=instructor_role)
 
         # Ron only teaches in the distant past, so he's not a member.
-        Task.objects.create(event=past, person=self.ron,
-                            role=instructor_role)
+        Task.objects.create(event=past, person=self.ron, role=instructor_role)
 
         # Harry only teaches in the future, so he's not a member.
-        Task.objects.create(event=future, person=self.harry,
-                            role=instructor_role)
+        Task.objects.create(event=future, person=self.harry, role=instructor_role)
 
     def test_members_default_cutoffs(self):
         """Make sure default membership rules are obeyed."""
@@ -833,38 +842,41 @@ class TestMembership(TestBase):
 
 class TestUsernameGeneration(TestBase):
     def setUp(self):
-        Person.objects.create_user(username='potter_harry', personal='Harry',
-                                   family='Potter', email='hp@ministry.gov')
+        Person.objects.create_user(
+            username="potter_harry",
+            personal="Harry",
+            family="Potter",
+            email="hp@ministry.gov",
+        )
 
     def test_conflicting_name(self):
         """Ensure `create_username` works correctly when conflicting username
         already exists."""
-        username = create_username(personal='Harry', family='Potter')
-        self.assertEqual(username, 'potter_harry_2')
+        username = create_username(personal="Harry", family="Potter")
+        self.assertEqual(username, "potter_harry_2")
 
     def test_nonconflicting_name(self):
         """Ensure `create_username` works correctly when there's no conflicts
         in the database."""
-        username = create_username(personal='Hermione', family='Granger')
-        self.assertEqual(username, 'granger_hermione')
+        username = create_username(personal="Hermione", family="Granger")
+        self.assertEqual(username, "granger_hermione")
 
     def test_nonlatin_characters(self):
         """Ensure correct behavior for non-latin names."""
-        username = create_username(personal='Grzegorz',
-                                   family='Brzęczyszczykiewicz')
-        self.assertEqual(username, 'brzczyszczykiewicz_grzegorz')
+        username = create_username(personal="Grzegorz", family="Brzęczyszczykiewicz")
+        self.assertEqual(username, "brzczyszczykiewicz_grzegorz")
 
     def test_reached_number_of_tries(self):
         """Ensure we don't DoS ourselves."""
         tries = 1
         with self.assertRaises(InternalError):
-            create_username(personal='Harry', family='Potter', tries=tries)
+            create_username(personal="Harry", family="Potter", tries=tries)
 
     def test_hyphenated_name(self):
         """Ensure people with hyphens in names have correct usernames
         generated."""
-        username = create_username(personal='Andy', family='Blanking-Crush')
-        self.assertEqual(username, 'blanking-crush_andy')
+        username = create_username(personal="Andy", family="Blanking-Crush")
+        self.assertEqual(username, "blanking-crush_andy")
 
     def test_noned_names(self):
         """This is a regression test against #1682
@@ -896,7 +908,7 @@ class TestPaginatorSections(TestBase):
         sections = paginator.paginate_sections()
         self.assertEqual(
             list(sections),
-            [1, 2, 3, 4, 5, None, 16, 17, 18, 19, 20]  # None is a break, '...'
+            [1, 2, 3, 4, 5, None, 16, 17, 18, 19, 20],  # None is a break, '...'
         )
 
     def test_in_the_middle(self):
@@ -907,8 +919,7 @@ class TestPaginatorSections(TestBase):
         self.assertEqual(
             list(sections),
             # None is a break, it appears as '...' in the paginator widget
-            [1, 2, 3, 4, 5, None, 8, 9, 10, 11, 12, 13, 14, None, 16, 17, 18,
-             19, 20]
+            [1, 2, 3, 4, 5, None, 8, 9, 10, 11, 12, 13, 14, None, 16, 17, 18, 19, 20],
         )
 
     def test_at_the_end(self):
@@ -919,7 +930,7 @@ class TestPaginatorSections(TestBase):
         self.assertEqual(
             list(sections),
             # None is a break, it appears as '...' in the paginator widget
-            [1, 2, 3, 4, 5, None, 16, 17, 18, 19, 20]
+            [1, 2, 3, 4, 5, None, 16, 17, 18, 19, 20],
         )
 
     def test_long_no_breaks(self):
@@ -930,24 +941,26 @@ class TestPaginatorSections(TestBase):
         self.assertEqual(
             list(sections),
             # None is a break, it appears as '...' in the paginator widget
-            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
         )
 
 
 class TestAssignUtil(TestBase):
     def setUp(self):
         """Set up RequestFactory for making fast fake requests."""
-        Person.objects.create_user(username='test_user', email='user@test',
-                                   personal='User', family='Test')
+        Person.objects.create_user(
+            username="test_user", email="user@test", personal="User", family="Test"
+        )
         self.factory = RequestFactory()
         self.event = Event.objects.create(
-            slug='event-for-assignment', host=Organization.objects.first())
+            slug="event-for-assignment", host=Organization.objects.first()
+        )
 
     def test_no_integer_pk(self):
         """Ensure we fail with 404 when person PK is string, not integer."""
         tests = [
-            (self.factory.get('/'), 'alpha'),
-            (self.factory.post('/', {'person': 'alpha'}), None),
+            (self.factory.get("/"), "alpha"),
+            (self.factory.post("/", {"person": "alpha"}), None),
         ]
         for request, person_id in tests:
             with self.subTest(method=request.method):
@@ -962,8 +975,8 @@ class TestAssignUtil(TestBase):
         """Ensure that with assignment is set correctly."""
         first_person = Person.objects.first()
         tests = [
-            (self.factory.get('/'), first_person.pk),
-            (self.factory.post('/', {'person': first_person.pk}), None),
+            (self.factory.get("/"), first_person.pk),
+            (self.factory.post("/", {"person": first_person.pk}), None),
         ]
         for request, person_id in tests:
             with self.subTest(method=request.method):
@@ -979,8 +992,8 @@ class TestAssignUtil(TestBase):
         """Ensure that with person_id=None, the assignment is removed."""
         first_person = Person.objects.first()
         tests = [
-            (self.factory.get('/'), None),
-            (self.factory.post('/'), None),
+            (self.factory.get("/"), None),
+            (self.factory.post("/"), None),
         ]
         for request, person_id in tests:
             with self.subTest(method=request.method):
@@ -996,25 +1009,38 @@ class TestAssignUtil(TestBase):
 
 class TestStr2Bool(TestBase):
     """Tests for ensuring str2bool works as expected."""
+
     def setUp(self):
         self.expected_true = (
-            'True', 'TRUE', 'true', 'tRuE',
-            '1',
-            't', 'T',
-            'yes', 'YES', 'yEs',
+            "True",
+            "TRUE",
+            "true",
+            "tRuE",
+            "1",
+            "t",
+            "T",
+            "yes",
+            "YES",
+            "yEs",
         )
         self.expected_false = (
-            'False', 'FALSE', 'false', 'fAlSe',
-            '0',
-            'f', 'F',
-            'no', 'NO', 'nO',
+            "False",
+            "FALSE",
+            "false",
+            "fAlSe",
+            "0",
+            "f",
+            "F",
+            "no",
+            "NO",
+            "nO",
         )
         self.expected_none = (
-            '',
-            ' ',
-            'dummy',
-            'None',
-            'asdgfh',
+            "",
+            " ",
+            "dummy",
+            "None",
+            "asdgfh",
         )
 
     def test_true(self):
@@ -1036,8 +1062,8 @@ class TestStr2Bool(TestBase):
 class TestHumanDaterange(TestBase):
     def setUp(self):
         self.formats = {
-            'no_date': '????',
-            'range_char': ' - ',
+            "no_date": "????",
+            "range_char": " - ",
         }
         self.inputs = (
             (datetime.datetime(2018, 9, 1), datetime.datetime(2018, 9, 30)),
@@ -1049,13 +1075,13 @@ class TestHumanDaterange(TestBase):
             (None, None),
         )
         self.expected_outputs = (
-            'Sep 01 - 30, 2018',
-            'Sep 30 - 01, 2018',
-            'Sep 01 - Dec 01, 2018',
-            'Sep 01, 2018 - Dec 01, 2019',
-            'Sep 01, 2018 - ????',
-            '???? - Sep 01, 2018',
-            '???? - ????',
+            "Sep 01 - 30, 2018",
+            "Sep 30 - 01, 2018",
+            "Sep 01 - Dec 01, 2018",
+            "Sep 01, 2018 - Dec 01, 2019",
+            "Sep 01, 2018 - ????",
+            "???? - Sep 01, 2018",
+            "???? - ????",
         )
 
     def test_function(self):
@@ -1069,85 +1095,90 @@ class TestHumanDaterange(TestBase):
 class TestMatchingNotificationEmail(TestBase):
     def setUp(self):
         self.request = WorkshopRequest.objects.create(
-            state="p", personal="Harry", family="Potter", email="h@potter.com",
+            state="p",
+            personal="Harry",
+            family="Potter",
+            email="h@potter.com",
             institution_other_name="Hogwarts",
-            institution_other_URL='hogwarts.uk',
-            location="Scotland", country="GB",
-            preferred_dates=None, other_preferred_dates="soon",
-            language=Language.objects.get(name='English'),
-            number_attendees='10-40',
+            institution_other_URL="hogwarts.uk",
+            location="Scotland",
+            country="GB",
+            preferred_dates=None,
+            other_preferred_dates="soon",
+            language=Language.objects.get(name="English"),
+            number_attendees="10-40",
             audience_description="Students of Hogwarts",
-            administrative_fee='waiver',
-            travel_expences_management='booked',
-            institution_restrictions='no_restrictions',
+            administrative_fee="waiver",
+            travel_expences_management="booked",
+            institution_restrictions="no_restrictions",
         )
 
     def test_default_criteria(self):
         # Online
-        self.request.country = 'W3'
+        self.request.country = "W3"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['workshops@carpentries.org'])
+        self.assertEqual(results, ["workshops@carpentries.org"])
 
         # European Union
-        self.request.country = 'EU'
+        self.request.country = "EU"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['workshops@carpentries.org'])
+        self.assertEqual(results, ["workshops@carpentries.org"])
 
         # United States
-        self.request.country = 'US'
+        self.request.country = "US"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['workshops@carpentries.org'])
+        self.assertEqual(results, ["workshops@carpentries.org"])
 
         # Poland
-        self.request.country = 'PL'
+        self.request.country = "PL"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['workshops@carpentries.org'])
+        self.assertEqual(results, ["workshops@carpentries.org"])
 
         # unknown country code
-        self.request.country = 'XY'
+        self.request.country = "XY"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['workshops@carpentries.org'])
+        self.assertEqual(results, ["workshops@carpentries.org"])
 
     def test_matching_Africa(self):
         """Testing just a subset of countries in Africa."""
 
         # the Democratic Republic of the Congo
-        self.request.country = 'CD'
+        self.request.country = "CD"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['admin-afr@carpentries.org'])
+        self.assertEqual(results, ["admin-afr@carpentries.org"])
 
         # Nigeria
-        self.request.country = 'NG'
+        self.request.country = "NG"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['admin-afr@carpentries.org'])
+        self.assertEqual(results, ["admin-afr@carpentries.org"])
 
         # South Sudan
-        self.request.country = 'SS'
+        self.request.country = "SS"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['admin-afr@carpentries.org'])
+        self.assertEqual(results, ["admin-afr@carpentries.org"])
 
         # Somalia
-        self.request.country = 'SO'
+        self.request.country = "SO"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['admin-afr@carpentries.org'])
+        self.assertEqual(results, ["admin-afr@carpentries.org"])
 
         # Egipt
-        self.request.country = 'EG'
+        self.request.country = "EG"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['admin-afr@carpentries.org'])
+        self.assertEqual(results, ["admin-afr@carpentries.org"])
 
         # Tunisia
-        self.request.country = 'TN'
+        self.request.country = "TN"
         results = list(match_notification_email(self.request))
-        self.assertEqual(results, ['admin-afr@carpentries.org'])
+        self.assertEqual(results, ["admin-afr@carpentries.org"])
 
     def test_matching_UK_CA_NZ_AU(self):
         """Test a bunch of criteria automatically."""
         data = [
-            ('GB', 'admin-uk@carpentries.org'),
-            ('CA', 'admin-ca@carpentries.org'),
-            ('NZ', 'admin-nz@carpentries.org'),
-            ('AU', 'admin-au@carpentries.org'),
+            ("GB", "admin-uk@carpentries.org"),
+            ("CA", "admin-ca@carpentries.org"),
+            ("NZ", "admin-nz@carpentries.org"),
+            ("AU", "admin-au@carpentries.org"),
         ]
         for code, email in data:
             with self.subTest(code=code):
@@ -1156,34 +1187,36 @@ class TestMatchingNotificationEmail(TestBase):
                 self.assertEqual(results, [email])
 
     def test_object_no_criteria(self):
-        self.assertFalse(hasattr(self, 'country'))
+        self.assertFalse(hasattr(self, "country"))
         results = match_notification_email(self)
-        self.assertEqual(results, ['workshops@carpentries.org'])
+        self.assertEqual(results, ["workshops@carpentries.org"])
 
         self.country = None
         results = match_notification_email(self)
-        self.assertEqual(results, ['workshops@carpentries.org'])
+        self.assertEqual(results, ["workshops@carpentries.org"])
 
 
 class TestReportsLink(TestBase):
     def setUp(self):
-        self.slug = '2020-04-12-Krakow'
+        self.slug = "2020-04-12-Krakow"
 
     def test_hash_lowercased_nonlowercased(self):
-        self.assertEqual(reports_link_hash(self.slug),
-                         reports_link_hash(self.slug.lower()))
+        self.assertEqual(
+            reports_link_hash(self.slug), reports_link_hash(self.slug.lower())
+        )
 
     def test_salts_alter_hash(self):
         hash_pre = reports_link_hash(self.slug)
 
-        with self.settings(REPORTS_SALT_FRONT='test12345'):
+        with self.settings(REPORTS_SALT_FRONT="test12345"):
             hash_salt_front = reports_link_hash(self.slug)
 
-        with self.settings(REPORTS_SALT_BACK='test12345'):
+        with self.settings(REPORTS_SALT_BACK="test12345"):
             hash_salt_back = reports_link_hash(self.slug)
 
-        with self.settings(REPORTS_SALT_FRONT='test12345',
-                           REPORTS_SALT_BACK='test12345'):
+        with self.settings(
+            REPORTS_SALT_FRONT="test12345", REPORTS_SALT_BACK="test12345"
+        ):
             hash_both_salts = reports_link_hash(self.slug)
 
         self.assertNotEqual(hash_pre, hash_salt_front)
@@ -1197,16 +1230,16 @@ class TestReportsLink(TestBase):
     def test_link(self):
         """Ensure the link gets correctly generated."""
 
-        with self.settings(REPORTS_LINK=''):
+        with self.settings(REPORTS_LINK=""):
             link = reports_link(self.slug)
-            self.assertEqual(link, '')
+            self.assertEqual(link, "")
 
-        with self.settings(REPORTS_LINK='{slug}'):
+        with self.settings(REPORTS_LINK="{slug}"):
             link = reports_link(self.slug)
             self.assertEqual(link, self.slug)
 
-        with self.settings(REPORTS_LINK='{slug}.{hash}'):
+        with self.settings(REPORTS_LINK="{slug}.{hash}"):
             link = reports_link(self.slug)
-            parts = link.split('.')
+            parts = link.split(".")
             self.assertEqual(parts[0], self.slug)
             self.assertEqual(parts[1], reports_link_hash(self.slug))

--- a/amy/workshops/tests/test_util.py
+++ b/amy/workshops/tests/test_util.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import datetime
 
-from django.contrib.auth.models import Group
 from django.http import Http404
 from django.test import RequestFactory
 
@@ -116,17 +115,13 @@ Other content.
     def test_fetching_event_metadata_timeout(self, mock):
         "Ensure 'fetch_workshop_metadata' reacts to timeout."
         website_url = "https://pbanaszkiewicz.github.io/workshop"
-        repo_url = (
-            "https://raw.githubusercontent.com/pbanaszkiewicz/"
-            "workshop/gh-pages/index.html"
-        )
         mock.register_uri(
             "GET",
             website_url,
             exc=requests.exceptions.ConnectTimeout,
         )
         with self.assertRaises(requests.exceptions.ConnectTimeout):
-            metadata = fetch_workshop_metadata(website_url)
+            fetch_workshop_metadata(website_url)
 
     def test_generating_url_to_index(self):
         tests = [

--- a/amy/workshops/tests/test_views_404.py
+++ b/amy/workshops/tests/test_views_404.py
@@ -10,46 +10,46 @@ class TestViewsFor404ing(TestBase):
         super()._setUpUsersAndLogin()
 
     def test_airport_details(self):
-        url = reverse('airport_details', args=['ASD'])
+        url = reverse("airport_details", args=["ASD"])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)
 
     def test_person_details(self):
-        url = reverse('person_details', args=[404])
+        url = reverse("person_details", args=[404])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)
 
     def test_person_edit(self):
-        url = reverse('person_edit', args=[404])
+        url = reverse("person_edit", args=[404])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)
 
     def test_event_details(self):
-        url = reverse('event_details', args=['non-existing-event'])
+        url = reverse("event_details", args=["non-existing-event"])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)
 
     def test_validate_event(self):
-        url = reverse('validate_event', args=['non-existing-event'])
+        url = reverse("validate_event", args=["non-existing-event"])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)
 
     def test_task_details(self):
-        url = reverse('task_details', args=[404])
+        url = reverse("task_details", args=[404])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)
 
     def test_badge_details(self):
-        url = reverse('badge_details', args=['non-existing-badge'])
+        url = reverse("badge_details", args=["non-existing-badge"])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)
 
     def test_revision_details(self):
-        url = reverse('object_changes', args=[1234])
+        url = reverse("object_changes", args=[1234])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)
 
     def test_organization_details(self):
-        url = reverse('organization_details', args=['non-existing-org'])
+        url = reverse("organization_details", args=["non-existing-org"])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)

--- a/amy/workshops/tests/test_workshop_staff_searching.py
+++ b/amy/workshops/tests/test_workshop_staff_searching.py
@@ -9,136 +9,136 @@ from workshops.views import _workshop_staff_query
 
 
 class TestLocateWorkshopStaff(TestBase):
-    '''Test cases for locating workshop staff.'''
+    """Test cases for locating workshop staff."""
 
     def setUp(self):
         super().setUp()
         self._setUpTags()
         self._setUpRoles()
         self._setUpUsersAndLogin()
-        self.url = reverse('workshop_staff')
+        self.url = reverse("workshop_staff")
 
     def test_non_instructors_and_instructors_returned_by_search(self):
         """Ensure search returns everyone with defined airport."""
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_0_0.pk,
-            }
+                "airport": self.airport_0_0.pk,
+            },
         )
         self.assertEqual(response.status_code, 200)
 
         # instructors
-        self.assertIn(self.hermione, response.context['persons'])
-        self.assertIn(self.harry, response.context['persons'])
-        self.assertIn(self.ron, response.context['persons'])
+        self.assertIn(self.hermione, response.context["persons"])
+        self.assertIn(self.harry, response.context["persons"])
+        self.assertIn(self.ron, response.context["persons"])
         # non-instructors
-        self.assertIn(self.spiderman, response.context['persons'])
-        self.assertIn(self.ironman, response.context['persons'])
-        self.assertIn(self.blackwidow, response.context['persons'])
+        self.assertIn(self.spiderman, response.context["persons"])
+        self.assertIn(self.ironman, response.context["persons"])
+        self.assertIn(self.blackwidow, response.context["persons"])
 
     def test_match_on_one_skill(self):
         """Ensure people with correct skill are returned."""
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_50_100.pk,
-                'lessons': [self.git.pk],
-            }
+                "airport": self.airport_50_100.pk,
+                "lessons": [self.git.pk],
+            },
         )
         self.assertEqual(response.status_code, 200)
         # lessons
-        self.assertIn(self.git, response.context['lessons'])
+        self.assertIn(self.git, response.context["lessons"])
 
         # instructors
-        self.assertIn(self.hermione, response.context['persons'])
-        self.assertNotIn(self.harry, response.context['persons'])
-        self.assertIn(self.ron, response.context['persons'])
+        self.assertIn(self.hermione, response.context["persons"])
+        self.assertNotIn(self.harry, response.context["persons"])
+        self.assertIn(self.ron, response.context["persons"])
         # non-instructors
-        self.assertNotIn(self.spiderman, response.context['persons'])
-        self.assertNotIn(self.ironman, response.context['persons'])
-        self.assertNotIn(self.blackwidow, response.context['persons'])
+        self.assertNotIn(self.spiderman, response.context["persons"])
+        self.assertNotIn(self.ironman, response.context["persons"])
+        self.assertNotIn(self.blackwidow, response.context["persons"])
 
     def test_match_instructors_on_two_skills(self):
         """Ensure people with correct skills are returned."""
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_50_100.pk,
-                'lessons': [self.git.pk, self.sql.pk],
-            }
+                "airport": self.airport_50_100.pk,
+                "lessons": [self.git.pk, self.sql.pk],
+            },
         )
         self.assertEqual(response.status_code, 200)
         # lessons
-        self.assertIn(self.git, response.context['lessons'])
-        self.assertIn(self.sql, response.context['lessons'])
+        self.assertIn(self.git, response.context["lessons"])
+        self.assertIn(self.sql, response.context["lessons"])
 
         # instructors
-        self.assertIn(self.hermione, response.context['persons'])
-        self.assertNotIn(self.harry, response.context['persons'])
-        self.assertNotIn(self.ron, response.context['persons'])
+        self.assertIn(self.hermione, response.context["persons"])
+        self.assertNotIn(self.harry, response.context["persons"])
+        self.assertNotIn(self.ron, response.context["persons"])
         # non-instructors
-        self.assertNotIn(self.spiderman, response.context['persons'])
-        self.assertNotIn(self.ironman, response.context['persons'])
-        self.assertNotIn(self.blackwidow, response.context['persons'])
+        self.assertNotIn(self.spiderman, response.context["persons"])
+        self.assertNotIn(self.ironman, response.context["persons"])
+        self.assertNotIn(self.blackwidow, response.context["persons"])
 
     def test_match_by_country(self):
         """Ensure people with airports in Bulgaria are returned."""
         response = self.client.get(
             self.url,
             {
-                'country': ['BG'],
-            }
+                "country": ["BG"],
+            },
         )
         self.assertEqual(response.status_code, 200)
 
         # instructors
-        self.assertNotIn(self.hermione, response.context['persons'])
-        self.assertIn(self.harry, response.context['persons'])
-        self.assertNotIn(self.ron, response.context['persons'])
+        self.assertNotIn(self.hermione, response.context["persons"])
+        self.assertIn(self.harry, response.context["persons"])
+        self.assertNotIn(self.ron, response.context["persons"])
         # non-instructors
-        self.assertNotIn(self.spiderman, response.context['persons'])
-        self.assertNotIn(self.ironman, response.context['persons'])
-        self.assertIn(self.blackwidow, response.context['persons'])
+        self.assertNotIn(self.spiderman, response.context["persons"])
+        self.assertNotIn(self.ironman, response.context["persons"])
+        self.assertIn(self.blackwidow, response.context["persons"])
 
     def test_match_by_multiple_countries(self):
         """Ensure people with airports in Albania and Bulgaria are returned."""
         response = self.client.get(
             self.url,
             {
-                'country': ['AL', 'BG'],
-            }
+                "country": ["AL", "BG"],
+            },
         )
         self.assertEqual(response.status_code, 200)
 
         # instructors
-        self.assertIn(self.hermione, response.context['persons'])
-        self.assertIn(self.harry, response.context['persons'])
-        self.assertNotIn(self.ron, response.context['persons'])
+        self.assertIn(self.hermione, response.context["persons"])
+        self.assertIn(self.harry, response.context["persons"])
+        self.assertNotIn(self.ron, response.context["persons"])
         # non-instructors
-        self.assertNotIn(self.spiderman, response.context['persons'])
-        self.assertNotIn(self.ironman, response.context['persons'])
-        self.assertIn(self.blackwidow, response.context['persons'])
+        self.assertNotIn(self.spiderman, response.context["persons"])
+        self.assertNotIn(self.ironman, response.context["persons"])
+        self.assertIn(self.blackwidow, response.context["persons"])
 
     def test_match_gender(self):
         """Ensure only people with specific gender are returned."""
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_0_0.pk,
-                'gender': 'F',
-            }
+                "airport": self.airport_0_0.pk,
+                "gender": "F",
+            },
         )
         self.assertEqual(response.status_code, 200)
 
         # instructors
-        self.assertIn(self.hermione, response.context['persons'])
-        self.assertNotIn(self.harry, response.context['persons'])
-        self.assertNotIn(self.ron, response.context['persons'])
+        self.assertIn(self.hermione, response.context["persons"])
+        self.assertNotIn(self.harry, response.context["persons"])
+        self.assertNotIn(self.ron, response.context["persons"])
         # non-instructors
-        self.assertNotIn(self.spiderman, response.context['persons'])
-        self.assertNotIn(self.ironman, response.context['persons'])
-        self.assertIn(self.blackwidow, response.context['persons'])
+        self.assertNotIn(self.spiderman, response.context["persons"])
+        self.assertNotIn(self.ironman, response.context["persons"])
+        self.assertIn(self.blackwidow, response.context["persons"])
 
     def test_instructor_badges(self):
         """Ensure people with instructor badges are returned by search. The
@@ -147,42 +147,42 @@ class TestLocateWorkshopStaff(TestBase):
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_0_0.pk,
-                'badges': Badge.objects.filter(name__in=[
-                    'swc-instructor',
-                    'dc-instructor']).values_list('pk', flat=True),
-            }
+                "airport": self.airport_0_0.pk,
+                "badges": Badge.objects.filter(
+                    name__in=["swc-instructor", "dc-instructor"]
+                ).values_list("pk", flat=True),
+            },
         )
         self.assertEqual(response.status_code, 200)
 
         # instructors
-        self.assertIn(self.hermione, response.context['persons'])  # SWC, DC,LC
-        self.assertIn(self.harry, response.context['persons'])  # SWC, DC
-        self.assertIn(self.ron, response.context['persons'])  # SWC only
+        self.assertIn(self.hermione, response.context["persons"])  # SWC, DC,LC
+        self.assertIn(self.harry, response.context["persons"])  # SWC, DC
+        self.assertIn(self.ron, response.context["persons"])  # SWC only
         # non-instructors
-        self.assertNotIn(self.spiderman, response.context['persons'])
-        self.assertNotIn(self.ironman, response.context['persons'])
-        self.assertNotIn(self.blackwidow, response.context['persons'])
+        self.assertNotIn(self.spiderman, response.context["persons"])
+        self.assertNotIn(self.ironman, response.context["persons"])
+        self.assertNotIn(self.blackwidow, response.context["persons"])
 
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_0_0.pk,
-                'badges': Badge.objects.filter(name__in=[
-                    'dc-instructor',
-                    'lc-instructor']).values_list('pk', flat=True),
-            }
+                "airport": self.airport_0_0.pk,
+                "badges": Badge.objects.filter(
+                    name__in=["dc-instructor", "lc-instructor"]
+                ).values_list("pk", flat=True),
+            },
         )
         self.assertEqual(response.status_code, 200)
 
         # instructors
-        self.assertIn(self.hermione, response.context['persons'])  # SWC, DC,LC
-        self.assertIn(self.harry, response.context['persons'])  # SWC, DC
-        self.assertNotIn(self.ron, response.context['persons'])  # SWC only
+        self.assertIn(self.hermione, response.context["persons"])  # SWC, DC,LC
+        self.assertIn(self.harry, response.context["persons"])  # SWC, DC
+        self.assertNotIn(self.ron, response.context["persons"])  # SWC only
         # non-instructors
-        self.assertNotIn(self.spiderman, response.context['persons'])
-        self.assertNotIn(self.ironman, response.context['persons'])
-        self.assertNotIn(self.blackwidow, response.context['persons'])
+        self.assertNotIn(self.spiderman, response.context["persons"])
+        self.assertNotIn(self.ironman, response.context["persons"])
+        self.assertNotIn(self.blackwidow, response.context["persons"])
 
     def test_match_on_one_language(self):
         """Ensure people with one particular language preference
@@ -199,13 +199,13 @@ class TestLocateWorkshopStaff(TestBase):
         response = self.client.get(
             self.url,
             {
-                'languages': [self.french.pk],
-            }
+                "languages": [self.french.pk],
+            },
         )
         self.assertEqual(response.status_code, 200)
 
-        self.assertIn(self.harry, response.context['persons'])
-        self.assertNotIn(self.ron, response.context['persons'])
+        self.assertIn(self.harry, response.context["persons"])
+        self.assertNotIn(self.ron, response.context["persons"])
 
     def test_match_on_many_language(self):
         """Ensure people with a set of language preferences
@@ -222,66 +222,75 @@ class TestLocateWorkshopStaff(TestBase):
         response = self.client.get(
             self.url,
             {
-                'languages': [self.english.pk, self.french.pk],
-            }
+                "languages": [self.english.pk, self.french.pk],
+            },
         )
         self.assertEqual(response.status_code, 200)
 
-        self.assertIn(self.ron, response.context['persons'])
-        self.assertNotIn(self.harry, response.context['persons'])
+        self.assertIn(self.ron, response.context["persons"])
+        self.assertNotIn(self.harry, response.context["persons"])
 
     def test_roles(self):
         """Ensure people with at least one helper/organizer roles are returned
         by search."""
         # prepare events and tasks
         self._setUpEvents()
-        helper_role = Role.objects.get(name='helper')
-        organizer_role = Role.objects.get(name='organizer')
+        helper_role = Role.objects.get(name="helper")
+        organizer_role = Role.objects.get(name="organizer")
 
-        Task.objects.create(role=helper_role, person=self.spiderman,
-                            event=Event.objects.first())
-        Task.objects.create(role=organizer_role, person=self.blackwidow,
-                            event=Event.objects.first())
+        Task.objects.create(
+            role=helper_role, person=self.spiderman, event=Event.objects.first()
+        )
+        Task.objects.create(
+            role=organizer_role, person=self.blackwidow, event=Event.objects.first()
+        )
 
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_0_0.pk,
-                'was_helper': 'on',
-            }
+                "airport": self.airport_0_0.pk,
+                "was_helper": "on",
+            },
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(response.context['persons']), [self.spiderman])
+        self.assertEqual(list(response.context["persons"]), [self.spiderman])
 
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_0_0.pk,
-                'was_organizer': 'on',
-            }
+                "airport": self.airport_0_0.pk,
+                "was_organizer": "on",
+            },
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(response.context['persons']), [self.blackwidow])
+        self.assertEqual(list(response.context["persons"]), [self.blackwidow])
 
     def test_form_logic(self):
         """Check if logic preventing searching from multiple fields,
         except lat+lng pair, and allowing searching from no location field,
         works."""
         test_vectors = [
-            (True, {'latitude': 1, 'longitude': 2}),
+            (True, {"latitude": 1, "longitude": 2}),
             (True, dict()),
-            (False, {'latitude': 1}),
-            (False, {'longitude': 1, 'country': ['BG']}),
-            (False, {'latitude': 1, 'longitude': 2, 'country': ['BG']}),
-            (False, {'latitude': 1, 'longitude': 2, 'country': ['BG'],
-                     'airport': self.airport_0_0.pk}),
+            (False, {"latitude": 1}),
+            (False, {"longitude": 1, "country": ["BG"]}),
+            (False, {"latitude": 1, "longitude": 2, "country": ["BG"]}),
+            (
+                False,
+                {
+                    "latitude": 1,
+                    "longitude": 2,
+                    "country": ["BG"],
+                    "airport": self.airport_0_0.pk,
+                },
+            ),
         ]
 
         for form_pass, data in test_vectors:
-            params = dict(submit='Submit')
+            params = dict(submit="Submit")
             params.update(data)
             rv = self.client.get(self.url, params)
-            form = rv.context['form']
+            form = rv.context["form"]
             self.assertEqual(form.is_valid(), form_pass, form.errors)
 
     def test_searching_trainees(self):
@@ -294,22 +303,23 @@ class TestLocateWorkshopStaff(TestBase):
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_0_0.pk,
-                'is_in_progress_trainee': 'on',
-            }
+                "airport": self.airport_0_0.pk,
+                "is_in_progress_trainee": "on",
+            },
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(response.context['persons']), [])
+        self.assertEqual(list(response.context["persons"]), [])
 
-        TTT = Tag.objects.get(name='TTT')
-        stalled = Tag.objects.get(name='stalled')
-        e1 = Event.objects.create(slug='TTT-event', host=Organization.objects.first())
+        TTT = Tag.objects.get(name="TTT")
+        stalled = Tag.objects.get(name="stalled")
+        e1 = Event.objects.create(slug="TTT-event", host=Organization.objects.first())
         e1.tags.set([TTT])
-        e2 = Event.objects.create(slug='stalled-TTT-event',
-                                  host=Organization.objects.first())
+        e2 = Event.objects.create(
+            slug="stalled-TTT-event", host=Organization.objects.first()
+        )
         e2.tags.set([TTT, stalled])
 
-        learner = Role.objects.get(name='learner')
+        learner = Role.objects.get(name="learner")
         # Ron is an instructor, so he should not be available as a trainee
         Task.objects.create(person=self.ron, event=e1, role=learner)
         Task.objects.create(person=self.ron, event=e2, role=learner)
@@ -328,28 +338,31 @@ class TestLocateWorkshopStaff(TestBase):
         response = self.client.get(
             self.url,
             {
-                'airport': self.airport_0_0.pk,
-                'is_in_progress_trainee': 'on',
-            }
+                "airport": self.airport_0_0.pk,
+                "is_in_progress_trainee": "on",
+            },
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            set(response.context['persons']), set([
-                self.blackwidow,
-                self.spiderman,
-            ])
+            set(response.context["persons"]),
+            set(
+                [
+                    self.blackwidow,
+                    self.spiderman,
+                ]
+            ),
         )
 
     def test_searching_trainers(self):
         """Make sure people with Trainer badge are shown correctly."""
         response = self.client.get(self.url, dict(is_trainer="on"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(response.context['persons']), [])
-        trainer = Badge.objects.get(name='trainer')
+        self.assertEqual(list(response.context["persons"]), [])
+        trainer = Badge.objects.get(name="trainer")
         self.harry.award_set.create(badge=trainer)
         response = self.client.get(self.url, dict(is_trainer="on"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(response.context['persons']), [self.harry])
+        self.assertEqual(list(response.context["persons"]), [self.harry])
 
 
 class TestWorkshopStaffCSV(TestBase):
@@ -361,12 +374,12 @@ class TestWorkshopStaffCSV(TestBase):
         self._setUpRoles()
         self._setUpUsersAndLogin()
 
-        self.url = reverse('workshop_staff_csv')
+        self.url = reverse("workshop_staff_csv")
 
     def test_header_row(self):
         """Ensure header contains the data we want."""
         rv = self.client.get(self.url)
-        first_row = rv.content.decode('utf-8').splitlines()[0]
+        first_row = rv.content.decode("utf-8").splitlines()[0]
         first_row_expected = (
             "Name,Email,Some badges,Has Trainer badge,Taught times,"
             "Is trainee,Airport,Country,Lessons,Affiliation"
@@ -377,19 +390,20 @@ class TestWorkshopStaffCSV(TestBase):
     def test_results(self):
         """Test for the workshop staff CSV output."""
         rv = self.client.get(self.url)
-        reader = csv.DictReader(io.StringIO(rv.content.decode('utf-8')))
+        reader = csv.DictReader(io.StringIO(rv.content.decode("utf-8")))
         results = _workshop_staff_query()
         for row, expected in zip(reader, results):
-            self.assertEqual(row['Name'], expected.full_name)
-            self.assertEqual(row['Email'] or None, expected.email)
-            self.assertEqual(row['Some badges'],
-                             " ".join(map(lambda x: x.name,
-                                          expected.important_badges)))
-            self.assertEqual(row['Has Trainer badge'],
-                             'yes' if expected.is_trainer else 'no')
-            self.assertEqual(row['Taught times'], str(expected.num_taught))
-            self.assertEqual(row['Is trainee'],
-                             'yes' if expected.is_trainee else 'no')
-            self.assertEqual(row['Airport'], str(expected.airport))
-            self.assertEqual(row['Country'], expected.country.name)
-            self.assertEqual(row['Affiliation'], expected.affiliation)
+            self.assertEqual(row["Name"], expected.full_name)
+            self.assertEqual(row["Email"] or None, expected.email)
+            self.assertEqual(
+                row["Some badges"],
+                " ".join(map(lambda x: x.name, expected.important_badges)),
+            )
+            self.assertEqual(
+                row["Has Trainer badge"], "yes" if expected.is_trainer else "no"
+            )
+            self.assertEqual(row["Taught times"], str(expected.num_taught))
+            self.assertEqual(row["Is trainee"], "yes" if expected.is_trainee else "no")
+            self.assertEqual(row["Airport"], str(expected.airport))
+            self.assertEqual(row["Country"], expected.country.name)
+            self.assertEqual(row["Affiliation"], expected.affiliation)

--- a/amy/workshops/util.py
+++ b/amy/workshops/util.py
@@ -7,7 +7,7 @@ from hashlib import sha1
 from itertools import chain
 import logging
 import re
-from typing import Optional, Union, Tuple
+from typing import Optional, Union
 
 import requests
 import yaml
@@ -567,12 +567,16 @@ class Paginator(DjangoPaginator):
 
         L = items[0:5]
 
+        four_after_index = index + 4
+        one_after_index = index + 1
         if index - 3 == 5:
             # Fix when two sets, L_s and M_s, are disjoint but make a sequence
             # [... 3 4, 5 6 ...], then there should not be dots between them
-            M = items[index - 4 : index + 4] or items[0 : index + 1]
+            four_before_index = index - 4
+            M = items[four_before_index:four_after_index] or items[0:one_after_index]
         else:
-            M = items[index - 3 : index + 4] or items[0 : index + 1]
+            three_before_index = index - 3
+            M = items[three_before_index:four_after_index] or items[0:one_after_index]
 
         if index + 4 == length - 5:
             # Fix when two sets, M_s and R_s, are disjoint but make a sequence

--- a/amy/workshops/util.py
+++ b/amy/workshops/util.py
@@ -491,7 +491,8 @@ def update_manual_score(cleaned_data):
                 score_manual = item["score_manual"]
                 score_notes = item["score_notes"]
                 records += TrainingRequest.objects.filter(pk=obj.pk).update(
-                    score_manual=score_manual, score_notes=score_notes,
+                    score_manual=score_manual,
+                    score_notes=score_notes,
                 )
             except (IntegrityError, ValueError, TypeError, ObjectDoesNotExist) as e:
                 raise e
@@ -569,9 +570,9 @@ class Paginator(DjangoPaginator):
         if index - 3 == 5:
             # Fix when two sets, L_s and M_s, are disjoint but make a sequence
             # [... 3 4, 5 6 ...], then there should not be dots between them
-            M = items[index - 4:index + 4] or items[0:index + 1]
+            M = items[index - 4 : index + 4] or items[0 : index + 1]
         else:
-            M = items[index - 3:index + 4] or items[0:index + 1]
+            M = items[index - 3 : index + 4] or items[0 : index + 1]
 
         if index + 4 == length - 5:
             # Fix when two sets, M_s and R_s, are disjoint but make a sequence
@@ -825,7 +826,8 @@ def validate_workshop_metadata(metadata):
     warnings = []
 
     Requirement = namedtuple(
-        "Requirement", ["name", "display", "required", "match_format"],
+        "Requirement",
+        ["name", "display", "required", "match_format"],
     )
 
     DATE_FMT = r"^\d{4}-\d{2}-\d{2}$"
@@ -1135,7 +1137,8 @@ def merge_objects(
                 # WARNING: sequence of operations is important here!
                 comments_b.update(is_removed=True)
                 comments_a.update(
-                    content_type=base_obj_ct, object_pk=base_obj.pk,
+                    content_type=base_obj_ct,
+                    object_pk=base_obj.pk,
                 )
 
             elif value == "obj_b":
@@ -1144,17 +1147,20 @@ def merge_objects(
                 # WARNING: sequence of operations is important here!
                 comments_a.update(is_removed=True)
                 comments_b.update(
-                    content_type=base_obj_ct, object_pk=base_obj.pk,
+                    content_type=base_obj_ct,
+                    object_pk=base_obj.pk,
                 )
 
             elif value == "combine":
                 # we're making comments from either of the objects point to
                 # the new base object
                 comments_a.update(
-                    content_type=base_obj_ct, object_pk=base_obj.pk,
+                    content_type=base_obj_ct,
+                    object_pk=base_obj.pk,
                 )
                 comments_b.update(
-                    content_type=base_obj_ct, object_pk=base_obj.pk,
+                    content_type=base_obj_ct,
+                    object_pk=base_obj.pk,
                 )
 
         merging_obj.delete()
@@ -1211,7 +1217,7 @@ def redirect_with_next_support(request, *args, **kwargs):
     """Works in the same way as `redirect` except when there is GET parameter
     named "next". In that case, user is redirected to the URL from that
     parameter. If you have a class-based view, use RedirectSupportMixin that
-    does the same. """
+    does the same."""
 
     next_url = request.GET.get("next", None)
     if next_url is not None and is_safe_url(
@@ -1257,7 +1263,11 @@ def choice_field_with_other(choices, default, verbose_name=None, help_text=None)
         default=default,
     )
     other_field = models.CharField(
-        max_length=STR_LONG, verbose_name=" ", null=False, blank=True, default="",
+        max_length=STR_LONG,
+        verbose_name=" ",
+        null=False,
+        blank=True,
+        default="",
     )
     return field, other_field
 

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -243,7 +243,6 @@ class PersonDetails(OnlyForAdminsMixin, AMYDetailView):
                     output_field=IntegerField(),
                 )
             ),
-
             num_supporting=Count(
                 Case(
                     When(task__role__name="supporting-instructor", then=Value(1)),
@@ -1432,7 +1431,7 @@ def events_metadata_changed(request):
     context = {
         "title": "Events with metadata changed",
         "events": events,
-        'assignment_form': assignment_form,
+        "assignment_form": assignment_form,
         "assigned_to": assigned_to,
     }
     return render(request, "workshops/events_metadata_changed.html", context)
@@ -1575,7 +1574,10 @@ class TaskDetails(OnlyForAdminsMixin, AMYDetailView):
 
 
 class TaskCreate(
-    OnlyForAdminsMixin, PermissionRequiredMixin, RedirectSupportMixin, AMYCreateView,
+    OnlyForAdminsMixin,
+    PermissionRequiredMixin,
+    RedirectSupportMixin,
+    AMYCreateView,
 ):
     permission_required = "workshops.add_task"
     model = Task
@@ -1643,7 +1645,8 @@ class TaskCreate(
                     self.request,
                     'Training "{}" has start or end date outside '
                     'membership "{}" agreement dates.'.format(
-                        str(event), str(seat_membership),
+                        str(event),
+                        str(seat_membership),
                     ),
                 )
 
@@ -1677,9 +1680,8 @@ class TaskCreate(
             )
 
         # check conditions for running a InstructorsHostIntroductionAction
-        if (
-            not check_ihia_old
-            and InstructorsHostIntroductionAction.check(self.object.event)
+        if not check_ihia_old and InstructorsHostIntroductionAction.check(
+            self.object.event
         ):
             triggers = Trigger.objects.filter(
                 active=True, action="instructors-host-introduction"
@@ -1695,10 +1697,7 @@ class TaskCreate(
             )
 
         # check conditions for running an AskForWebsiteAction
-        if (
-            not check_afwa_old
-            and AskForWebsiteAction.check(self.object.event)
-        ):
+        if not check_afwa_old and AskForWebsiteAction.check(self.object.event):
             triggers = Trigger.objects.filter(active=True, action="ask-for-website")
             ActionManageMixin.add(
                 action_class=AskForWebsiteAction,
@@ -1711,10 +1710,7 @@ class TaskCreate(
             )
 
         # check conditions for running a RecruitHelpersAction
-        if (
-            not check_rha_old
-            and RecruitHelpersAction.check(self.object.event)
-        ):
+        if not check_rha_old and RecruitHelpersAction.check(self.object.event):
             triggers = Trigger.objects.filter(active=True, action="recruit-helpers")
             ActionManageMixin.add(
                 action_class=RecruitHelpersAction,
@@ -1728,10 +1724,7 @@ class TaskCreate(
 
         # When someone adds a helper, then the condition will no longer be met and we
         # have to remove the job.
-        elif (
-            check_rha_old
-            and not RecruitHelpersAction.check(self.object.event)
-        ):
+        elif check_rha_old and not RecruitHelpersAction.check(self.object.event):
             jobs = self.object.event.rq_jobs.filter(trigger__action="recruit-helpers")
             ActionManageMixin.remove(
                 action_class=RecruitHelpersAction,
@@ -1748,7 +1741,9 @@ class TaskCreate(
 
 
 class TaskUpdate(
-    OnlyForAdminsMixin, PermissionRequiredMixin, AMYUpdateView,
+    OnlyForAdminsMixin,
+    PermissionRequiredMixin,
+    AMYUpdateView,
 ):
     permission_required = "workshops.change_task"
     model = Task
@@ -1916,7 +1911,10 @@ class TaskUpdate(
 
 
 class TaskDelete(
-    OnlyForAdminsMixin, PermissionRequiredMixin, RedirectSupportMixin, AMYDeleteView,
+    OnlyForAdminsMixin,
+    PermissionRequiredMixin,
+    RedirectSupportMixin,
+    AMYDeleteView,
 ):
     model = Task
     permission_required = "workshops.delete_task"
@@ -1976,9 +1974,7 @@ class TaskDelete(
 
         # AskForWebsiteAction conditions were met, but aren't anymore
         if self.check_afwa_old and not self.check_afwa_new:
-            jobs = self.object.event.rq_jobs.filter(
-                trigger__action="ask-for-website"
-            )
+            jobs = self.object.event.rq_jobs.filter(trigger__action="ask-for-website")
             ActionManageMixin.remove(
                 action_class=AskForWebsiteAction,
                 logger=logger,

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -14,15 +14,16 @@ from django.core.wsgi import get_wsgi_application
 
 # This allows easy placement of apps within the interior
 # amy directory.
-app_path = os.path.abspath(os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), os.pardir))
-sys.path.append(os.path.join(app_path, 'amy'))
+app_path = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir)
+)
+sys.path.append(os.path.join(app_path, "amy"))
 
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
 # if running multiple sites in the same mod_wsgi process. To fix this, use
 # mod_wsgi daemon mode with each site in its own daemon process, or use
 # os.environ["DJANGO_SETTINGS_MODULE"] = "config.settings.production"
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION

--- a/manage.py
+++ b/manage.py
@@ -2,8 +2,8 @@
 import os
 import sys
 
-if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
Updates the README and runs Black on everything with the commit skipped by the git blame. As of the creation of this PR. This is not true for the GitHub blame UI:

> The one caveat is that GitHub and GitLab do not yet support ignoring revisions using their native UI of blame. So blame information will be cluttered with a reformatting commit on those platforms. (If you'd like this feature, there's an open issue for GitLab and please let GitHub know!)

See for more info on the process: https://github.com/psf/black/#migrating-your-code-style-without-ruining-git-blame

Fixes https://github.com/carpentries/amy/issues/1812.