### PR TITLE
[#1942][#1943] List events on membership page, display event type of organization page

### DIFF
--- a/amy/fiscal/tests/test_organization.py
+++ b/amy/fiscal/tests/test_organization.py
@@ -77,7 +77,7 @@ class TestOrganization(TestBase):
                 self.assertIn("domain", form.cleaned_data)
                 self.assertEqual(form.cleaned_data["domain"], expected)
 
-    def test_creating_event_with_no_comment(self):
+    def test_creating_organization_with_no_comment(self):
         """Ensure that no comment is added when OrganizationCreateForm without
         comment content is saved."""
         self.assertEqual(Comment.objects.count(), 0)
@@ -90,7 +90,7 @@ class TestOrganization(TestBase):
         form.save()
         self.assertEqual(Comment.objects.count(), 0)
 
-    def test_creating_event_with_comment(self):
+    def test_creating_organization_with_comment(self):
         """Ensure that a comment is added when OrganizationCreateForm with
         comment content is saved."""
         self.assertEqual(Comment.objects.count(), 0)

--- a/amy/fiscal/views.py
+++ b/amy/fiscal/views.py
@@ -70,13 +70,17 @@ class OrganizationDetails(UnquoteSlugMixin, OnlyForAdminsMixin, AMYDetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = "Organization {0}".format(self.object)
+        related = ["host", "sponsor", "membership"]
         context["all_events"] = (
-            self.object.hosted_events.all()
+            self.object.hosted_events.select_related(*related)
             .union(
-                self.object.sponsored_events.all(),
-                self.object.administered_events.all(),
+                self.object.sponsored_events.select_related(*related),
+                self.object.administered_events.select_related(*related),
             )
             .prefetch_related("tags")
+        )
+        context["main_organisation_memberships"] = Membership.objects.filter(
+            member__role__name="main", member__organization=self.object
         )
         return context
 

--- a/amy/templates/fiscal/membership.html
+++ b/amy/templates/fiscal/membership.html
@@ -231,6 +231,31 @@
   </div>
 </div>
 
+
+{% if membership.event_set.all %}
+<h2>Events</h2>
+<table class="table table-striped">
+  <tr>
+    <th>Slug</th>
+    <th>Tags</th>
+    <th>Start date</th>
+    <th>End date</th>
+    <th>URL</th>
+  </tr>
+  {% for e in membership.event_set.all %}
+  <tr>
+    <td><a href="{{ e.get_absolute_url }}">{{ e.slug }}</a></td>
+    <td>{{ e.tags.all | join:", " }}</td>
+    <td>{{ e.start }}</td>
+    <td>{{ e.end }}</td>
+    <td>{{ e.url|urlize_newtab }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% else %}
+<p>No events.</p>
+{% endif %}
+
 {% include "includes/comments.html" with object=membership %}
 
 {% endblock %}

--- a/amy/templates/fiscal/organization.html
+++ b/amy/templates/fiscal/organization.html
@@ -69,6 +69,7 @@
 <table class="table table-striped">
   <tr>
     <th>Slug</th>
+    <th>Type</th>
     <th>Tags</th>
     <th>Start date</th>
     <th>End date</th>
@@ -77,6 +78,17 @@
   {% for e in all_events %}
   <tr>
     <td><a href="{{ e.get_absolute_url }}">{{ e.slug }}</a></td>
+    <td>
+    {% if e.host == organization %}
+    <span class="badge badge-pill badge-primary">Hosted</span>
+    {% endif %}
+    {% if e.sponsor == organization %}
+    <span class="badge badge-pill badge-secondary">Sponsored</span>
+    {% endif %}
+    {% if e.membership in main_organisation_memberships %}
+    <span class="badge badge-pill badge-success">Affiliated</span>
+    {% endif %}
+    </td>
     <td>{{ e.tags.all | join:", " }}</td>
     <td>{{ e.start }}</td>
     <td>{{ e.end }}</td>

--- a/amy/templates/fiscal/organization.html
+++ b/amy/templates/fiscal/organization.html
@@ -68,18 +68,18 @@
 <h2>Events</h2>
 <table class="table table-striped">
   <tr>
-    <th>tags</th>
-    <th>start date</th>
-    <th>end date</th>
-    <th>slug</th>
-    <th>url</th>
+    <th>Slug</th>
+    <th>Tags</th>
+    <th>Start date</th>
+    <th>End date</th>
+    <th>URL</th>
   </tr>
   {% for e in all_events %}
   <tr>
+    <td><a href="{{ e.get_absolute_url }}">{{ e.slug }}</a></td>
     <td>{{ e.tags.all | join:", " }}</td>
     <td>{{ e.start }}</td>
     <td>{{ e.end }}</td>
-    <td><a href="{% url 'event_details' e.slug %}">{{ e.slug }}</a></td>
     <td>{{ e.url|urlize_newtab }}</td>
   </tr>
   {% endfor %}


### PR DESCRIPTION
Table style is taken from organisation page. Additional style fixes
were introduced to the original table (columns switched, headers
capitalised.)

The same table is enhanced with a new column defining 
organization<->workshop relation (hosted, sponsored, or affiliated).

This fixes #1943.
This fixes #1942.