### PR TITLE
feature(Profile Archival): Remove groups and permissions from the user when the profile is archived.

### DIFF
--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -996,6 +996,10 @@ class Person(
         self.data_privacy_agreement = False
         self.may_contact = False
         self.publish_profile = False
+        # Remove permissions
+        self.is_superuser = False
+        self.groups.clear()
+        self.user_permissions.clear()
         self.save()
 
         # This deletes all pre-existing Versions of the object.


### PR DESCRIPTION
Fixes https://github.com/carpentries/amy/issues/1889

Set custom permissions on the user and made them a super user:
<img width="1151" alt="Screen Shot 2021-05-02 at 5 37 21 PM" src="https://user-images.githubusercontent.com/12959365/116830117-9389d200-ab6d-11eb-8960-43530e45a33a.png">

Permissions after the profile is archived:
<img width="1212" alt="Screen Shot 2021-05-02 at 5 37 54 PM" src="https://user-images.githubusercontent.com/12959365/116830142-ac928300-ab6d-11eb-859a-19ca61be175c.png">

