### PR TITLE
[#1835] Switch Organization.domain to accept domain + path

### DIFF
--- a/amy/api/urls.py
+++ b/amy/api/urls.py
@@ -7,7 +7,7 @@ from api import views
 app_name = 'api'
 
 # routers generate URLs for methods like `.list` or `.retrieve`
-router = routers.SimpleRouter()
+router = routers.SimpleRouter(trailing_slash=False)
 router.register('persons', views.PersonViewSet)
 awards_router = routers.NestedSimpleRouter(router, 'persons', lookup='person')
 awards_router.register('awards', views.AwardViewSet, basename='person-awards')

--- a/amy/api/views.py
+++ b/amy/api/views.py
@@ -201,7 +201,7 @@ class OrganizationViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
     lookup_field = "domain"
-    lookup_value_regex = r"[^/]+"  # the default one doesn't work with domains
+    lookup_value_regex = ".+"  # the default one doesn't work with domains with paths
     pagination_class = StandardResultsSetPagination
 
 

--- a/amy/fiscal/base_views.py
+++ b/amy/fiscal/base_views.py
@@ -1,3 +1,5 @@
+from urllib.parse import unquote
+
 from django.shortcuts import get_object_or_404
 from django.views.generic import FormView
 
@@ -51,3 +53,11 @@ class MembershipFormsetView(GetMembershipMixin, FormView):
 
     def get_success_url(self):
         return self.membership.get_absolute_url()
+
+
+class UnquoteSlugMixin:
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        slug_url = self.kwargs.get(self.slug_url_kwarg)
+        if slug_url is not None:
+            self.kwargs[self.slug_url_kwarg] = unquote(slug_url)

--- a/amy/fiscal/views.py
+++ b/amy/fiscal/views.py
@@ -33,6 +33,7 @@ from fiscal.models import MembershipTask
 from fiscal.base_views import (
     GetMembershipMixin,
     MembershipFormsetView,
+    UnquoteSlugMixin,
 )
 from workshops.base_views import (
     AMYCreateView,
@@ -77,7 +78,7 @@ class AllOrganizations(OnlyForAdminsMixin, AMYListView):
     title = "All Organizations"
 
 
-class OrganizationDetails(OnlyForAdminsMixin, AMYDetailView):
+class OrganizationDetails(UnquoteSlugMixin, OnlyForAdminsMixin, AMYDetailView):
     queryset = Organization.objects.prefetch_related("memberships")
     context_object_name = "organization"
     template_name = "fiscal/organization.html"
@@ -112,7 +113,9 @@ class OrganizationCreate(OnlyForAdminsMixin, PermissionRequiredMixin, AMYCreateV
         return initial
 
 
-class OrganizationUpdate(OnlyForAdminsMixin, PermissionRequiredMixin, AMYUpdateView):
+class OrganizationUpdate(
+    UnquoteSlugMixin, OnlyForAdminsMixin, PermissionRequiredMixin, AMYUpdateView
+):
     permission_required = "workshops.change_organization"
     model = Organization
     form_class = OrganizationForm
@@ -121,7 +124,9 @@ class OrganizationUpdate(OnlyForAdminsMixin, PermissionRequiredMixin, AMYUpdateV
     template_name = "generic_form_with_comments.html"
 
 
-class OrganizationDelete(OnlyForAdminsMixin, PermissionRequiredMixin, AMYDeleteView):
+class OrganizationDelete(
+    UnquoteSlugMixin, OnlyForAdminsMixin, PermissionRequiredMixin, AMYDeleteView
+):
     model = Organization
     slug_field = "domain"
     slug_url_kwarg = "org_domain"

--- a/amy/templates/dashboard/admin_dashboard.html
+++ b/amy/templates/dashboard/admin_dashboard.html
@@ -82,7 +82,7 @@
         {% endif %}
         <!-- HOST -->
         <td>
-          <a href="{% url 'organization_details' event.host.domain %}">
+          <a href="{% url 'organization_details' event.host.domain_quoted %}">
             {{ event.host }}
           </a>
         </td>

--- a/amy/templates/dashboard/search.html
+++ b/amy/templates/dashboard/search.html
@@ -54,7 +54,7 @@
             {% if organisations %}
             <ul>
               {% for organisation in organisations %}
-              <li><a class="searchresult" href="{% url 'organization_details' organisation.domain %}">{{ organisation.domain }}</a></li>
+              <li><a class="searchresult" href="{% url 'organization_details' organisation.domain_quoted %}">{{ organisation.domain }}</a></li>
               {% endfor %}
             </ul>
             {% else %}

--- a/amy/templates/fiscal/all_organizations.html
+++ b/amy/templates/fiscal/all_organizations.html
@@ -18,7 +18,7 @@
         </tr>
     {% for organization in all_organizations %}
         <tr>
-            <td><a href="{% url 'organization_details' organization.domain %}">{{ organization.fullname }}</a></td>
+            <td><a href="{% url 'organization_details' organization.domain_quoted %}">{{ organization.fullname }}</a></td>
             <td><a href="http://{{ organization.domain }}" target="_blank" rel="noreferrer">{{ organization.domain }}</a></td>
             <td>
               {% for membership in organization.current_memberships %}
@@ -28,10 +28,10 @@
               {% endfor %}
             </td>
             <td>
-              <a href="{% url 'organization_details' organization.domain %}" title="View {{ organization.fullname }}"><i class="fas fa-info-circle"></i></a>
+              <a href="{% url 'organization_details' organization.domain_quoted %}" title="View {{ organization.fullname }}"><i class="fas fa-info-circle"></i></a>
                 &nbsp;
               {% if perms.workshops.change_organization %}
-                <a href="{% url 'organization_edit' organization.domain %}" title="Edit {{ organization.fullname }}"><i class="fas fa-edit"></i></a>
+                <a href="{% url 'organization_edit' organization.domain_quoted %}" title="Edit {{ organization.fullname }}"><i class="fas fa-edit"></i></a>
               {% endif %}
             </td>
         </tr>

--- a/amy/templates/fiscal/organization.html
+++ b/amy/templates/fiscal/organization.html
@@ -8,14 +8,14 @@
 
 <p class="edit-object">
   {% if perms.workshops.change_organization %}
-  <a href="{% url 'organization_edit' organization.domain %}" class="btn btn-primary">Edit</a>
+  <a href="{% url 'organization_edit' organization.domain_quoted %}" class="btn btn-primary">Edit</a>
   {% else %}
-  <a href="{% url 'organization_edit' organization.domain %}" class="btn btn-primary disabled">Edit</a>
+  <a href="{% url 'organization_edit' organization.domain_quoted %}" class="btn btn-primary disabled">Edit</a>
   {% endif %}
 </p>
 <table class="table table-striped">
   <tr><th>Full name:</th><td>{{ organization.fullname }}</td></tr>
-  <tr><th>Domain:</th><td><a href="http://{{ organization.domain }}" target="_blank" rel="noreferrer">{{ organization.domain }}</a></td></tr>
+  <tr><th>Domain:</th><td><a href="//{{ organization.domain }}" target="_blank" rel="noreferrer">{{ organization.domain }}</a></td></tr>
   <tr><th>Country:</th><td>{{ organization.country.name|default:"&mdash;" }} <img src="{{ organization.country.flag }}" alt="{{ organization.country }}" class="country-flag" /></td></tr>
   <tr>
     <th>Latitude / longitude:</th>
@@ -31,14 +31,14 @@
 <div class="clearfix">
   <p class="edit-object float-left">
     {% if perms.workshops.change_organization %}
-    <a href="{% url 'organization_edit' organization.domain %}" class="btn btn-primary">Edit</a>
+    <a href="{% url 'organization_edit' organization.domain_quoted %}" class="btn btn-primary">Edit</a>
     {% else %}
-    <a href="{% url 'organization_edit' organization.domain %}" class="btn btn-primary disabled">Edit</a>
+    <a href="{% url 'organization_edit' organization.domain_quoted %}" class="btn btn-primary disabled">Edit</a>
     {% endif %}
   </p>
   <div class="delete-object float-right">
     {% if perms.workshops.delete_organization %}
-    <form action="{% url 'organization_delete' organization.domain %}" onsubmit='return confirm("Are you sure you wish to remove  \"{{ organization }}\"?")' method="POST">
+    <form action="{% url 'organization_delete' organization.domain_quoted %}" onsubmit='return confirm("Are you sure you wish to remove  \"{{ organization }}\"?")' method="POST">
       {% csrf_token %}
       <button type="submit" class="btn btn-danger">Delete organization</button>
     </form>

--- a/amy/templates/includes/event_details_table.html
+++ b/amy/templates/includes/event_details_table.html
@@ -8,7 +8,7 @@
   <tr><th>Completed:</th><td colspan="2">{{ event.completed|yesno }}</td></tr>
   <tr class="{% if event.start > event.end %}table-danger{% endif %}"><th>Start date:</th><td colspan="2">{{ event.start|default:"&mdash;" }}</td></tr>
   <tr class="{% if event.start > event.end %}table-danger{% endif %}"><th>End date: </th><td colspan="2">{{ event.end|default:"&mdash;" }}</td></tr>
-  <tr><th>Host:</th><td colspan="2"><a href="{% url 'organization_details' event.host.domain %}">{{ event.host }}</a></td></tr>
+  <tr><th>Host:</th><td colspan="2"><a href="{% url 'organization_details' event.host.domain_quoted %}">{{ event.host }}</a></td></tr>
   <tr><th>Sponsor:</th><td colspan="2">{% if event.sponsor %}<a href="{{ event.sponsor.get_absolute_url }}">{{ event.sponsor }}</a>{% else %}&mdash;{% endif %}</td></tr>
   <tr><th>Administrator:</th><td colspan="2">{% if event.administrator %}<a href="{{ event.administrator.get_absolute_url }}">{{ event.administrator }}</a>{% else %}&mdash;{% endif %}</td></tr>
   <tr><th>Is this workshop public?<br><small>Public workshops will show up in public Carpentries feeds.</small></th><td colspan="2">{{ event.get_public_status_display|default:"&mdash;" }}</td></tr>

--- a/amy/templates/workshops/all_events.html
+++ b/amy/templates/workshops/all_events.html
@@ -44,7 +44,7 @@
           {{ event.repository_url|default:"—"|urlize_newtab }}
         </td>
         <td {% if event.num_instructors == 0 %}class="table-warning"{% endif %}> {{ event.num_instructors }}</td>
-        <td><a href="{% url 'organization_details' event.host.domain %}">{{ event.host }}</a></td>
+        <td><a href="{% url 'organization_details' event.host.domain_quoted %}">{{ event.host }}</a></td>
         <td>{{ event.start }} &ndash; {{ event.end }}</td>
         <td>
           {{ event.completed|yesno }}

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from urllib.parse import quote
 
 from django.contrib.auth.models import (
     AbstractBaseUser,
@@ -84,8 +85,12 @@ class Organization(models.Model):
     def __str__(self):
         return "{} <{}>".format(self.fullname, self.domain)
 
+    @property
+    def domain_quoted(self):
+        return quote(self.domain, safe="")
+
     def get_absolute_url(self):
-        return reverse("organization_details", args=[str(self.domain)])
+        return reverse("organization_details", args=[self.domain_quoted])
 
     class Meta:
         ordering = ("domain",)


### PR DESCRIPTION
Previously `Organization.domain` was just that - only a domain. Now it can contain almost entire URL, without scheme.

Generic URL format: `scheme://netloc/path;parameters?query#fragment`

Out of it we're stripping scheme, `//` before the netloc, parameters and fragment.

Breaking change: URLs in API don't contain trailing slashes (otherwise they would not match new domain format correctly).

This fixes #1835.

This PR is built on top of PR #1858 and contains it's commits.