### PR TITLE
fix(Consent): Remove old-style consents from trainee dashboard.

### DIFF
--- a/amy/templates/dashboard/trainee_dashboard.html
+++ b/amy/templates/dashboard/trainee_dashboard.html
@@ -28,9 +28,9 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
       </i></small>
       </th><td>{{ user.secondary_email|default:"—" }}</td></tr>
     <tr><th>Gender:</th><td>{{ user.get_gender_display }}{{ user.gender_other }}</td></tr>
-    <tr><th>Can we contact you?</th><td>{{ may_contact|yesno }}</td></tr>
-    <tr><th>Do you consent to publish your profile<br>on The Carpentries website?</th><td>{{ public_profile|yesno }}</td></tr>
-    <tr><th>Do you consent to have your name or identity<br>associated with lesson publications?</th><td>{{ may_publish_name|default:"—" }}</td></tr>
+    <tr><th>Can we contact you?</th><td>{{ may_contact|default:"Unset" }}</td></tr>
+    <tr><th>Do you consent to publish your profile<br>on The Carpentries website?</th><td>{{ public_profile|default:"Unset" }}</td></tr>
+    <tr><th>Do you consent to have your name or identity<br>associated with lesson publications?</th><td>{{ may_publish_name|default:"Unset" }}</td></tr>
     <tr><th>Country:</th><td>{% if user.country %}{{ user.country.name }} <img src="{{ user.country.flag }}" alt="{{ user.country }}" class="country-flag" />{% else %}—{% endif %}</td></tr>
     <tr><th>Airport:</th><td>{{ user.airport|default:"—"  }}</td></tr>
     <tr><th>Github:</th><td>{{ user.github|default:"—" }}</td></tr>

--- a/amy/templates/dashboard/trainee_dashboard.html
+++ b/amy/templates/dashboard/trainee_dashboard.html
@@ -13,7 +13,6 @@
 Click on the button at the bottom of this page to update your profile information. <br>
 Your email address and GitHub id can not be updated here, as they are tied to your login id. Please contact us at <a href="mailto:team@carpentries.org">team@carpentries.org</a> if you would like to update this information.  <br>
 
-
   <table class="table table-striped">
     <tr><th width="40%">Personal name:</th><td>{{ user.personal|default:"—" }}</td></tr>
     <tr><th>Middle name:</th><td>{{ user.middle|default:"—" }}</td></tr>
@@ -29,9 +28,9 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
       </i></small>
       </th><td>{{ user.secondary_email|default:"—" }}</td></tr>
     <tr><th>Gender:</th><td>{{ user.get_gender_display }}{{ user.gender_other }}</td></tr>
-    <tr><th>Can we contact you?</th><td>{{ user.may_contact|yesno }}</td></tr>
-    <tr><th>Do you consent to publish your profile<br>on The Carpentries website?</th><td>{{ user.publish_profile|yesno }}</td></tr>
-    <tr><th>Do you consent to have your name or identity<br>associated with lesson publications?</th><td>{{ user.get_lesson_publication_consent_display|default:"—" }}</td></tr>
+    <tr><th>Can we contact you?</th><td>{{ may_contact|yesno }}</td></tr>
+    <tr><th>Do you consent to publish your profile<br>on The Carpentries website?</th><td>{{ public_profile|yesno }}</td></tr>
+    <tr><th>Do you consent to have your name or identity<br>associated with lesson publications?</th><td>{{ may_publish_name|default:"—" }}</td></tr>
     <tr><th>Country:</th><td>{% if user.country %}{{ user.country.name }} <img src="{{ user.country.flag }}" alt="{{ user.country }}" class="country-flag" />{% else %}—{% endif %}</td></tr>
     <tr><th>Airport:</th><td>{{ user.airport|default:"—"  }}</td></tr>
     <tr><th>Github:</th><td>{{ user.github|default:"—" }}</td></tr>


### PR DESCRIPTION
Partial fix to #1963

With a consent unset:
<img width="1205" alt="Screen Shot 2021-06-02 at 12 35 14 PM" src="https://user-images.githubusercontent.com/12959365/120526934-62383800-c39f-11eb-8ff1-b36c8990fb65.png">

The same consent answered:
<img width="1101" alt="Screen Shot 2021-06-02 at 12 36 04 PM" src="https://user-images.githubusercontent.com/12959365/120526951-682e1900-c39f-11eb-85c4-c32ea67467b3.png">
