### PR TITLE
fix(Profile Archival): Remove more  personal information when the user is  archived.

### DIFF
--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -46,7 +46,6 @@ from workshops.mixins import (
 )
 from workshops.signals import person_archived_signal
 
-
 STR_SHORT = 10  # length of short strings
 STR_MED = 40  # length of medium strings
 STR_LONG = 100  # length of long strings
@@ -988,6 +987,13 @@ class Person(
         self.is_active = False
         self.occupation = ""
         self.orcid = ""
+        self.secondary_email = ""
+        self.gender = GenderMixin.UNDISCLOSED
+        self.gender_other = ""
+        # TODO(lb): Remove references to agreements when Consents project is launched
+        self.data_privacy_agreement = False
+        self.may_contact = False
+        self.publish_profile = False
         self.save()
         person_archived_signal.send(
             sender=self.__class__,

--- a/amy/workshops/tests/test_person.py
+++ b/amy/workshops/tests/test_person.py
@@ -1383,14 +1383,14 @@ class TestArchivePerson(TestBase):
             family="",
             email="user@example.org",
             password="pass",
-            data_privacy_agreement=True,
-            may_contact=True,
-            publish_profile=True,
-            is_active=True,
-            secondary_email="user@second_example.org",
-            gender=GenderMixin.OTHER,
-            other_gender="Agender",
         )
+        self.user.data_privacy_agreement = True
+        self.user.may_contact = True
+        self.user.publish_profile = True
+        self.user.is_active = True
+        self.user.secondary_email = "user@second_example.org"
+        self.user.gender = GenderMixin.OTHER
+        self.user.other_gender = "Agender"
         self.user.save()
         # folks don't have any tasks by default, so let's add one
         self.harry.task_set.create(event=self.event, role=self.role)
@@ -1459,7 +1459,7 @@ class TestArchivePerson(TestBase):
         Asserts that all personal data about the user has been removed.
         """
         self.assertIsNone(archived_profile.email)
-        self.assertIsNone(archived_profile.secondary_email)
+        self.assertEqual(archived_profile.secondary_email, "")
         self.assertEqual(archived_profile.country, "")
         self.assertIsNone(archived_profile.airport)
         self.assertIsNone(archived_profile.github)


### PR DESCRIPTION
I missed some personal information. Removing those as well.
Fixes https://github.com/carpentries/amy/issues/1918

Before Archival:
<img width="1412" alt="Screen Shot 2021-05-02 at 6 02 37 PM" src="https://user-images.githubusercontent.com/12959365/116830598-06487c80-ab71-11eb-9266-9bad33415e5a.png">

After Archival:
<img width="1349" alt="Screen Shot 2021-05-02 at 6 03 03 PM" src="https://user-images.githubusercontent.com/12959365/116830601-0cd6f400-ab71-11eb-9165-8504586b98e1.png">

