### PR TITLE
[#1999] Change Training Progress "a" state badge color

### DIFF
--- a/amy/templates/trainings/all_trainees.html
+++ b/amy/templates/trainings/all_trainees.html
@@ -30,7 +30,10 @@
                          <span class='badge badge-success'>Passed</span>
                          <span class='badge badge-warning'>Not evaluated</span>
                          <span class='badge badge-danger'>Failed</span>
-                         <span class='badge badge-dark'><strike>Discarded</strike></span></p>
+                         <span class='badge badge-info'>Asked to repeat</span>
+                         <!-- 'Discarded' is also strokethrough, but for some reason it would not display in popover -->
+                         <span class='badge badge-dark'>Discarded</span>
+                         </p>
                          <p>Click one of labels below to edit or delete it.</p>
                         "></i>
       </th>

--- a/amy/workshops/templatetags/training_progress.py
+++ b/amy/workshops/templatetags/training_progress.py
@@ -18,7 +18,7 @@ def progress_label(progress):
         switch = {
             "n": "warning",
             "f": "danger",
-            "a": "warning",
+            "a": "info",
             "p": "success",
         }
         additional_label = switch[progress.state]


### PR DESCRIPTION
This fixes #1999.

Display "A" (Asked to repeat) in light shade of blue.

For screenshot, please see: https://github.com/carpentries/amy/issues/1999#issuecomment-894694367