### PR TITLE
[#1934][#1935] Membership Rollover form: remove default agreement link, move "Copy ...?" fields up

### DIFF
--- a/amy/fiscal/forms.py
+++ b/amy/fiscal/forms.py
@@ -235,6 +235,8 @@ class MembershipRollOverForm(MembershipCreateForm):
         fields = [
             "name",
             "consortium",
+            "copy_members",
+            "copy_membership_tasks",
             "public_status",
             "variant",
             "agreement_start",
@@ -252,8 +254,6 @@ class MembershipRollOverForm(MembershipCreateForm):
             "inhouse_instructor_training_seats_rolled_from_previous",
             "emergency_contact",
             "comment",
-            "copy_members",
-            "copy_membership_tasks",
         ]
 
     def __init__(self, *args, **kwargs):

--- a/amy/fiscal/views.py
+++ b/amy/fiscal/views.py
@@ -377,7 +377,6 @@ class MembershipCreateRollOver(
             ),
             "contribution_type": self.membership.contribution_type,
             "registration_code": self.membership.registration_code,
-            "agreement_link": self.membership.agreement_link,
             "workshops_without_admin_fee_per_agreement": self.membership.workshops_without_admin_fee_per_agreement,  # noqa
             "workshops_without_admin_fee_rolled_from_previous": 0,
             "public_instructor_training_seats": self.membership.public_instructor_training_seats,  # noqa


### PR DESCRIPTION
This fixes #1934.
This fixes #1935.

No tests needed adjusting.