### PR TITLE
feat(Consents): Remove old-style consents from api serializers

### DIFF
--- a/amy/api/serializers.py
+++ b/amy/api/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from autoemails.models import EmailTemplate
+from consents.models import Consent, Term
 from workshops.models import (
     Airport,
     Award,
@@ -61,6 +62,29 @@ class AwardSerializer(serializers.ModelSerializer):
         fields = ("badge", "awarded", "event")
 
 
+class TermSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Term
+        fields = ("slug", "content", "required_type", "help_text")
+
+
+class ConsentSerializer(serializers.ModelSerializer):
+    # term = serializers.HyperlinkedRelatedField(
+    #     read_only=True, view_name="api:term-detail"
+    # )
+    term = TermSerializer(
+        read_only=True,
+    )
+    term_option = serializers.StringRelatedField()
+    person = serializers.HyperlinkedRelatedField(
+        read_only=True, view_name="api:person-detail"
+    )
+
+    class Meta:
+        model = Consent
+        fields = ("term", "person", "term_option")
+
+
 class PersonSerializer(serializers.ModelSerializer):
     airport = serializers.HyperlinkedRelatedField(
         read_only=True, view_name="api:airport-detail", lookup_field="iata"
@@ -79,6 +103,11 @@ class PersonSerializer(serializers.ModelSerializer):
         lookup_field="pk",
         lookup_url_kwarg="person_pk",
     )
+    consents = serializers.HyperlinkedIdentityField(
+        view_name="api:person-consents-list",
+        lookup_field="pk",
+        lookup_url_kwarg="person_pk",
+    )
 
     class Meta:
         model = Person
@@ -91,10 +120,6 @@ class PersonSerializer(serializers.ModelSerializer):
             "secondary_email",
             "gender",
             "gender_other",
-            "may_contact",
-            "publish_profile",
-            "lesson_publication_consent",
-            "data_privacy_agreement",
             "airport",
             "country",
             "github",
@@ -109,6 +134,7 @@ class PersonSerializer(serializers.ModelSerializer):
             "domains",
             "awards",
             "tasks",
+            "consents",
         )
 
 
@@ -436,6 +462,7 @@ class PersonSerializerAllData(PersonSerializer):
     training_progresses = TrainingProgressSerializer(
         many=True, read_only=True, source="trainingprogress_set"
     )
+    consents = ConsentSerializer(many=True, read_only=True, source="consent_set")
 
     class Meta:
         model = Person
@@ -448,10 +475,6 @@ class PersonSerializerAllData(PersonSerializer):
             "secondary_email",
             "gender",
             "gender_other",
-            "may_contact",
-            "publish_profile",
-            "lesson_publication_consent",
-            "data_privacy_agreement",
             "airport",
             "country",
             "github",
@@ -469,6 +492,7 @@ class PersonSerializerAllData(PersonSerializer):
             "tasks",
             "training_requests",
             "training_progresses",
+            "consents",
         )
 
 

--- a/amy/api/serializers.py
+++ b/amy/api/serializers.py
@@ -69,9 +69,6 @@ class TermSerializer(serializers.ModelSerializer):
 
 
 class ConsentSerializer(serializers.ModelSerializer):
-    # term = serializers.HyperlinkedRelatedField(
-    #     read_only=True, view_name="api:term-detail"
-    # )
     term = TermSerializer(
         read_only=True,
     )

--- a/amy/api/tests/test_export.py
+++ b/amy/api/tests/test_export.py
@@ -1,8 +1,10 @@
 import datetime
+from typing import List
 
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
+from consents.models import Consent, Term
 from workshops.models import (
     Airport,
     Award,
@@ -194,6 +196,20 @@ class TestExportingPersonData(BaseExportingTest):
             discarded=False,
             url="http://example.org/homework",
         )
+        terms = (
+            Term.objects.active()
+            .filter(required_type=Term.PROFILE_REQUIRE_TYPE)
+            .prefetch_active_options()
+        )
+        consents = Consent.objects.filter(person=self.user).active()
+        consents_by_term_id = {consent.term_id: consent for consent in consents}
+        self.user_consents: List[Consent] = []
+        for term in terms:
+            self.user_consents.append(
+                Consent.reconsent(
+                    consent=consents_by_term_id[term.pk], term_option=term.options[0]
+                )
+            )
 
     def test_unauthorized_access(self):
         """Make sure only authenticated users can access."""
@@ -257,15 +273,12 @@ class TestExportingPersonData(BaseExportingTest):
 
         # simple (non-relational) fields expected in API output
         expected_fields = [
-            "data_privacy_agreement",
             "personal",
             "middle",
             "family",
             "email",
             "username",
             "gender",
-            "may_contact",
-            "publish_profile",
             "github",
             "twitter",
             "url",
@@ -286,6 +299,7 @@ class TestExportingPersonData(BaseExportingTest):
             "awards",  # renamed in serializer (was: award_set)
             "training_requests",  # renamed from "trainingrequest_set"
             "training_progresses",  # renamed from "trainingprogress_set"
+            "consents",  # renamed from "consent_set"
         ]
 
         # ensure missing fields are not to be found in API output
@@ -322,6 +336,25 @@ class TestExportingPersonData(BaseExportingTest):
         }
         self.assertEqual(data["airport"], expected["airport"])
 
+        # test expected Consents output
+        user_data_term_slugs = [consent["term"]["slug"] for consent in data["consents"]]
+        for consent in self.user_consents:
+            self.assertIn(consent.term.slug, user_data_term_slugs)
+        # assert consent format
+        self.assertIn(
+            {
+                "person": f"http://testserver/api/v1/persons/{self.user.id}",
+                "term": {
+                    "content": "May contact",
+                    "help_text": "Allow to contact from The Carpentries according to "
+                    "the Privacy Policy.",
+                    "required_type": "profile",
+                    "slug": "may-contact",
+                },
+                "term_option": None,
+            },
+            data["consents"],
+        )
         # test expected Badges output
         expected["badges"] = [
             {

--- a/amy/api/urls.py
+++ b/amy/api/urls.py
@@ -15,6 +15,10 @@ person_task_router = routers.NestedSimpleRouter(router, 'persons',
                                                 lookup='person')
 person_task_router.register('tasks', views.PersonTaskViewSet,
                             basename='person-tasks')
+person_consent_router = routers.NestedSimpleRouter(router, 'persons',
+                                                lookup='person')
+person_consent_router.register('consents', views.PersonConsentViewSet,
+                            basename='person-consents')
 training_progress_router = routers.NestedSimpleRouter(router, 'persons', lookup='person')
 training_progress_router.register('trainingprogress', views.TrainingProgressViewSet, basename='person-training-progress')
 router.register('events', views.EventViewSet)
@@ -24,6 +28,7 @@ router.register('organizations', views.OrganizationViewSet)
 router.register('airports', views.AirportViewSet)
 router.register('emailtemplates', views.EmailTemplateViewSet,
                 basename='emailtemplate')
+router.register('terms', views.TermViewSet)
 
 urlpatterns = [
     path('', views.ApiRoot.as_view(), name='root'),
@@ -37,6 +42,7 @@ urlpatterns = [
     path('', include(router.urls)),
     path('', include(awards_router.urls)),
     path('', include(person_task_router.urls)),
+    path('', include(person_consent_router.urls)),
     path('', include(tasks_router.urls)),
     path('', include(training_progress_router.urls)),
 ]

--- a/amy/consents/models.py
+++ b/amy/consents/models.py
@@ -220,3 +220,12 @@ class Consent(CreatedUpdatedArchivedMixin, models.Model):
         ]
         consents.update(archived_at=timezone.now())
         cls.objects.bulk_create(new_consents)
+
+    @classmethod
+    def reconsent(cls, consent: Consent, term_option: TermOption) -> Consent:
+        consent.archive()
+        return Consent.objects.create(
+            term_id=term_option.term_id,
+            term_option=term_option,
+            person_id=consent.person_id,
+        )

--- a/amy/workshops/tests/base.py
+++ b/amy/workshops/tests/base.py
@@ -5,8 +5,8 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.sites.models import Site
 from django_webtest import WebTest
 import webtest.forms
-from consents.models import Consent, Term, TermOption
 
+from consents.models import Consent, Term, TermOption
 from workshops.models import (
     Airport,
     Award,
@@ -460,8 +460,7 @@ class TestBase(
         consent = Consent.objects.get(
             person=person, term=term, archived_at__isnull=True
         )
-        consent.archive()
-        return Consent.objects.create(term_option=term_option, term=term, person=person)
+        return Consent.reconsent(consent, term_option)
 
     def person_agree_to_terms(self, person: Person, terms: Iterable[Term]) -> None:
         for term in terms:


### PR DESCRIPTION
Part of a fix for https://github.com/carpentries/amy/issues/1963

Handles the person data export. 