### PR TITLE
[#1946] Fix BulkMatchTrainingRequestForm

### DIFF
--- a/amy/extrequests/forms.py
+++ b/amy/extrequests/forms.py
@@ -118,11 +118,13 @@ class BulkMatchTrainingRequestForm(forms.Form):
         widget=ModelSelect2Widget(data_view="membership-lookup"),
     )
 
-    seat_public = forms.BooleanField(
-        label=Task._meta.get_field("seat_public").verbose_name,
-        required=False,
+    seat_public = forms.TypedChoiceField(
+        coerce=bool,
+        choices=Task.SEAT_PUBLIC_CHOICES,
         initial=Task._meta.get_field("seat_public").default,
-        widget=forms.RadioSelect(choices=Task.SEAT_PUBLIC_CHOICES),
+        required=False,
+        label=Task._meta.get_field("seat_public").verbose_name,
+        widget=forms.RadioSelect(),
     )
 
     seat_open_training = forms.BooleanField(

--- a/amy/extrequests/tests/test_training_request.py
+++ b/amy/extrequests/tests/test_training_request.py
@@ -325,6 +325,7 @@ class TestTrainingRequestsListView(TestBase):
             "match": "",
             "event": self.second_training.pk,
             "requests": [self.first_req.pk],
+            "seat_public": "True",
         }
         rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 
@@ -383,6 +384,7 @@ class TestTrainingRequestsListView(TestBase):
             "match": "",
             "event": self.second_training.pk,
             "requests": [self.second_req.pk],
+            "seat_public": "True",
         }
         rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 


### PR DESCRIPTION
The form didn't display the field correctly, because a wrong field was
used (BooleanField instead of ChoiceField).

Please delete this line and the text below before submitting your contribution.
This fixes #1946.