### PR TITLE
fix(MakeFile): Fix command createsuperuser in the MakeFile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dev_database :
 	${MANAGE} loaddata amy/autoemails/fixtures/templates_triggers.json
 	${MANAGE} fake_database
 	${MANAGE} createinitialrevisions
-	${MANAGE} create_superuser
+	${MANAGE} createsuperuser
 
 ## node_modules : install front-end dependencies using Yarn
 node_modules : package.json


### PR DESCRIPTION
The command has a typo and would fail out before creating the superuser.
See https://docs.djangoproject.com/en/2.2/intro/tutorial02/#creating-an-admin-user