### PR TITLE
[#1819] Fix search for single result

### DIFF
--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -163,7 +163,5 @@ class SearchForm(forms.Form):
     """Represent general searching form."""
 
     term = forms.CharField(label="Term", max_length=100)
-    no_redirect = forms.BooleanField(
-        required=False, initial=False, widget=forms.HiddenInput
-    )
+    no_redirect = forms.BooleanField(required=False, initial=False)
     helper = BootstrapHelper(add_cancel_button=False, use_get_method=True)

--- a/amy/dashboard/tests/test_search.py
+++ b/amy/dashboard/tests/test_search.py
@@ -183,3 +183,19 @@ class TestSearch(TestBase):
 
         self.assertEqual(len(response.context["memberships"]), 1)
         self.assertEqual(len(response.context["organisations"]), 0)
+
+    def test_search_redirect_two_single_results(self):
+        """Regression test: make sure redirect doesn't happen if two single results are
+        present."""
+        Comment.objects.create(
+            content_object=self.org_alpha,
+            user=self.hermione,
+            comment="Testing commenting system for Alpha Organization",
+            submit_date=datetime.now(tz=timezone.utc),
+            site=Site.objects.get_current(),
+        )
+
+        response = self.search_for("Alpha", no_redirect=False, follow=False)
+        self.assertEqual(response.status_code, 200)  # doesn't redirect
+        self.assertEqual(len(response.context["organisations"]), 1)
+        self.assertEqual(len(response.context["comments"]), 1)


### PR DESCRIPTION
When one result group contained single result, the other results would
be ignored. This fixes the invalid logic.
