### PR TITLE
feature(Profile Archival): Added an info message when the user's profile is not active

### DIFF
--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -280,11 +280,14 @@ class PersonDetails(OnlyForAdminsMixin, AMYDetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["title"] = "Person {0}".format(self.object)
+        title = "Person {0}".format(self.object)
+        context["title"] = title
 
         is_usersocialauth_in_sync = len(self.object.github_usersocialauth) > 0
         context["is_usersocialauth_in_sync"] = is_usersocialauth_in_sync
 
+        if not self.object.is_active:
+            messages.info(self.request, f"{title} is not active.")
         return context
 
 


### PR DESCRIPTION
Fixes https://github.com/carpentries/amy/issues/1890

Inactive User:
<img width="1053" alt="Screen Shot 2021-05-02 at 12 23 04 PM" src="https://user-images.githubusercontent.com/12959365/116821891-82c36700-ab41-11eb-893b-e9124ede41c6.png">

Active User (no change):
<img width="1434" alt="Screen Shot 2021-05-02 at 12 22 56 PM" src="https://user-images.githubusercontent.com/12959365/116821899-8d7dfc00-ab41-11eb-8f9b-f10eba11126c.png">
