### PR TITLE
feature(Consents): Generate fake terms and consents for dev database.

### DIFF
--- a/amy/consents/models.py
+++ b/amy/consents/models.py
@@ -45,21 +45,26 @@ class ConsentQuerySet(models.query.QuerySet):
 
 
 class Term(CreatedUpdatedArchivedMixin, models.Model):
+    PROFILE_REQUIRE_TYPE = "profile"
+    OPTIONAL_REQUIRE_TYPE = "optional"
     TERM_REQUIRE_TYPE = (
-        ("profile", "Required to create a Profile"),
-        ("optional", "Optional"),
+        (PROFILE_REQUIRE_TYPE, "Required to create a Profile"),
+        (OPTIONAL_REQUIRE_TYPE, "Optional"),
     )
 
     slug = models.SlugField(unique=True)
     content = models.TextField(verbose_name="Content")
     required_type = models.CharField(
-        max_length=STR_MED, choices=TERM_REQUIRE_TYPE, default="optional"
+        max_length=STR_MED, choices=TERM_REQUIRE_TYPE, default=OPTIONAL_REQUIRE_TYPE
     )
     objects = TermQuerySet.as_manager()
 
 
 class TermOption(CreatedUpdatedArchivedMixin, models.Model):
-    OPTION_TYPE = (("agree", "Agree"), ("decline", "Decline"), ("unset", "Unset"))
+    AGREE = "agree"
+    DECLINE = "decline"
+    UNSET = "unset"
+    OPTION_TYPE = ((AGREE, "Agree"), (DECLINE, "Decline"), (UNSET, "Unset"))
 
     term = models.ForeignKey(Term, on_delete=models.CASCADE)
     option_type = models.CharField(max_length=STR_MED, choices=OPTION_TYPE)

--- a/amy/workshops/management/commands/fake_database.py
+++ b/amy/workshops/management/commands/fake_database.py
@@ -863,10 +863,10 @@ class Command(BaseCommand):
         user_old_enough = Term.objects.create(
             content="Are you 18 years of age or older?",
             slug="18-or-older",
-            required_type="profile",
+            required_type=Term.PROFILE_REQUIRE_TYPE,
         )
         user_old_enough_agree = TermOption.objects.create(
-            term=user_old_enough, option_type="agree"
+            term=user_old_enough, option_type=TermOption.AGREE
         )
         may_contact = Term.objects.create(
             content="May contact: Allow to contact from The Carpentries according to"
@@ -874,10 +874,10 @@ class Command(BaseCommand):
             slug="may-contact",
         )
         may_contact_agree = TermOption.objects.create(
-            term=may_contact, option_type="agree"
+            term=may_contact, option_type=TermOption.AGREE
         )
         may_contact_disagree = TermOption.objects.create(
-            term=may_contact, option_type="disagree"
+            term=may_contact, option_type=TermOption.DECLINE
         )
         may_publish_name = Term.objects.create(
             content="Do you consent to have your name or identity"
@@ -886,21 +886,21 @@ class Command(BaseCommand):
         )
         may_publish_name_agree1 = TermOption.objects.create(
             term=may_publish_name,
-            option_type="agree",
+            option_type=TermOption.AGREE,
             content="Yes, and only use my GitHub Handle",
         )
         may_publish_name_agree2 = TermOption.objects.create(
             term=may_publish_name,
-            option_type="agree",
+            option_type=TermOption.AGREE,
             content="Yes, and use the name associated with my ORCID profile",
         )
         may_publish_name_agree3 = TermOption.objects.create(
             term=may_publish_name,
-            option_type="agree",
+            option_type=TermOption.AGREE,
             content="Yes, and use the name associated with my profile.",
         )
         may_publish_name_disagree = TermOption.objects.create(
-            term=may_publish_name, option_type="disagree"
+            term=may_publish_name, option_type=TermOption.DECLINE
         )
 
         for person in Person.objects.all():

--- a/amy/workshops/management/commands/fake_database.py
+++ b/amy/workshops/management/commands/fake_database.py
@@ -47,6 +47,7 @@ from workshops.models import (
     WorkshopRequest,
 )
 from workshops.util import create_username
+from consents.models import Term, TermOption, Consent
 
 
 def randbool(chances_of_true):
@@ -854,6 +855,77 @@ class Command(BaseCommand):
             req.workshop_types.set(workshop_types)
             req.save()
 
+    def fake_terms_and_consents(self):
+        count = (
+            Person.objects.all().count() * 3
+        )  # all persons * number of consents generated
+        self.stdout.write("Generating {} fake " "terms and consents...".format(count))
+        user_old_enough = Term.objects.create(
+            content="Are you 18 years of age or older?",
+            slug="18-or-older",
+            required_type="profile",
+        )
+        user_old_enough_agree = TermOption.objects.create(
+            term=user_old_enough, option_type="agree"
+        )
+        may_contact = Term.objects.create(
+            content="May contact: Allow to contact from The Carpentries according to"
+            " the Privacy Policy.",
+            slug="may-contact",
+        )
+        may_contact_agree = TermOption.objects.create(
+            term=may_contact, option_type="agree"
+        )
+        may_contact_disagree = TermOption.objects.create(
+            term=may_contact, option_type="disagree"
+        )
+        may_publish_name = Term.objects.create(
+            content="Do you consent to have your name or identity"
+            " associated with lesson publications?",
+            slug="may-publish-name",
+        )
+        may_publish_name_agree1 = TermOption.objects.create(
+            term=may_publish_name,
+            option_type="agree",
+            content="Yes, and only use my GitHub Handle",
+        )
+        may_publish_name_agree2 = TermOption.objects.create(
+            term=may_publish_name,
+            option_type="agree",
+            content="Yes, and use the name associated with my ORCID profile",
+        )
+        may_publish_name_agree3 = TermOption.objects.create(
+            term=may_publish_name,
+            option_type="agree",
+            content="Yes, and use the name associated with my profile.",
+        )
+        may_publish_name_disagree = TermOption.objects.create(
+            term=may_publish_name, option_type="disagree"
+        )
+
+        for person in Person.objects.all():
+            Consent.objects.create(
+                person=person, term_option=user_old_enough_agree, term=user_old_enough
+            )
+            Consent.objects.create(
+                person=person,
+                term_option=choice([may_contact_agree, may_contact_disagree]),
+                term=may_contact,
+            )
+            may_publish_name_answer = choice(
+                [
+                    may_publish_name_agree1,
+                    may_publish_name_agree2,
+                    may_publish_name_agree3,
+                    may_publish_name_disagree,
+                ]
+            )
+            Consent.objects.create(
+                person=person,
+                term_option=may_publish_name_answer,
+                term=may_publish_name,
+            )
+
     def handle(self, *args, **options):
         seed = options["seed"]
         if seed is not None:
@@ -882,6 +954,7 @@ class Command(BaseCommand):
             self.fake_workshop_requests()
             self.fake_workshop_inquiries()
             self.fake_selforganised_submissions()
+            self.fake_terms_and_consents()
         except IntegrityError as e:
             print("!!!" * 10)
             print("Delete the database, and rerun this script.")


### PR DESCRIPTION
Fixes https://github.com/carpentries/amy/issues/1842


It adds three terms:
- Are you 18 years of age or older?
- May contact: Allow to contact from The Carpentries according to the Privacy Policy.
- Do you consent to have your name or identity associated with lesson publications?

Then adds consents for all the terms above to all persons in the database. 

## Testing
```
$ make dev_database
...
Generating 255 fake terms and consents...
...
$ python manage.py shell  
>>> from consents.models import *
>>> Term.objects.all()
<TermQuerySet [<Term: Term object (1)>, <Term: Term object (2)>, <Term: Term object (3)>]>
>>> Consent.objects.all().count()
255
```