### PR TITLE
[#1854][#1855][#1856] Adjustments to rolling-over mechanism, display person membership roles

### DIFF
--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -11,18 +11,20 @@ from django.db.models import (
     Prefetch,
     Q,
 )
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.html import format_html
 from django.urls import reverse
 from django.views.decorators.http import require_GET
 from django_comments.models import Comment
 
+from fiscal.models import MembershipTask
 from workshops.models import (
     Airport,
     Badge,
     Event,
     Qualification,
     Person,
+    Task,
     Organization,
     Membership,
     Tag,
@@ -107,12 +109,25 @@ def admin_dashboard(request):
 
 @login_required
 def trainee_dashboard(request):
-    # Workshops person taught at
-    workshops = request.user.task_set.select_related("role", "event")
+    qs = Person.objects.select_related("airport").prefetch_related(
+        "badges",
+        "lessons",
+        "domains",
+        "languages",
+        Prefetch(
+            "task_set",
+            queryset=Task.objects.select_related(),
+        ),
+        Prefetch(
+            "membershiptask_set",
+            queryset=MembershipTask.objects.select_related(),
+        ),
+    )
+    user = get_object_or_404(qs, id=request.user.id)
 
     context = {
         "title": "Your profile",
-        "workshops": workshops,
+        "user": user,
     }
     return render(request, "dashboard/trainee_dashboard.html", context)
 

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -116,11 +116,11 @@ def trainee_dashboard(request):
         "languages",
         Prefetch(
             "task_set",
-            queryset=Task.objects.select_related(),
+            queryset=Task.objects.select_related("event", "role"),
         ),
         Prefetch(
             "membershiptask_set",
-            queryset=MembershipTask.objects.select_related(),
+            queryset=MembershipTask.objects.select_related("membership", "role"),
         ),
     )
     user = get_object_or_404(qs, id=request.user.id)

--- a/amy/fiscal/forms.py
+++ b/amy/fiscal/forms.py
@@ -228,6 +228,20 @@ class MembershipCreateForm(MembershipForm):
 class MembershipRollOverForm(MembershipCreateForm):
     main_organization = None  # remove the additional field
 
+    copy_members = forms.BooleanField(
+        label="Do you want to automatically copy member organisations from existing "
+        "membership?",
+        required=False,
+        initial=True,
+        help_text="If not consortium, the main organisation is always copied.",
+    )
+    copy_membership_tasks = forms.BooleanField(
+        label="Do you want to automatically copy persons and their roles from existing "
+        "membership?",
+        required=False,
+        initial=True,
+    )
+
     class Meta(MembershipCreateForm.Meta):
         fields = [
             "name",
@@ -249,6 +263,8 @@ class MembershipRollOverForm(MembershipCreateForm):
             "inhouse_instructor_training_seats_rolled_from_previous",
             "emergency_contact",
             "comment",
+            "copy_members",
+            "copy_membership_tasks",
         ]
 
     def __init__(self, *args, **kwargs):
@@ -271,6 +287,13 @@ class MembershipRollOverForm(MembershipCreateForm):
                 MinValueValidator(self[field].field.min_value),
                 MaxValueValidator(self[field].field.max_value),
             ]
+
+        # disable editing consortium
+        self["consortium"].field.disabled = True
+
+        # if not consortium, disable option to not copy members
+        if self.initial.get("consortium", False) is False:
+            self["copy_members"].field.disabled = True
 
 
 class EditableFormsetFormMixin(forms.ModelForm):

--- a/amy/fiscal/tests/test_membership.py
+++ b/amy/fiscal/tests/test_membership.py
@@ -872,6 +872,20 @@ class TestMembershipCreateRollOver(TestBase):
     def setUp(self):
         super().setUp()
         self._setUpUsersAndLogin()
+        self.data = {
+            "name": "Test Name",
+            "consortium": True,
+            "public_status": "public",
+            "variant": "partner",
+            "agreement_start": "2021-03-01",
+            "agreement_end": "2022-03-01",
+            "contribution_type": "financial",
+            "workshops_without_admin_fee_per_agreement": 10,
+            "public_instructor_training_seats": 12,
+            "additional_public_instructor_training_seats": 0,
+            "inhouse_instructor_training_seats": 9,
+            "additional_inhouse_instructor_training_seats": 0,
+        }
 
     def setUpMembership(self):
         self.membership = Membership.objects.create(
@@ -896,70 +910,172 @@ class TestMembershipCreateRollOver(TestBase):
         )
 
     def test_form_simple_valid(self):
-        data = {
-            "name": "Test Name",
-            "consortium": True,
-            "public_status": "public",
-            "variant": "partner",
-            "agreement_start": "2021-03-01",
-            "agreement_end": "2022-03-01",
-            "contribution_type": "financial",
-            "workshops_without_admin_fee_per_agreement": 10,
-            "public_instructor_training_seats": 12,
-            "additional_public_instructor_training_seats": 0,
-            "inhouse_instructor_training_seats": 9,
-            "additional_inhouse_instructor_training_seats": 0,
-        }
-
-        form = MembershipRollOverForm(data)
-
+        form = MembershipRollOverForm(self.data)
         self.assertTrue(form.is_valid())
 
-    def test_form_ignoring_fields(self):
-        data = {
-            # field accepted
-            "name": "Test Name",
-            "consortium": True,
-            "public_status": "public",
-            "variant": "partner",
-            "agreement_start": "2021-03-01",
-            "agreement_end": "2022-03-01",
-            "contribution_type": "financial",
-            "workshops_without_admin_fee_per_agreement": 10,
-            "public_instructor_training_seats": 12,
-            "additional_public_instructor_training_seats": 0,
-            "inhouse_instructor_training_seats": 9,
-            "additional_inhouse_instructor_training_seats": 0,
-            # fields ignored
-            "workshops_without_admin_fee_rolled_from_previous": "invalid value",
-            "public_instructor_training_seats_rolled_from_previous": "invalid value",
-            "inhouse_instructor_training_seats_rolled_from_previous": "invalid value",
-        }
-
-        form = MembershipRollOverForm(data)
-
-        self.assertTrue(form.is_valid(), form.errors)
+    def test_form_validation_rolled_fields(self):
+        test_data = [
+            # PASS: centrally org. workshops maxed out, others set to 0
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 1,
+                    "public_instructor_training_seats_rolled_from_previous": 0,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 0,
+                },
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 1,
+                },
+                True,
+                [],
+            ),
+            # FAIL: more (1) centrally org. workshops than allowed (0)
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 1,
+                    "public_instructor_training_seats_rolled_from_previous": 0,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 0,
+                },
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 0,
+                },
+                False,
+                ["workshops_without_admin_fee_rolled_from_previous"],
+            ),
+            # PASS: public ITT seats maxed out, others set to 0
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 0,
+                    "public_instructor_training_seats_rolled_from_previous": 1,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 0,
+                },
+                {
+                    "public_instructor_training_seats_rolled_from_previous": 1,
+                },
+                True,
+                [],
+            ),
+            # FAIL: more (1) public ITT seats than allowed (0)
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 0,
+                    "public_instructor_training_seats_rolled_from_previous": 1,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 0,
+                },
+                {
+                    "public_instructor_training_seats_rolled_from_previous": 0,
+                },
+                False,
+                ["public_instructor_training_seats_rolled_from_previous"],
+            ),
+            # PASS: in-house ITT seats maxed out, others set to 0
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 0,
+                    "public_instructor_training_seats_rolled_from_previous": 0,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 1,
+                },
+                {
+                    "inhouse_instructor_training_seats_rolled_from_previous": 1,
+                },
+                True,
+                [],
+            ),
+            # FAIL: more (1) in-house ITT seats than allowed (0)
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 0,
+                    "public_instructor_training_seats_rolled_from_previous": 0,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 1,
+                },
+                {
+                    "inhouse_instructor_training_seats_rolled_from_previous": 0,
+                },
+                False,
+                ["inhouse_instructor_training_seats_rolled_from_previous"],
+            ),
+            # FAIL: no max_values provided, so all fields default to 0
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 1,
+                    "public_instructor_training_seats_rolled_from_previous": 1,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 1,
+                },
+                {},
+                False,
+                [
+                    "workshops_without_admin_fee_rolled_from_previous",
+                    "public_instructor_training_seats_rolled_from_previous",
+                    "inhouse_instructor_training_seats_rolled_from_previous",
+                ],
+            ),
+            # PASS: all values within max_values ranges
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 1,
+                    "public_instructor_training_seats_rolled_from_previous": 1,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 0,
+                },
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 1,
+                    "public_instructor_training_seats_rolled_from_previous": 2,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 0,
+                },
+                True,
+                [],
+            ),
+            # FAIL: negative values
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": -1,
+                    "public_instructor_training_seats_rolled_from_previous": -1,
+                    "inhouse_instructor_training_seats_rolled_from_previous": -1,
+                },
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 1,
+                    "public_instructor_training_seats_rolled_from_previous": 1,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 1,
+                },
+                False,
+                [
+                    "workshops_without_admin_fee_rolled_from_previous",
+                    "public_instructor_training_seats_rolled_from_previous",
+                    "inhouse_instructor_training_seats_rolled_from_previous",
+                ],
+            ),
+            # FAIL: too big values
+            (
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 2,
+                    "public_instructor_training_seats_rolled_from_previous": 2,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 2,
+                },
+                {
+                    "workshops_without_admin_fee_rolled_from_previous": 1,
+                    "public_instructor_training_seats_rolled_from_previous": 1,
+                    "inhouse_instructor_training_seats_rolled_from_previous": 1,
+                },
+                False,
+                [
+                    "workshops_without_admin_fee_rolled_from_previous",
+                    "public_instructor_training_seats_rolled_from_previous",
+                    "inhouse_instructor_training_seats_rolled_from_previous",
+                ],
+            ),
+        ]
+        for data, max_values, is_valid, failed_fields in test_data:
+            with self.subTest(max_values=max_values):
+                data.update(self.data)
+                form = MembershipRollOverForm(data, max_values=max_values)
+                self.assertEqual(form.is_valid(), is_valid)
+                if not is_valid:
+                    self.assertEqual(set(failed_fields), form.errors.keys())
 
     def test_new_membership_created(self):
         self.setUpMembership()
-        data = {
-            "name": "Test Name",
-            "consortium": True,
-            "public_status": "public",
-            "variant": "partner",
-            "agreement_start": "2021-03-01",
-            "agreement_end": "2022-03-01",
-            "contribution_type": "financial",
-            "workshops_without_admin_fee_per_agreement": 10,
-            "public_instructor_training_seats": 12,
-            "additional_public_instructor_training_seats": 0,
-            "inhouse_instructor_training_seats": 9,
-            "additional_inhouse_instructor_training_seats": 0,
-        }
 
         response = self.client.post(
             reverse("membership_create_roll_over", args=[self.membership.pk]),
-            data=data,
+            data=self.data,
             follow=True,
         )
 
@@ -972,17 +1088,10 @@ class TestMembershipCreateRollOver(TestBase):
         self.setUpMembership()
         data = {
             "name": "Test Membership",
-            "consortium": False,
-            "public_status": "public",
-            "variant": "partner",
-            "agreement_start": "2020-03-01",
-            "agreement_end": "2021-03-01",
-            "contribution_type": "financial",
-            "workshops_without_admin_fee_per_agreement": 10,
-            "public_instructor_training_seats": 12,
-            "additional_public_instructor_training_seats": 0,
-            "inhouse_instructor_training_seats": 9,
-            "additional_inhouse_instructor_training_seats": 0,
+            "workshops_without_admin_fee_rolled_from_previous": 3,
+            "public_instructor_training_seats_rolled_from_previous": 2,
+            "inhouse_instructor_training_seats_rolled_from_previous": 1,
+            **self.data,
         }
 
         self.client.post(
@@ -1012,12 +1121,12 @@ class TestMembershipCreateRollOver(TestBase):
             self.membership.inhouse_instructor_training_seats_rolled_from_previous, None
         )
 
-        self.assertEqual(self.membership.workshops_without_admin_fee_rolled_over, 10)
+        self.assertEqual(self.membership.workshops_without_admin_fee_rolled_over, 3)
         self.assertEqual(
-            self.membership.public_instructor_training_seats_rolled_over, 12
+            self.membership.public_instructor_training_seats_rolled_over, 2
         )
         self.assertEqual(
-            self.membership.inhouse_instructor_training_seats_rolled_over, 9
+            self.membership.inhouse_instructor_training_seats_rolled_over, 1
         )
 
         self.assertEqual(last_membership.workshops_without_admin_fee_per_agreement, 10)
@@ -1028,13 +1137,13 @@ class TestMembershipCreateRollOver(TestBase):
             last_membership.additional_inhouse_instructor_training_seats, 0
         )
         self.assertEqual(
-            last_membership.workshops_without_admin_fee_rolled_from_previous, 10
+            last_membership.workshops_without_admin_fee_rolled_from_previous, 3
         )
         self.assertEqual(
-            last_membership.public_instructor_training_seats_rolled_from_previous, 12
+            last_membership.public_instructor_training_seats_rolled_from_previous, 2
         )
         self.assertEqual(
-            last_membership.inhouse_instructor_training_seats_rolled_from_previous, 9
+            last_membership.inhouse_instructor_training_seats_rolled_from_previous, 1
         )
         self.assertEqual(last_membership.workshops_without_admin_fee_rolled_over, None)
         self.assertEqual(

--- a/amy/fiscal/views.py
+++ b/amy/fiscal/views.py
@@ -411,22 +411,26 @@ class MembershipCreateRollOver(
         )
         self.membership.save()
 
-        # create the object and store returned success url redirect
         result = super().form_valid(form)
 
         # duplicate members and membership tasks from old membership to the new one
-        Member.objects.bulk_create(
-            [
-                Member(membership=self.object, organization=m.organization, role=m.role)
-                for m in self.membership.member_set.all()
-            ]
-        )
-        MembershipTask.objects.bulk_create(
-            [
-                MembershipTask(membership=self.object, person=m.person, role=m.role)
-                for m in self.membership.membershiptask_set.all()
-            ]
-        )
+        if form.cleaned_data["copy_members"]:
+            Member.objects.bulk_create(
+                [
+                    Member(
+                        membership=self.object, organization=m.organization, role=m.role
+                    )
+                    for m in self.membership.member_set.all()
+                ]
+            )
+
+        if form.cleaned_data["copy_membership_tasks"]:
+            MembershipTask.objects.bulk_create(
+                [
+                    MembershipTask(membership=self.object, person=m.person, role=m.role)
+                    for m in self.membership.membershiptask_set.all()
+                ]
+            )
 
         return result
 

--- a/amy/fiscal/views.py
+++ b/amy/fiscal/views.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+from typing import Dict, Any
 
 from django.contrib import messages
 from django.contrib.auth.mixins import (
@@ -357,7 +358,7 @@ class MembershipCreateRollOver(
     form_class = MembershipRollOverForm
     pk_url_kwarg = "membership_id"
 
-    def get_initial(self):
+    def get_initial(self) -> Dict[str, Any]:
         return {
             "name": self.membership.name,
             "consortium": self.membership.consortium,
@@ -373,14 +374,24 @@ class MembershipCreateRollOver(
             "registration_code": self.membership.registration_code,
             "agreement_link": self.membership.agreement_link,
             "workshops_without_admin_fee_per_agreement": self.membership.workshops_without_admin_fee_per_agreement,  # noqa
-            "workshops_without_admin_fee_rolled_from_previous": self.membership.workshops_without_admin_fee_remaining,  # noqa
+            "workshops_without_admin_fee_rolled_from_previous": 0,
             "public_instructor_training_seats": self.membership.public_instructor_training_seats,  # noqa
             "additional_public_instructor_training_seats": self.membership.additional_public_instructor_training_seats,  # noqa
-            "public_instructor_training_seats_rolled_from_previous": self.membership.public_instructor_training_seats_remaining,  # noqa
+            "public_instructor_training_seats_rolled_from_previous": 0,
             "inhouse_instructor_training_seats": self.membership.inhouse_instructor_training_seats,  # noqa
             "additional_inhouse_instructor_training_seats": self.membership.additional_inhouse_instructor_training_seats,  # noqa
-            "inhouse_instructor_training_seats_rolled_from_previous": self.membership.public_instructor_training_seats_remaining,  # noqa  # TODO
+            "inhouse_instructor_training_seats_rolled_from_previous": 0,
             "emergency_contact": self.membership.emergency_contact,
+        }
+
+    def get_form_kwargs(self) -> Dict[str, Any]:
+        return {
+            "max_values": {
+                "workshops_without_admin_fee_rolled_from_previous": self.membership.workshops_without_admin_fee_remaining,  # noqa
+                "public_instructor_training_seats_rolled_from_previous": self.membership.public_instructor_training_seats_remaining,  # noqa
+                "inhouse_instructor_training_seats_rolled_from_previous": self.membership.inhouse_instructor_training_seats_remaining,  # noqa
+            },
+            **super().get_form_kwargs(),
         }
 
     def get_context_data(self, **kwargs):
@@ -388,17 +399,6 @@ class MembershipCreateRollOver(
         return super().get_context_data(**kwargs)
 
     def form_valid(self, form):
-        # set rolled_from_previous fields to the same values as in initial form data
-        form.instance.workshops_without_admin_fee_rolled_from_previous = (
-            self.membership.workshops_without_admin_fee_remaining
-        )
-        form.instance.public_instructor_training_seats_rolled_from_previous = (
-            self.membership.public_instructor_training_seats_remaining
-        )
-        form.instance.inhouse_instructor_training_seats_rolled_from_previous = (
-            self.membership.inhouse_instructor_training_seats_remaining
-        )
-
         # save values rolled over in membership
         self.membership.workshops_without_admin_fee_rolled_over = (
             form.instance.workshops_without_admin_fee_rolled_from_previous

--- a/amy/templates/dashboard/trainee_dashboard.html
+++ b/amy/templates/dashboard/trainee_dashboard.html
@@ -4,6 +4,7 @@
 {% endblock %}
 
 {% load crispy_forms_tags %}
+{% load dates %}
 
 {% block content %}
 
@@ -14,7 +15,7 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
 
 
   <table class="table table-striped">
-    <tr><th>Personal name:</th><td>{{ user.personal|default:"—" }}</td></tr>
+    <tr><th width="40%">Personal name:</th><td>{{ user.personal|default:"—" }}</td></tr>
     <tr><th>Middle name:</th><td>{{ user.middle|default:"—" }}</td></tr>
     <tr><th>Family name:</th><td>{{ user.family|default:"—" }}</td></tr>
     <tr><th>Email:
@@ -87,7 +88,8 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
     </td></tr>
     <tr><th>Your workshop activity:<br>
         <small>If you'd like to let us know about a workshop you are planning or have run a self-organised workshop that is missing from this list, please fill out our <a href="{% url 'selforganised_submission' %}">self-organised workshop form</a>.</small></th><td>
-        {% if workshops %}
+        {% with tasks=user.task_set.all %}
+        {% if tasks %}
         <table class="table">
           <tr>
             <th>Workshop name</th>
@@ -95,7 +97,7 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
             <th>Venue</th>
             <th>Your role</th>
           </tr>
-          {% for task in workshops %}
+          {% for task in tasks %}
             <tr>
             {% if task.event.website_url %}
               <td><a href="{{ task.event.website_url }}" target="_blank" rel="noreferrer">{{ task.event.slug }}</a></td>
@@ -111,7 +113,31 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
         {% else %}
         No workshops to show.
         {% endif %}
+        {% endwith %}
     </td></tr>
+    {% with membership_tasks=user.membershiptask_set.all %}
+    {% if membership_tasks %}
+    <tr><th>Your roles in memberships:</th>
+        <td>
+        <table class="table">
+          <tr>
+            <th>Role</th>
+            <th>Membership</th>
+            <th>Dates</th>
+            <th>Consortium?</th>
+          </tr>
+          {% for task in membership_tasks %}
+          <tr>
+            <td>{{ task.role }}</td>
+            <td>{{ task.membership.name }}</td>
+            <td>{% human_daterange task.membership.agreement_start task.membership.agreement_end %}</td>
+            <td>{{ task.membership.consortium|yesno }}</td>
+          </tr>
+          {% endfor %}
+        </table>
+    </td></tr>
+    {% endif %}
+    {% endwith %}
   </table>
 
   <p>

--- a/amy/templates/workshops/person.html
+++ b/amy/templates/workshops/person.html
@@ -2,6 +2,7 @@
 
 {% load links %}
 {% load revisions %}
+{% load dates %}
 
 {% block content %}
 {% last_modified person %}
@@ -177,6 +178,28 @@
   <tr>
     <th>Instructor Training progress:</th>
     <td>{% include "includes/training_progresses_inline.html" with person=person %}</td>
+  </tr>
+  <tr>
+    <th>Membership roles:</th>
+    <td>
+      {% with membership_tasks=person.membershiptask_set.all %}
+      {% if membership_tasks %}
+      <table class="table table-sm">
+        <tr><th>Role</th><th>Membership</th><th>Dates</th><th>Consortium?</th></tr>
+        {% for task in membership_tasks %}
+        <tr>
+          <td>{{ task.role }}</td>
+          <td><a href="{{ task.membership.get_absolute_url }}">{{ task.membership.name }}</a></td>
+          <td>{% human_daterange task.membership.agreement_start task.membership.agreement_end %}</td>
+          <td>{{ task.membership.consortium|yesno }}</td>
+        </tr>
+        {% endfor %}
+      </table>
+      {% else %}
+      No related membership roles.
+      {% endif %}
+      {% endwith %}
+    </td>
   </tr>
 </table>
 

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -257,24 +257,24 @@ class PersonDetails(OnlyForAdminsMixin, AMYDetailView):
             "languages",
             Prefetch(
                 "award_set",
-                queryset=Award.objects.select_related(),
+                queryset=Award.objects.select_related("badge", "event", "awarded_by"),
             ),
             Prefetch(
                 "task_set",
-                queryset=Task.objects.select_related(),
+                queryset=Task.objects.select_related("role", "event"),
             ),
             Prefetch(
                 "task_set",
                 to_attr="training_tasks",
                 queryset=Task.objects.filter(
                     role__name="learner", event__tags__name="TTT"
-                ).select_related(),
+                ).select_related("role", "event"),
             ),
             "trainingrequest_set",
             "trainingprogress_set",
             Prefetch(
                 "membershiptask_set",
-                queryset=MembershipTask.objects.select_related(),
+                queryset=MembershipTask.objects.select_related("role", "membership"),
             ),
         )
         .select_related("airport")

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -56,6 +56,7 @@ from autoemails.actions import (
 from autoemails.models import Trigger
 from autoemails.base_views import ActionManageMixin
 from dashboard.forms import AssignmentForm
+from fiscal.models import MembershipTask
 from workshops.base_views import (
     AMYCreateView,
     AMYUpdateView,
@@ -250,17 +251,30 @@ class PersonDetails(OnlyForAdminsMixin, AMYDetailView):
             ),
         )
         .prefetch_related(
-            "award_set__badge",
-            "award_set__awarded_by",
-            "award_set__event",
-            "task_set__role",
-            "task_set__event",
+            "badges",
+            "lessons",
+            "domains",
+            "languages",
+            Prefetch(
+                "award_set",
+                queryset=Award.objects.select_related(),
+            ),
+            Prefetch(
+                "task_set",
+                queryset=Task.objects.select_related(),
+            ),
             Prefetch(
                 "task_set",
                 to_attr="training_tasks",
                 queryset=Task.objects.filter(
                     role__name="learner", event__tags__name="TTT"
-                ),
+                ).select_related(),
+            ),
+            "trainingrequest_set",
+            "trainingprogress_set",
+            Prefetch(
+                "membershiptask_set",
+                queryset=MembershipTask.objects.select_related(),
             ),
         )
         .select_related("airport")


### PR DESCRIPTION
This fixes #1854.
This fixes #1855.
This fixes #1856.

Depends on #1869.

1. Display person membership roles in person details view as well as in the trainee dashboard (but only if person has any membership roles) - #1856
2. Allow editing values for roll-over fields when creating membership through roll-over mechanism - #1854 
3. Allow for copying over member organisations and membership person tasks when rolling over; mechanism is controlled over checkboxes - #1855 