### PR TITLE
[#1711] Reactivate instructor survey links

### DIFF
--- a/amy/templates/includes/event_details_table.html
+++ b/amy/templates/includes/event_details_table.html
@@ -19,6 +19,8 @@
   <tr class="{% if not event.url %}table-danger{% endif %}"><th>Website URL:</th><td colspan="2">{{ event.website_url|default:"&mdash;"|urlize_newtab }} {% if event.url %}<a href="{% url 'validate_event' event.slug %}" class="btn btn-primary btn-sm float-right" id="validate_event" data-toggle="modal" data-target="#validation_modal">Validate event</a>{% else %}<a class="btn btn-danger btn-sm float-right" id="error_event_url" tabindex="0" role="button" data-toggle="popover" title="Validation error" data-content="Cannot validate an event without URL pointing to the GitHub repository, e.g.: <code>https://github.com/swcarpentry/2015-05-24-training</code>" data-html="true" data-trigger="focus">Error</a>{% endif %}</td></tr>
   <tr><th>Language:</th><td colspan="2">{{ event.language|default:"&mdash;" }}</td></tr>
   <tr><th>Eventbrite key:</th><td colspan="2">{% if event.reg_key %}<a href="https://www.eventbrite.com/myevent?eid={{ event.reg_key }}" title="Go to Eventbrite's page for this event" target="_blank" rel="noreferrer">{{ event.reg_key }}</a>{% else %}&mdash;{% endif %}</td></tr>
+  <tr><th>Pre-workshop assessment survey for instructors</th><td colspan="2">{{ event.instructors_pre|default:"&mdash;"|urlize_newtab}}</td></tr>
+  <tr><th>Post-workshop assessment survey for instructors</th><td colspan="2">{{ event.instructors_post|default:"&mdash;"|urlize_newtab}}</td></tr>
   <tr class="{% if not event.attendance %}table-danger{% endif %}">
     <th>Attendance:</th>
     <td colspan="2">

--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -429,6 +429,8 @@ class EventForm(forms.ModelForm):
             "curricula",
             "lessons",
             "public_status",
+            "instructors_pre",
+            "instructors_post",
             "comment",
         ]
         widgets = {
@@ -473,6 +475,8 @@ class EventForm(forms.ModelForm):
             "reg_key",
             "manual_attendance",
             "contact",
+            "instructors_pre",
+            "instructors_post",
             Div(
                 Div(HTML("Location details"), css_class="card-header"),
                 Div(


### PR DESCRIPTION
This fixes #1711 by re-introducing instructors pre/post survey links into event details page and event create/edit form.