### PR TITLE
[#1931] Prepopulate workshop and public training seats based on selected membership variant

### DIFF
--- a/amy/fiscal/forms.py
+++ b/amy/fiscal/forms.py
@@ -201,6 +201,28 @@ class MembershipCreateForm(MembershipForm):
             "membership."
         ).format(reverse("organization_add"))
 
+        # set up a layout object for the helper
+        self.helper.layout = self.helper.build_default_layout(self)
+
+        # add warning alert for dates falling within next 2-3 months
+        STANDARD_PACKAGES_PREPOPULATION_WARNING = (
+            "<b>Workshops without admin fee per agreement</b> and "
+            "<b>Public instructor training seats</b> were adjusted according to "
+            "standard membership packages."
+        )
+        pos_index = self.helper.layout.fields.index("variant")
+        self.helper.layout.insert(
+            pos_index + 1,
+            Div(
+                Div(
+                    HTML(STANDARD_PACKAGES_PREPOPULATION_WARNING),
+                    css_class="alert alert-warning offset-lg-2 col-lg-8 col-12",
+                ),
+                id="standard_packages_prepopulation_warning",
+                css_class="form-group row d-none",
+            ),
+        )
+
     def save(self, *args, **kwargs):
         res = super().save(*args, **kwargs)
 

--- a/amy/static/membership_create.js
+++ b/amy/static/membership_create.js
@@ -10,4 +10,30 @@ jQuery(function() {
             id_name.val(fullname);
         }
     });
+
+    $('#id_variant').on('change', (e) => {
+        const parameters = {
+            bronze: {
+                it_seats_public: 0,
+                workshops: 2
+            },
+            silver: {
+                it_seats_public: 6,
+                workshops: 4
+            },
+            gold: {
+                it_seats_public: 15,
+                workshops: 6
+            }
+        };
+
+        const publicInstructorTrainingSeats = $("#id_public_instructor_training_seats");
+        const workshopsWithoutAdminFee = $("#id_workshops_without_admin_fee_per_agreement");
+
+        if (e.target.value in parameters) {
+            // set values from parameters
+            publicInstructorTrainingSeats.val(parameters[e.target.value].it_seats_public);
+            workshopsWithoutAdminFee.val(parameters[e.target.value].workshops);
+        }
+    });
 });

--- a/amy/static/membership_create.js
+++ b/amy/static/membership_create.js
@@ -1,57 +1,63 @@
-jQuery(function() {
-    $('#id_main_organization').on('change.select2', (e) => {
-        // additional data is sent from the backend and it's stored in
-        // select2 `data` parameter
-        const fullname = $(e.target).select2("data")[0].fullname;
-        const id_name = $("#id_name");
+jQuery(function () {
+  $("#id_main_organization").on("change.select2", (e) => {
+    // additional data is sent from the backend and it's stored in
+    // select2 `data` parameter
+    const fullname = $(e.target).select2("data")[0].fullname;
+    const id_name = $("#id_name");
 
-        // only write the new name if "name" field is empty
-        if (!!fullname && !!id_name && !id_name.val()) {
-            id_name.val(fullname);
-        }
-    });
+    // only write the new name if "name" field is empty
+    if (!!fullname && !!id_name && !id_name.val()) {
+      id_name.val(fullname);
+    }
+  });
 
-    // prepopulate some fields based on selected variant
-    const variantChange = (e) => {
-        const parameters = {
-            bronze: {
-                it_seats_public: 0,
-                workshops: 2
-            },
-            silver: {
-                it_seats_public: 6,
-                workshops: 4
-            },
-            gold: {
-                it_seats_public: 15,
-                workshops: 6
-            }
-        };
-
-        const publicInstructorTrainingSeats = $("#id_public_instructor_training_seats");
-        const workshopsWithoutAdminFee = $("#id_workshops_without_admin_fee_per_agreement");
-        const changedFieldValues = $("#standard_packages_prepopulation_warning");
-
-        const variant = e ? $(e.target) : $("#id_variant");
-
-        if (variant.val() in parameters) {
-            // set values from parameters
-            publicInstructorTrainingSeats.val(parameters[variant.val()].it_seats_public);
-            workshopsWithoutAdminFee.val(parameters[variant.val()].workshops);
-
-            // set visual indication
-            publicInstructorTrainingSeats.addClass('border-warning');
-            workshopsWithoutAdminFee.addClass('border-warning');
-            changedFieldValues.removeClass('d-none');
-        } else {
-            // remove visual indication (if any set)
-            publicInstructorTrainingSeats.removeClass('border-warning');
-            workshopsWithoutAdminFee.removeClass('border-warning');
-            changedFieldValues.addClass('d-none');
-        }
+  // prepopulate some fields based on selected variant
+  const variantChange = (e) => {
+    const parameters = {
+      bronze: {
+        it_seats_public: 0,
+        workshops: 2,
+      },
+      silver: {
+        it_seats_public: 6,
+        workshops: 4,
+      },
+      gold: {
+        it_seats_public: 15,
+        workshops: 6,
+      },
     };
-    variantChange();  // on load
-    $('#id_variant').on('change', (e) => {
-        variantChange(e);
-    });
+
+    const publicInstructorTrainingSeats = $(
+      "#id_public_instructor_training_seats"
+    );
+    const workshopsWithoutAdminFee = $(
+      "#id_workshops_without_admin_fee_per_agreement"
+    );
+    const changedFieldValues = $("#standard_packages_prepopulation_warning");
+
+    const variant = e ? $(e.target) : $("#id_variant");
+
+    if (variant.val() in parameters) {
+      // set values from parameters
+      publicInstructorTrainingSeats.val(
+        parameters[variant.val()].it_seats_public
+      );
+      workshopsWithoutAdminFee.val(parameters[variant.val()].workshops);
+
+      // set visual indication
+      publicInstructorTrainingSeats.addClass("border-warning");
+      workshopsWithoutAdminFee.addClass("border-warning");
+      changedFieldValues.removeClass("d-none");
+    } else {
+      // remove visual indication (if any set)
+      publicInstructorTrainingSeats.removeClass("border-warning");
+      workshopsWithoutAdminFee.removeClass("border-warning");
+      changedFieldValues.addClass("d-none");
+    }
+  };
+  variantChange(); // on load
+  $("#id_variant").on("change", (e) => {
+    variantChange(e);
+  });
 });

--- a/amy/static/membership_create.js
+++ b/amy/static/membership_create.js
@@ -11,7 +11,8 @@ jQuery(function() {
         }
     });
 
-    $('#id_variant').on('change', (e) => {
+    // prepopulate some fields based on selected variant
+    const variantChange = (e) => {
         const parameters = {
             bronze: {
                 it_seats_public: 0,
@@ -31,10 +32,12 @@ jQuery(function() {
         const workshopsWithoutAdminFee = $("#id_workshops_without_admin_fee_per_agreement");
         const changedFieldValues = $("#standard_packages_prepopulation_warning");
 
-        if (e.target.value in parameters) {
+        const variant = e ? $(e.target) : $("#id_variant");
+
+        if (variant.val() in parameters) {
             // set values from parameters
-            publicInstructorTrainingSeats.val(parameters[e.target.value].it_seats_public);
-            workshopsWithoutAdminFee.val(parameters[e.target.value].workshops);
+            publicInstructorTrainingSeats.val(parameters[variant.val()].it_seats_public);
+            workshopsWithoutAdminFee.val(parameters[variant.val()].workshops);
 
             // set visual indication
             publicInstructorTrainingSeats.addClass('border-warning');
@@ -46,5 +49,9 @@ jQuery(function() {
             workshopsWithoutAdminFee.removeClass('border-warning');
             changedFieldValues.addClass('d-none');
         }
+    };
+    variantChange();  // on load
+    $('#id_variant').on('change', (e) => {
+        variantChange(e);
     });
 });

--- a/amy/static/membership_create.js
+++ b/amy/static/membership_create.js
@@ -29,11 +29,22 @@ jQuery(function() {
 
         const publicInstructorTrainingSeats = $("#id_public_instructor_training_seats");
         const workshopsWithoutAdminFee = $("#id_workshops_without_admin_fee_per_agreement");
+        const changedFieldValues = $("#standard_packages_prepopulation_warning");
 
         if (e.target.value in parameters) {
             // set values from parameters
             publicInstructorTrainingSeats.val(parameters[e.target.value].it_seats_public);
             workshopsWithoutAdminFee.val(parameters[e.target.value].workshops);
+
+            // set visual indication
+            publicInstructorTrainingSeats.addClass('border-warning');
+            workshopsWithoutAdminFee.addClass('border-warning');
+            changedFieldValues.removeClass('d-none');
+        } else {
+            // remove visual indication (if any set)
+            publicInstructorTrainingSeats.removeClass('border-warning');
+            workshopsWithoutAdminFee.removeClass('border-warning');
+            changedFieldValues.addClass('d-none');
         }
     });
 });


### PR DESCRIPTION
This fixes #1931 by prepopulating *workshops without admin fee* and *public instructor training seats* fields based on variant values proposed in #1931.

Visual indication was added to aid users.

Preview:
![prepopulated_fields](https://user-images.githubusercontent.com/72821/126900326-9e51f91f-cdbd-44bb-9aff-bcded6335b87.gif)
