### PR TITLE
[#1759] Self-organised Submission form URL warnings + JS validation

### DIFF
--- a/amy/extrequests/forms.py
+++ b/amy/extrequests/forms.py
@@ -1119,6 +1119,9 @@ class SelfOrganisedSubmissionBaseForm(forms.ModelForm):
             "additional_contact": Select2TagWidget,
         }
 
+    class Media:
+        js = ("selforganisedsubmission_form.js",)
+
     @staticmethod
     def institution_label_from_instance(obj):
         """Static method that overrides ModelChoiceField choice labels,
@@ -1174,6 +1177,41 @@ class SelfOrganisedSubmissionBaseForm(forms.ModelForm):
                 self.helper.layout.fields.index(field),
                 HTML(self.helper.hr()),
             )
+
+        # add warning alert for workshop URL
+        REPO_WARNING = (
+            "Would you be able to update the name of the workshop webpage prior to "
+            "submitting this notification? If so, we recommend using the following "
+            "name: YEAR-MM-DD-site-online. If not, that's okay and please feel free "
+            "to submit the form."
+        )
+        URL_WARNING = (
+            "Please adjust the URL format so that it points to the workshop website. "
+            "The format for this is: https://username.github.io/repo"
+        )
+        pos_index = self.helper.layout.fields.index("workshop_url")
+        self.helper.layout.insert(
+            pos_index + 1,
+            Div(
+                Div(
+                    HTML(REPO_WARNING),
+                    css_class="alert alert-warning offset-lg-2 col-lg-8 col-12",
+                ),
+                id="workshop_url_repo_warning",
+                css_class="form-group row d-none",
+            ),
+        )
+        self.helper.layout.insert(
+            pos_index + 2,
+            Div(
+                Div(
+                    HTML(URL_WARNING),
+                    css_class="alert alert-warning offset-lg-2 col-lg-8 col-12",
+                ),
+                id="workshop_url_warning",
+                css_class="form-group row d-none",
+            ),
+        )
 
     def clean(self):
         super().clean()

--- a/amy/static/selforganisedsubmission_form.js
+++ b/amy/static/selforganisedsubmission_form.js
@@ -1,0 +1,77 @@
+const isGithubIoRepo = function(url) {
+    const url_regex = /(?:https?:\/\/)?(?<username>[^.]+)\.github\.io\/(?<repo>[^\/]+)/i;
+    const results = url.match(url_regex);
+    if (!results) {
+        return false;
+    } else {
+        return {username: results[1], repo: results[2]};
+    }
+}
+
+const isGithubComRepo = function(url) {
+    const url_regex = /(?:https?:\/\/)?github\.com\/(?<username>[^/]+)\/(?<repo>[^\/]+)/i;
+    const results = url.match(url_regex);
+    if (!results) {
+        return false;
+    } else {
+        return {username: results[1], repo: results[2]};
+    }
+}
+
+const isRepoNameValid = function(repo_name) {
+    const repo_regex = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})-(?<name>.+)/i;
+    const results = repo_name.match(repo_regex);
+    if (!results) {
+        return false;
+    } else {
+        return {year: results[1], month: results[2], day: results[3], name: results[4]};
+    }
+}
+
+const validateWorkshopUrl = function(input, warning1, warning2) {
+    const github_io = isGithubIoRepo(input.value);
+    const github_com = isGithubComRepo(input.value);
+
+    if (github_io) {
+        // github.io link, let's check the repo name
+        const repo_valid = isRepoNameValid(github_io.repo);
+        if (!repo_valid) {
+            // invalid repository name format
+            input.classList.add("border");
+            input.classList.add("border-warning");
+            warning1.classList.remove("d-none");
+        } else {
+            // repo URL okay
+            input.classList.remove("border");
+            input.classList.remove("border-warning");
+            warning1.classList.add("d-none");
+            warning2.classList.add("d-none");
+        }
+    } else if (github_com) {
+        // github.com link, show the warning
+        input.classList.add("border");
+        input.classList.add("border-warning");
+        warning2.classList.remove("d-none");
+    } else {
+        // unable to match with anything, but it's okay - they may use
+        // their own website
+        input.classList.remove("border");
+        input.classList.remove("border-warning");
+        warning1.classList.add("d-none");
+        warning2.classList.add("d-none");
+    }
+}
+
+window.addEventListener("load", (e) => {
+    const workshop_url = document.querySelector("#id_workshop_url");
+    const repo_warning_div = document.querySelector("#workshop_url_repo_warning");
+    const url_warning_div = document.querySelector("#workshop_url_warning");
+
+    if (!!workshop_url) {
+        validateWorkshopUrl(workshop_url, repo_warning_div, url_warning_div);
+
+        workshop_url.addEventListener("change", ({target}) => {
+            validateWorkshopUrl(target, repo_warning_div, url_warning_div);
+        });
+    }
+});


### PR DESCRIPTION
This adds REGEX validation in JavaScript for checking the URL.

Fixes #1759.

When URL is correct:
![obraz](https://user-images.githubusercontent.com/72821/115112698-09474880-9f87-11eb-8bfd-20447d93d32b.png)

When repository name format is incorrect:
![obraz](https://user-images.githubusercontent.com/72821/115112725-29770780-9f87-11eb-9c69-fcbff7a1818a.png)

When Github.com link was used:
![obraz](https://user-images.githubusercontent.com/72821/115112835-9be7e780-9f87-11eb-8394-8e352aa46057.png)

When URL is not for username.github.io or github.com/username:
![obraz](https://user-images.githubusercontent.com/72821/115112761-56c3b580-9f87-11eb-98c2-0292bba06cd2.png)

@Talishask I corrected wording slightly (switched "slug" with "repo").
