### PR TITLE
[#1938] Add comment to membership extension

### DIFF
--- a/amy/fiscal/forms.py
+++ b/amy/fiscal/forms.py
@@ -399,6 +399,16 @@ class MembershipExtensionForm(forms.Form):
         help_text="Number of days the agreement should be extended.",
     )
     new_agreement_end = forms.DateField(disabled=True, required=False)
+    comment = MarkdownxFormField(
+        label="Comment",
+        help_text=(
+            "This will be added to comments after the membership is extended. Beginning"
+            " of the comment will be prefixed with information about length of the "
+            "extension."
+        ),
+        widget=forms.Textarea,
+        required=False,
+    )
 
     helper = BootstrapHelper()
 

--- a/amy/fiscal/tests/test_membership.py
+++ b/amy/fiscal/tests/test_membership.py
@@ -926,8 +926,14 @@ class TestMembershipExtension(TestBase):
             role=MemberRole.objects.first(),
         )
         extension = 30
-        data = {"extension": extension}
+        comment = "Everything is awesome."
+        data = {"extension": extension, "comment": comment}
         today = date.today()
+        expected_comment = f"""Extended membership by {extension} days on {today}.
+
+----
+
+{comment}"""
 
         # Act
         self.client.post(reverse("membership_extend", args=[membership.pk]), data=data)
@@ -935,9 +941,7 @@ class TestMembershipExtension(TestBase):
         # Assert
         self.assertEqual(CommentModel.objects.for_model(membership).count(), 1)
         comment = CommentModel.objects.for_model(membership).first()
-        self.assertEqual(
-            comment.comment, f"Extended membership by {extension} days on {today}."
-        )
+        self.assertEqual(comment.comment, expected_comment)
 
 
 class TestMembershipCreateRollOver(TestBase):

--- a/amy/fiscal/views.py
+++ b/amy/fiscal/views.py
@@ -304,7 +304,7 @@ class MembershipExtend(
     form_class = MembershipExtensionForm
     template_name = "generic_form.html"
     permission_required = "workshops.change_membership"
-    comment = "Extended membership by {days} days on {date}."
+    comment = "Extended membership by {days} days on {date}.\n\n----\n\n{comment}"
 
     def get_initial(self):
         return {
@@ -321,6 +321,7 @@ class MembershipExtend(
 
     def form_valid(self, form):
         days = form.cleaned_data["extension"]
+        comment = form.cleaned_data["comment"]
         extension = timedelta(days=days)
         self.membership.agreement_end += extension
         self.membership.extensions.append(days)
@@ -330,7 +331,7 @@ class MembershipExtend(
         add_comment_for_object(
             self.membership,
             self.request.user,
-            self.comment.format(days=days, date=date.today()),
+            self.comment.format(days=days, date=date.today(), comment=comment),
         )
 
         return super().form_valid(form)


### PR DESCRIPTION
This fixes #1938.
Membership extension form now contains a comment field.
This comment will be posted once the form is submitted. The comment
content's will include information about extension length.
