### PR TITLE
feat(Profile Archival): All consents are unset when a person is archived.

### DIFF
--- a/amy/consents/apps.py
+++ b/amy/consents/apps.py
@@ -8,4 +8,4 @@ class ConsentsConfig(AppConfig):
 
     def ready(self):
         super().ready()
-        from consents import signals  # noqa
+        from consents import receivers  # noqa

--- a/amy/consents/models.py
+++ b/amy/consents/models.py
@@ -210,10 +210,19 @@ class Consent(CreatedUpdatedArchivedMixin, models.Model):
     @classmethod
     def archive_all_for_term(cls, terms: Iterable[Term]) -> None:
         consents = cls.objects.filter(term__in=terms).active()
+        cls.archive_all(consents)
+
+    @classmethod
+    def archive_all_for_person(cls, person: Person):
+        consents = cls.objects.filter(person=person).active()
+        cls.archive_all(consents)
+
+    @classmethod
+    def archive_all(cls, consents: Iterable[Consent]) -> None:
         new_consents = [
             cls(
-                person=consent.person,
-                term=consent.term,
+                person_id=consent.person_id,
+                term_id=consent.term_id,
                 term_option=None,
             )
             for consent in consents

--- a/amy/consents/receivers.py
+++ b/amy/consents/receivers.py
@@ -1,9 +1,9 @@
 from django.db.models.signals import post_save
-from workshops.signals import person_archived_signal
 from django.dispatch import receiver
 
 from consents.models import Consent, Term
 from workshops.models import Person
+from workshops.signals import person_archived_signal
 
 
 @receiver(post_save, sender=Person)

--- a/amy/consents/receivers.py
+++ b/amy/consents/receivers.py
@@ -1,4 +1,5 @@
 from django.db.models.signals import post_save
+from workshops.signals import person_archived_signal
 from django.dispatch import receiver
 
 from consents.models import Consent, Term
@@ -35,3 +36,9 @@ def create_unset_consents_on_term_create(
             )
             for person in Person.objects.all()
         )
+
+
+@receiver(person_archived_signal, sender=Person)
+def unset_consents_on_person_archive(sender, **kwargs) -> None:
+    person = kwargs["person"]
+    Consent.archive_all_for_person(person=person)

--- a/amy/consents/tests/base.py
+++ b/amy/consents/tests/base.py
@@ -1,8 +1,6 @@
 from contextlib import contextmanager
-from typing import Iterable
 
-from consents.models import Consent, Term, TermOption
-from workshops.models import Person
+from consents.models import Term, TermOption
 from workshops.tests.base import TestBase
 
 
@@ -20,18 +18,6 @@ class ConsentTestBase(TestBase):
         TermOption.objects.create(term=optional_term, option_type=TermOption.AGREE)
         TermOption.objects.create(term=optional_term, option_type=TermOption.DECLINE)
         self.assert_required_terms()
-
-    @staticmethod
-    def reconsent(person: Person, term: Term, term_option: TermOption) -> Consent:
-        consent = Consent.objects.get(
-            person=person, term=term, archived_at__isnull=True
-        )
-        consent.archive()
-        return Consent.objects.create(term_option=term_option, term=term, person=person)
-
-    def person_agree_to_terms(self, person: Person, terms: Iterable[Term]) -> None:
-        for term in terms:
-            self.reconsent(person=person, term_option=term.options[0], term=term)
 
     @contextmanager
     def terms_middleware(self) -> None:

--- a/amy/templates/navigation.html
+++ b/amy/templates/navigation.html
@@ -82,7 +82,6 @@
               <a class="dropdown-item" href="{% url 'autoupdate_profile' %}">Your profile</a>
               {% endif %}
               <a class="dropdown-item" href="{% url 'api:export-person-data' %}?format=json">Download your data</a>
-              <a class="dropdown-item" href="{% url 'person_archive' user.id %}?format=json">Archive your profile</a>
               <a class="dropdown-item" href="{% url 'person_password' user.id %}">Change password</a>
               <div class="dropdown-divider"></div>
               {% if user.is_superuser %}

--- a/amy/templates/navigation.html
+++ b/amy/templates/navigation.html
@@ -82,6 +82,7 @@
               <a class="dropdown-item" href="{% url 'autoupdate_profile' %}">Your profile</a>
               {% endif %}
               <a class="dropdown-item" href="{% url 'api:export-person-data' %}?format=json">Download your data</a>
+              <a class="dropdown-item" href="{% url 'person_archive' user.id %}?format=json">Archive your profile</a>
               <a class="dropdown-item" href="{% url 'person_password' user.id %}">Change password</a>
               <div class="dropdown-divider"></div>
               {% if user.is_superuser %}

--- a/amy/workshops/apps.py
+++ b/amy/workshops/apps.py
@@ -31,7 +31,6 @@ class WorkshopsConfig(AppConfig):
     name = "workshops"
     label = "workshops"
     verbose_name = "Workshops"
-    has_run = False
 
     def ready(self):
         # connect m2m_changed signal for TrainingRequest.domains to calculate

--- a/amy/workshops/apps.py
+++ b/amy/workshops/apps.py
@@ -31,6 +31,7 @@ class WorkshopsConfig(AppConfig):
     name = "workshops"
     label = "workshops"
     verbose_name = "Workshops"
+    has_run = False
 
     def ready(self):
         # connect m2m_changed signal for TrainingRequest.domains to calculate
@@ -46,3 +47,4 @@ class WorkshopsConfig(AppConfig):
             trainingrequest_m2m_changed,
             sender=TrainingRequest.previous_involvement.through,
         )
+        from workshops import receivers  # noqa

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -44,6 +44,8 @@ from workshops.mixins import (
     SecondaryEmailMixin,
     StateMixin,
 )
+from workshops.signals import person_archived_signal
+
 
 STR_SHORT = 10  # length of short strings
 STR_MED = 40  # length of medium strings
@@ -987,6 +989,10 @@ class Person(
         self.occupation = ""
         self.orcid = ""
         self.save()
+        person_archived_signal.send(
+            sender=self.__class__,
+            person=self,
+        )
 
 
 # ------------------------------------------------------------

--- a/amy/workshops/receivers.py
+++ b/amy/workshops/receivers.py
@@ -1,16 +1,11 @@
 import logging
 
 from django.contrib.auth.signals import user_login_failed
-from django.dispatch import Signal, receiver
+from django.dispatch import receiver
 from django.http.request import HttpRequest
 
 # AMY server logger
 logger = logging.getLogger("amy.server_logs")
-
-# signal generated when a comment regarding specific object should be saved
-create_comment_signal = Signal(
-    providing_args=["content_object", "comment", "timestamp"]
-)
 
 
 # a receiver for "failed login attempt" signal

--- a/amy/workshops/signals/__init__.py
+++ b/amy/workshops/signals/__init__.py
@@ -1,0 +1,8 @@
+from django.dispatch import Signal
+
+# signal generated when a comment regarding specific object should be saved
+create_comment_signal = Signal(
+    providing_args=["content_object", "comment", "timestamp"]
+)
+# signal generated when a Person object has been archived
+person_archived_signal = Signal(providing_args=["person"])

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -10,6 +10,7 @@ from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.forms import PasswordChangeForm, SetPasswordForm
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import (
     LoginRequiredMixin,
     PermissionRequiredMixin,


### PR DESCRIPTION
Fixes https://github.com/carpentries/amy/issues/1888

Dependent upon https://github.com/carpentries/amy/pull/1905
I needed to move signals in Workshops app so that they could be registered by the receivers in Consents. The way it was structured before the Signal init function ran after the Consents app had registered the signal (wiping out the receiver). Putting it in a module __init__ prevents that from happening. 