### PR TITLE
[#1929] Log membership members change

### DIFF
--- a/amy/fiscal/tests/test_membership_members.py
+++ b/amy/fiscal/tests/test_membership_members.py
@@ -1,9 +1,12 @@
 from django.db import IntegrityError
 from django.urls import reverse
+import django_comments
 
 from fiscal.forms import MemberForm
 from workshops.models import Member, MemberRole, Membership
 from workshops.tests.base import TestBase
+
+CommentModel = django_comments.get_model()
 
 
 class MembershipTestMixin:
@@ -309,6 +312,51 @@ class TestMembershipMembers(MembershipTestMixin, TestBase):
             response, reverse("membership_details", args=[self.membership.pk])
         )
         self.assertEqual(list(self.membership.organizations.all()), [self.org_alpha])
+
+    def test_mix_adding_removing_members_leaves_comment(self):
+        """Ensure a mixed-content formset for consortium membership members leaves
+        correct message in the comments."""
+        self.setUpMembership(consortium=True)
+        m1 = Member.objects.create(
+            organization=self.org_alpha,
+            membership=self.membership,
+            role=self.member_role,
+        )
+
+        data = {
+            "form-TOTAL_FORMS": 2,
+            "form-INITIAL_FORMS": 1,
+            "form-MIN_NUM_FORMS": 0,
+            "form-MAX_NUM_FORMS": 1000,
+            "form-0-membership": self.membership.pk,
+            "form-0-organization": m1.organization.pk,
+            "form-0-role": m1.role.pk,
+            "form-0-id": m1.pk,
+            "form-0-EDITABLE": True,
+            "form-0-DELETE": "on",
+            "form-1-membership": self.membership.pk,
+            "form-1-organization": self.org_beta.pk,
+            "form-1-role": self.member_role.pk,
+            "form-1-id": "",
+            "form-1-EDITABLE": True,
+        }
+        response = self.client.post(
+            reverse("membership_members", args=[self.membership.pk]),
+            data=data,
+            follow=True,
+        )
+
+        self.assertRedirects(
+            response, reverse("membership_details", args=[self.membership.pk])
+        )
+        comment = CommentModel.objects.first()
+        self.assertEqual(
+            comment.comment,
+            """Changed members on 2021-07-24:
+
+* Added Beta Organization <beta.com>
+* Removed Alpha Organization <alpha.edu>""",
+        )
 
 
 class TestMemberUnique(MembershipTestMixin, TestBase):

--- a/amy/fiscal/tests/test_membership_members.py
+++ b/amy/fiscal/tests/test_membership_members.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django.db import IntegrityError
 from django.urls import reverse
 import django_comments
@@ -352,7 +354,7 @@ class TestMembershipMembers(MembershipTestMixin, TestBase):
         comment = CommentModel.objects.first()
         self.assertEqual(
             comment.comment,
-            """Changed members on 2021-07-24:
+            f"""Changed members on {date.today():%Y-%m-%d}:
 
 * Added Beta Organization <beta.com>
 * Removed Alpha Organization <alpha.edu>""",

--- a/amy/fiscal/tests/test_membership_members.py
+++ b/amy/fiscal/tests/test_membership_members.py
@@ -333,11 +333,11 @@ class TestMembershipMembers(MembershipTestMixin, TestBase):
             "form-0-role": m1.role.pk,
             "form-0-id": m1.pk,
             "form-0-EDITABLE": True,
-            "form-0-DELETE": "on",
+            "form-0-DELETE": "on",  # marks org_alpha member for removal
             "form-1-membership": self.membership.pk,
             "form-1-organization": self.org_beta.pk,
             "form-1-role": self.member_role.pk,
-            "form-1-id": "",
+            "form-1-id": "",  # no ID, so a new member for org_beta will be created
             "form-1-EDITABLE": True,
         }
         response = self.client.post(

--- a/amy/workshops/management/commands/sync_usersocialauth.py
+++ b/amy/workshops/management/commands/sync_usersocialauth.py
@@ -24,8 +24,8 @@ class Command(BaseCommand):
                 person = Person.objects.get(username=username)
                 person.synchronize_usersocialauth()
             except Person.DoesNotExist:
-                print("{} -- no such person".format(username))
-            except GithubException:
-                print("{} -- failed due to errors with GitHub API".format(username))
+                print("Person not found")  # not disclosing username
+            except GithubException as e:
+                print(f"GitHub API exception {e}")  # not disclosing username
             else:
-                print("{} -- success; UserSocialAuth is now in sync".format(username))
+                print("Success")  # not disclosing username

--- a/amy/workshops/receivers.py
+++ b/amy/workshops/receivers.py
@@ -11,10 +11,8 @@ logger = logging.getLogger("amy.server_logs")
 # a receiver for "failed login attempt" signal
 @receiver(user_login_failed)
 def log_user_login_failed(sender, **kwargs):
-    credentials = kwargs.get("credentials") or dict()
     request = kwargs.get("request") or HttpRequest()
 
     ip = request.META.get("REMOTE_ADDR") or "UNKNOWN"
-    username = credentials.get("username") or "UNKNOWN"
-    msg = "Login failure from IP {} for user '{}'".format(ip, username)
+    msg = f"Login failure from IP {ip}"
     logger.error(msg)


### PR DESCRIPTION
This fixes #1929 by adding a comment with listed member changes when
user updates members related to a membership.

Sample result comment:
![obraz](https://user-images.githubusercontent.com/72821/126869286-c1dd1d56-72a6-4926-98c1-b073ed4892c4.png)
