### PR TITLE
[#2000] "Seats exceeded" warning

### DIFF
--- a/amy/extrequests/forms.py
+++ b/amy/extrequests/forms.py
@@ -119,7 +119,7 @@ class BulkMatchTrainingRequestForm(forms.Form):
     )
 
     seat_public = forms.TypedChoiceField(
-        coerce=bool,
+        coerce=lambda x: x == "True",
         choices=Task.SEAT_PUBLIC_CHOICES,
         initial=Task._meta.get_field("seat_public").default,
         required=False,

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -548,6 +548,7 @@ def all_trainingrequests(request):
             membership = match_form.cleaned_data["seat_membership"]
             seat_public = match_form.cleaned_data["seat_public"]
             open_seat = match_form.cleaned_data["seat_open_training"]
+            role = Role.objects.get(name="learner")
 
             # Perform bulk match
             for r in match_form.cleaned_data["requests"]:
@@ -559,7 +560,7 @@ def all_trainingrequests(request):
                 Task.objects.get_or_create(
                     event=event,
                     person=r.person,
-                    role=Role.objects.get(name="learner"),
+                    role=role,
                     defaults=dict(
                         seat_membership=membership,
                         seat_public=seat_public,

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -1729,24 +1729,6 @@ class Task(RQJobsMixin, models.Model):
                 "Seat (open / membership) can be assigned only to a workshop learner."
             )
 
-        if (
-            self.seat_membership
-            and self.seat_public
-            and not self.seat_membership.public_instructor_training_seats_remaining
-        ):
-            errors["seat_public"] = ValidationError(
-                "This membership doesn't have any remaining public seats."
-            )
-
-        if (
-            self.seat_membership
-            and not self.seat_public
-            and not self.seat_membership.inhouse_instructor_training_seats_remaining
-        ):
-            errors["seat_public"] = ValidationError(
-                "This membership doesn't have any remaining in-house seats."
-            )
-
         if errors:
             raise ValidationError(errors)
 


### PR DESCRIPTION
This fixes #2000.

There were two issues reported:
1. inability to create tasks when membership was out of seats -> solution was to change errors into warnings and move the logic into 2 views (task add, task update); tests were updated correspondingly
2. training request match form: inability to create in-house seats -> solution was to fix the error.