### PR TITLE
ref(README): Changed setup instructions ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ before starting work on new features.
     ~~~
     $ git clone https://github.com/carpentries/amy.git
     $ cd amy
-    ~~~
-
-1.   Configure git to automatically ignore revisions in the `.git-blame-ignore-revs`:
+    ~~~ 
+1.  Configure git to automatically ignore revisions in the `.git-blame-ignore-revs`:
 
     ~~~
     $ git config blame.ignoreRevsFile .git-blame-ignore-revs

--- a/README.md
+++ b/README.md
@@ -69,12 +69,6 @@ before starting work on new features.
     $ python manage.py createcachetable
     ~~~
 
-1.  Create an administrator account:
-
-    ~~~
-    $ python manage.py createsuperuser
-    ~~~
-
 1.  Start a local Django development server by running:
 
     ~~~

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ before starting work on new features.
 
 1.  Install [yarn][yarn], the tool that manages AMY's JavaScript and CSS dependencies. [You can install it here][yarn].
 
-1. Start running a local instance of Redis. This requires Docker to be installed locally.  Redis is required to have certain features (like creating a new person and viewing a workshop request) work correctly.
+1. Start running a local instance of Postgres and Redis. This requires Docker to be installed locally.  Redis is required to have certain features (like creating a new person and viewing a workshop request) work correctly.
 
     ~~~
-    $ docker-compose -f docker/docker-compose.yml -p amy up -d redis
+    $ docker-compose -f docker/docker-compose.yml -p amy up -d database redis
     ~~~
 
 1.  Set up your local database with fake (development-ready) data with:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ before starting work on new features.
     ~~~
     $ git clone https://github.com/carpentries/amy.git
     $ cd amy
-    ~~~ 
+    ~~~
+
 1.  Configure git to automatically ignore revisions in the `.git-blame-ignore-revs`:
 
     ~~~

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ before starting work on new features.
 
 1.  Install [yarn][yarn], the tool that manages AMY's JavaScript and CSS dependencies. [You can install it here][yarn].
 
+1. Start running a local instance of Redis. This requires Docker to be installed locally.  Redis is required to have certain features (like creating a new person and viewing a workshop request) work correctly.
+
+    ~~~
+    $ docker-compose -f docker/docker-compose.yml -p amy up -d redis
+    ~~~
+
 1.  Set up your local database with fake (development-ready) data with:
 
     ~~~
@@ -67,13 +73,6 @@ before starting work on new features.
 
     ~~~
     $ python manage.py createsuperuser
-    ~~~
-
-
-1. Start running a local instance of Redis. This requires Docker to be installed locally.  Redis is required to have certain features (like creating a new person and viewing a workshop request) work correctly.
-
-    ~~~
-    $ docker-compose -f docker/docker-compose.yml -p amy up -d redis
     ~~~
 
 1.  Start a local Django development server by running:


### PR DESCRIPTION
- Docker must be running prior to trying to use `make dev_database`
- Fixed indentation issues introduced in a prior pr
- removed reference to createsuperuser since the make file covers that.