### PR TITLE
[#1898] Fix django messages tags

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -443,10 +443,11 @@ MANAGERS = ADMINS
 from django.contrib.messages import constants as message_constants  # noqa
 
 MESSAGE_TAGS = {
-    message_constants.INFO: "alert-info",
-    message_constants.SUCCESS: "alert-success",
-    message_constants.WARNING: "alert-warning",
-    message_constants.ERROR: "alert-danger",
+    message_constants.DEBUG: "debug",
+    message_constants.INFO: "info alert-info",
+    message_constants.SUCCESS: "success alert-success",
+    message_constants.WARNING: "warning alert-warning",
+    message_constants.ERROR: "error alert-danger",
 }
 
 # django-countries


### PR DESCRIPTION
This fixes #1898 by adding default tag classes to changed message tags.

Thanks to this change, messages shown in Django Admin display with
correct styles, and current styling of messages in other parts of AMY
is maintained.

A warning message in Django Admin:
![obraz](https://user-images.githubusercontent.com/72821/115113666-b58b2e00-9f8b-11eb-9e8f-5c4b7a8b460e.png)
