### PR TITLE
[#1946] Fix: warning msg for exceeding remaining seats

### DIFF
--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -567,7 +567,6 @@ def all_trainingrequests(request):
                     ),
                 )
 
-            requests_count = len(match_form.cleaned_data["requests"])
             today = datetime.date.today()
 
             if membership:
@@ -576,7 +575,7 @@ def all_trainingrequests(request):
                     if seat_public
                     else membership.inhouse_instructor_training_seats_remaining
                 )
-                if remaining - requests_count <= 0:
+                if remaining <= 0:
                     messages.warning(
                         request,
                         f'Membership "{membership}" is using more training seats than '


### PR DESCRIPTION
Calculation in some specific cases would result in a warning message
even though the remaining number of seats was >=1.
