### PR TITLE
ref(Consents): Filtered out already answered required consents in actions required.

### DIFF
--- a/amy/consents/forms.py
+++ b/amy/consents/forms.py
@@ -31,10 +31,10 @@ class BaseTermConsentsForm(WidgetOverrideMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         form_tag = kwargs.pop("form_tag", True)
-        person = kwargs["initial"]["person"]
+        self.person = kwargs["initial"]["person"]
         super().__init__(*args, **kwargs)
         self.terms = self.get_terms()
-        self._build_form(person)
+        self._build_form(self.person)
         self.helper = BootstrapHelper(
             add_cancel_button=False,
             form_tag=form_tag,
@@ -104,6 +104,19 @@ class RequiredConsentsForm(BaseTermConsentsForm):
     """
     Builds form shown on login when there are missing required consents.
     """
+
+    def _build_form(self, person: Person) -> None:
+        """
+        Construct a Form of terms with the
+        consent answers added as initial.
+
+        Filter terms to only those that have not been answered by the person.
+        """
+        term_ids = Consent.objects.filter(
+            archived_at=None, term__in=self.terms, person=person, term_option=None
+        ).values_list("term_id", flat=True)
+        self.terms = [term for term in self.terms if term.id in term_ids]
+        super()._build_form(person)
 
     @classmethod
     def get_terms(cls) -> Iterable[Term]:

--- a/amy/consents/tests/test_forms.py
+++ b/amy/consents/tests/test_forms.py
@@ -92,7 +92,20 @@ class TestRequiredConsentsForm(ConsentTestBase):
             archived_at=timezone.now(),
             required_type=Term.PROFILE_REQUIRE_TYPE,
         )
+        answered_required_term = Term.objects.create(
+            content="answered_required_term",
+            slug="answered_required_term",
+            required_type=Term.PROFILE_REQUIRE_TYPE,
+        )
+        answered_required_term_yes = TermOption.objects.create(
+            term=answered_required_term,
+            option_type=TermOption.AGREE,
+            content="Yes",
+        )
+        self.reconsent(self.person, answered_required_term, answered_required_term_yes)
         form = RequiredConsentsForm(initial={"person": self.person})
         self.assertIn(required_term.slug, form.fields)
         self.assertNotIn(not_required_term.slug, form.fields)
         self.assertNotIn(archived_term.slug, form.fields)
+        # Already answered terms are filtered out
+        self.assertNotIn(answered_required_term.slug, form.fields)


### PR DESCRIPTION
Fixes https://github.com/carpentries/amy/issues/1927
