### PR TITLE
feature(Profile Archival): Remove profile change history.

### DIFF
--- a/amy/workshops/tests/test_person.py
+++ b/amy/workshops/tests/test_person.py
@@ -10,11 +10,13 @@ from django.contrib.sites.models import Site
 from django.core.validators import ValidationError
 from django.urls import reverse
 from django_comments.models import Comment
+from reversion.models import Version
+from reversion.revisions import create_revision
 from social_django.models import UserSocialAuth
 import webtest
 from webtest.forms import Upload
-from consents.models import Consent, Term
 
+from consents.models import Consent, Term
 from workshops.filters import filter_taught_workshops
 from workshops.forms import PersonForm, PersonsMergeForm
 from workshops.models import (
@@ -1512,3 +1514,42 @@ class TestArchivePerson(TestBase):
         self.assertFalse(
             self.client.login(username=self.user.username, password="pass")
         )
+
+    def test_version_history_removed_when_archived(self) -> None:
+        # Create the person and change their information a few times.
+        with create_revision():
+            person = Person.objects.create(
+                personal="Draco",
+                family="Malfoy",
+                username="dmalfoy",
+                email="draco@malfoy.com",
+            )
+        with create_revision():
+            person.twitter = "dmalfoy"
+            person.save()
+        with create_revision():
+            person.github = "dmalfoy"
+            person.save()
+
+        # get the current profile change history
+        original_versions = Version.objects.get_for_object(person)
+        self.assertEqual(len(original_versions), 3)
+
+        # Login as a normal user (non-admin)
+        # This user should not be able to archive anyone else's profile
+        # Profile edit history should be unchanged
+        assert not self.user.is_superuser
+        self.assertTrue(self.client.login(username=self.user.username, password="pass"))
+        self.assert_cannot_archive(person)
+        self.assertCountEqual(original_versions, Version.objects.get_for_object(person))
+
+        # Login as the admin user and archive the profile
+        # All profile change history after archival
+        # should be removed but the current one
+        self.assertTrue(
+            self.client.login(username=self.admin.username, password="admin")
+        )
+        self.assert_person_archive(person)
+        archived_profile = Person.objects.get(pk=person.pk)
+        versions_after_archive = Version.objects.get_for_object(archived_profile)
+        self.assertEqual(len(versions_after_archive), 1)


### PR DESCRIPTION
Fixes https://github.com/carpentries/amy/issues/1892

Person with a change history:
<img width="1378" alt="Screen Shot 2021-05-02 at 2 21 59 PM" src="https://user-images.githubusercontent.com/12959365/116824992-a80ca100-ab52-11eb-83d7-990325652053.png">

Person's change history after archival:
<img width="1036" alt="Screen Shot 2021-05-02 at 2 22 13 PM" src="https://user-images.githubusercontent.com/12959365/116825004-b955ad80-ab52-11eb-8a6d-fcc1b759d83e.png">
