### PR TITLE
[#1996] Fix *CountriesFilter override countries

### DIFF
--- a/amy/workshops/filters.py
+++ b/amy/workshops/filters.py
@@ -50,12 +50,15 @@ def extend_country_choices(
 
 
 class AllCountriesFilter(django_filters.ChoiceFilter):
-    @property
-    def field(self):
+    def _get_countries(self):
         qs = self.model._default_manager.distinct()
         qs = qs.order_by(self.field_name).values_list(self.field_name, flat=True)
-
         choices = [o for o in qs if o]
+        return choices
+
+    @property
+    def field(self):
+        choices = self._get_countries()
         overrides = extend_country_choices(choices, settings.COUNTRIES_OVERRIDE)
         countries = Countries()
         countries.only = overrides
@@ -65,12 +68,15 @@ class AllCountriesFilter(django_filters.ChoiceFilter):
 
 
 class AllCountriesMultipleFilter(django_filters.MultipleChoiceFilter):
-    @property
-    def field(self):
+    def _get_countries(self):
         qs = self.model._default_manager.distinct()
         qs = qs.order_by(self.field_name).values_list(self.field_name, flat=True)
-
         choices = [o for o in qs if o]
+        return choices
+
+    @property
+    def field(self):
+        choices = self._get_countries()
         overrides = extend_country_choices(choices, settings.COUNTRIES_OVERRIDE)
         countries = Countries()
         countries.only = overrides

--- a/amy/workshops/tests/test_filters.py
+++ b/amy/workshops/tests/test_filters.py
@@ -1,6 +1,12 @@
+from unittest.mock import MagicMock
+
 from django.test import TestCase
 
-from workshops.filters import extend_country_choices
+from workshops.filters import (
+    AllCountriesFilter,
+    AllCountriesMultipleFilter,
+    extend_country_choices,
+)
 
 
 class TestExtendCountryChoices(TestCase):
@@ -42,5 +48,51 @@ class TestExtendCountryChoices(TestCase):
                 "US",
                 "GB",
                 ("W3", "Online"),
+            ],
+        )
+
+
+class TestAllCountriesFilterCustomCountries(TestCase):
+    def test_extra_choices(self):
+        """Regression test for https://github.com/carpentries/amy/issues/1996."""
+        # Arrange
+        filter_ = AllCountriesFilter()
+        filter_._get_countries = MagicMock(return_value=["PL", "US", "GB", "W3", "EU"])
+
+        # Act
+        filter_.field
+
+        # Assert
+        self.assertEqual(
+            filter_.extra["choices"],
+            [
+                ("EU", "European Union"),
+                ("W3", "Online"),
+                ("PL", "Poland"),
+                ("GB", "United Kingdom"),
+                ("US", "United States"),
+            ],
+        )
+
+
+class TestAllCountriesMultipleFilterCustomCountries(TestCase):
+    def test_extra_choices(self):
+        """Regression test for https://github.com/carpentries/amy/issues/1996."""
+        # Arrange
+        filter_ = AllCountriesMultipleFilter()
+        filter_._get_countries = MagicMock(return_value=["PL", "US", "GB", "W3", "EU"])
+
+        # Act
+        filter_.field
+
+        # Assert
+        self.assertEqual(
+            filter_.extra["choices"],
+            [
+                ("EU", "European Union"),
+                ("W3", "Online"),
+                ("PL", "Poland"),
+                ("GB", "United Kingdom"),
+                ("US", "United States"),
             ],
         )

--- a/amy/workshops/tests/test_filters.py
+++ b/amy/workshops/tests/test_filters.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+
+from workshops.filters import extend_country_choices
+
+
+class TestExtendCountryChoices(TestCase):
+    def test_no_overrides(self):
+        # Arrange
+        choices = ["PL", "US", "GB", "W3"]
+        overrides = {}
+
+        # Act
+        results = extend_country_choices(choices, overrides)
+
+        # Assert
+        self.assertEqual(choices, results)
+
+    def test_no_common_overrides(self):
+        # Arrange
+        choices = ["PL", "US", "GB"]
+        overrides = {"W3": "Online"}
+
+        # Act
+        results = extend_country_choices(choices, overrides)
+
+        # Assert
+        self.assertEqual(choices, results)
+
+    def test_overrides(self):
+        # Arrange
+        choices = ["PL", "US", "GB", "W3"]
+        overrides = {"W3": "Online"}
+
+        # Act
+        results = extend_country_choices(choices, overrides)
+
+        # Assert
+        self.assertEqual(
+            results,
+            [
+                "PL",
+                "US",
+                "GB",
+                ("W3", "Online"),
+            ],
+        )


### PR DESCRIPTION
AllCountriesFilter and AllCountriesMultipleFilter use COUNTRIES_OVERRIDE
to substitute custom countries used to narrow the total list of
countries.

For example: `['W3']`
will be replaced with: `[('W3', 'Online')]`
since this value is set in the `settings.py`.
