### PR TITLE
[#2015] Edit membership extensions

### DIFF
--- a/amy/fiscal/fields.py
+++ b/amy/fiscal/fields.py
@@ -1,0 +1,9 @@
+from django.contrib.postgres.forms import SplitArrayField
+
+
+class FlexibleSplitArrayField(SplitArrayField):
+    """Allow to dynamically change size of SplitArrayField and Widget."""
+
+    def change_size(self, new_size: int):
+        self.size = new_size
+        self.widget.size = new_size

--- a/amy/static/css/amy.css
+++ b/amy/static/css/amy.css
@@ -177,3 +177,9 @@ select[readonly].select2-hidden-accessible + .select2-container
 .select2-selection__clear {
     display: none;
 }
+
+/* Special case: multiple inputs in one form row (e.g. extensions in membership form on
+   membership edit page) */
+.form-group.row input + input {
+    margin-top: 0.25em;
+}

--- a/config/settings.py
+++ b/config/settings.py
@@ -99,6 +99,7 @@ DJANGO_APPS = [
     # for TemplatesSetting form template renderer
     # https://docs.djangoproject.com/en/dev/ref/forms/renderers/
     "django.forms",
+    "django.contrib.postgres",
 ]
 THIRD_PARTY_APPS = [
     "crispy_forms",


### PR DESCRIPTION
Fixes #2015.

This PR introduces a way to edit extensions in Membership Edit page.

Screenshot:
![obraz](https://user-images.githubusercontent.com/72821/128564034-eafd6fec-fc4d-4511-b4bb-ba2ad962b4d3.png)
