### PR TITLE
fix typo in documentation

### DIFF
--- a/docs/amy_database_structure.md
+++ b/docs/amy_database_structure.md
@@ -36,7 +36,7 @@ The primary tables used in AMY (that will likely appear in every query) are thos
 
 ## Persons
 
-`workshops_persons` - Primary table for all person data. This includes all individuals, regardless of their role with The Carpentries.
+`workshops_person` - Primary table for all person data. This includes all individuals, regardless of their role with The Carpentries.
 
 ### Commonly used fields
 


### PR DESCRIPTION
We do not have a `workshops_persons` table, but we do have a `workshops_person` table.
