### PR TITLE
[#1936] Membership: edit rolled values

### DIFF
--- a/amy/fiscal/forms.py
+++ b/amy/fiscal/forms.py
@@ -111,10 +111,29 @@ class MembershipForm(forms.ModelForm):
             "inhouse_instructor_training_seats",
             "additional_inhouse_instructor_training_seats",
             "emergency_contact",
+            "workshops_without_admin_fee_rolled_over",
+            "workshops_without_admin_fee_rolled_from_previous",
+            "public_instructor_training_seats_rolled_over",
+            "public_instructor_training_seats_rolled_from_previous",
+            "inhouse_instructor_training_seats_rolled_over",
+            "inhouse_instructor_training_seats_rolled_from_previous",
         ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self, *args, show_rolled_over=False, show_rolled_from_previous=False, **kwargs
+    ):
         super().__init__(*args, **kwargs)
+
+        # When editing membership, allow to edit rolled_over or rolled_from_previous
+        # values when membership was rolled over or rolled from other membership.
+        if not show_rolled_over:
+            del self.fields["workshops_without_admin_fee_rolled_over"]
+            del self.fields["public_instructor_training_seats_rolled_over"]
+            del self.fields["inhouse_instructor_training_seats_rolled_over"]
+        if not show_rolled_from_previous:
+            del self.fields["workshops_without_admin_fee_rolled_from_previous"]
+            del self.fields["public_instructor_training_seats_rolled_from_previous"]
+            del self.fields["inhouse_instructor_training_seats_rolled_from_previous"]
 
         # set up a layout object for the helper
         self.helper.layout = self.helper.build_default_layout(self)
@@ -258,7 +277,9 @@ class MembershipRollOverForm(MembershipCreateForm):
 
     def __init__(self, *args, **kwargs):
         max_values = kwargs.pop("max_values", {})
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            *args, show_rolled_over=True, show_rolled_from_previous=True, **kwargs
+        )
 
         # don't allow values over the limit imposed by the view using this form
         fields = [

--- a/amy/fiscal/views.py
+++ b/amy/fiscal/views.py
@@ -235,6 +235,77 @@ class MembershipUpdate(
     pk_url_kwarg = "membership_id"
     template_name = "generic_form_with_comments.html"
 
+    def get_form_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().get_form_kwargs()
+
+        show_rolled_over = False
+        show_rolled_from_previous = False
+        if self.object.rolled_to_membership:
+            show_rolled_over = True
+
+        try:
+            if self.object.rolled_from_membership:
+                show_rolled_from_previous = True
+        except Membership.DoesNotExist:
+            pass
+
+        kwargs["show_rolled_over"] = show_rolled_over
+        kwargs["show_rolled_from_previous"] = show_rolled_from_previous
+        return kwargs
+
+    def form_valid(self, form):
+        result = super().form_valid(form)
+        data = form.cleaned_data
+
+        # see if updated "rolled" values are available, and update related memberships
+        pairs = (
+            (
+                "workshops_without_admin_fee_rolled_over",
+                "workshops_without_admin_fee_rolled_from_previous",
+            ),
+            (
+                "public_instructor_training_seats_rolled_over",
+                "public_instructor_training_seats_rolled_from_previous",
+            ),
+            (
+                "inhouse_instructor_training_seats_rolled_over",
+                "inhouse_instructor_training_seats_rolled_from_previous",
+            ),
+        )
+        save_rolled_to = False
+        try:
+            for rolled_over, rolled_from in pairs:
+                if rolled_over in data:
+                    setattr(
+                        self.object.rolled_to_membership,
+                        rolled_from,
+                        data[rolled_over],
+                    )
+                    save_rolled_to = True
+
+            if save_rolled_to:
+                self.object.rolled_to_membership.save()
+        except Membership.DoesNotExist:
+            pass
+
+        save_rolled_from = False
+        try:
+            for rolled_over, rolled_from in pairs:
+                if rolled_from in data:
+                    setattr(
+                        self.object.rolled_from_membership,
+                        rolled_over,
+                        data[rolled_from],
+                    )
+                    save_rolled_from = True
+
+            if save_rolled_from:
+                self.object.rolled_from_membership.save()
+        except Membership.DoesNotExist:
+            pass
+
+        return result
+
 
 class MembershipDelete(OnlyForAdminsMixin, PermissionRequiredMixin, AMYDeleteView):
     model = Membership


### PR DESCRIPTION
This fixes #1936 by allowing to edit rolled fields.

Two kind of fields: rolled from previous and rolled over to.
"Rolled from previous" are enabled when membership was created as rolling-over.
"Rolled over" fields are enabled when membership was rolled over to another one.