### PR TITLE
[#1945] Change Membership public status def. value

### DIFF
--- a/amy/workshops/migrations/0228_auto_20210204_0658.py
+++ b/amy/workshops/migrations/0228_auto_20210204_0658.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='membership',
             name='public_status',
-            field=models.CharField(choices=[('public', 'Public'), ('private', 'Private')], default='public', max_length=20,
+            field=models.CharField(choices=[('public', 'Public'), ('private', 'Private')], default='private', max_length=20,
                                    verbose_name="Can this membership be publicized on The carpentries websites?",
                                    help_text="Public memberships may be listed on any of The Carpentries websites."
             ),

--- a/amy/workshops/migrations/0237_auto_20210321_1056.py
+++ b/amy/workshops/migrations/0237_auto_20210321_1056.py
@@ -82,4 +82,17 @@ class Migration(migrations.Migration):
             model_name='membership',
             name='self_organized_workshops_rolled_over',
         ),
+
+        # The following migration is a no-op as a result of
+        # https://github.com/carpentries/amy/pull/1949
+        # Previously 0228 introduced `public_status` field with default value of `public`,
+        # and this migration changed the default value to `private`. This is however
+        # incorrect as the existing memberships need to be migrated with default value
+        # of `private` first, thus 0228 was amended to have default value as `private`,
+        # and this migration became no-op.
+        # migrations.AlterField(
+        #     model_name='membership',
+        #     name='public_status',
+        #     field=models.CharField(choices=[('public', 'Public'), ('private', 'Private')], default='private', help_text='Public memberships may be listed on any of The Carpentries websites.', max_length=20, verbose_name='Can this membership be publicized on The carpentries websites?'),
+        # ),
     ]

--- a/amy/workshops/migrations/0237_auto_20210321_1056.py
+++ b/amy/workshops/migrations/0237_auto_20210321_1056.py
@@ -82,9 +82,4 @@ class Migration(migrations.Migration):
             model_name='membership',
             name='self_organized_workshops_rolled_over',
         ),
-        migrations.AlterField(
-            model_name='membership',
-            name='public_status',
-            field=models.CharField(choices=[('public', 'Public'), ('private', 'Private')], default='private', help_text='Public memberships may be listed on any of The Carpentries websites.', max_length=20, verbose_name='Can this membership be publicized on The carpentries websites?'),
-        ),
     ]


### PR DESCRIPTION
The migrations order would:
1. introduce "public_status" field with "public" default value
2. change default value to "private".

This was wrong because all the memberships would become public once
the first migration is run.

Changes introduced in this commit/PR make "private" default for the first
migration; the second migration is removed as it's now a no-op.

This fixes #1945.