### PR TITLE
[#2005] Membership Extend: use new end date instead of number of days

### DIFF
--- a/amy/fiscal/tests/test_membership.py
+++ b/amy/fiscal/tests/test_membership.py
@@ -923,9 +923,9 @@ class TestMembershipExtension(TestBase):
             # fields ignored
             "agreement_start": "invalid value",
             "agreement_end": "invalid value",
-            "new_agreement_end": "invalid value",
+            "extension": "invalid value",
             # field accepted
-            "extension": "1",
+            "new_agreement_end": "2021-08-10",
         }
 
         form = MembershipExtensionForm(data)
@@ -936,14 +936,16 @@ class TestMembershipExtension(TestBase):
         data = [
             ("string", False),
             ("", False),
-            ("-1", False),
-            ("0", False),
-            ("1", True),
-            ("2", True),
+            ("2020-01-01", False),
+            ("2021-01-01", False),
+            ("2022-01-01", True),
         ]
-        for extension, valid in data:
-            with self.subTest(extension=extension, valid=valid):
-                form = MembershipExtensionForm(dict(extension=extension))
+        for end_date, valid in data:
+            with self.subTest(date=end_date, valid=valid):
+                form = MembershipExtensionForm(
+                    dict(new_agreement_end=end_date),
+                    initial=dict(agreement_end="2021-01-01"),
+                )
                 self.assertEqual(form.is_valid(), valid)
 
     def test_membership_extended(self):
@@ -963,7 +965,7 @@ class TestMembershipExtension(TestBase):
             membership=membership,
             role=MemberRole.objects.first(),
         )
-        data = {"extension": 30}
+        data = {"new_agreement_end": date(2021, 3, 31)}
 
         response = self.client.post(
             reverse("membership_extend", args=[membership.pk]),
@@ -995,9 +997,9 @@ class TestMembershipExtension(TestBase):
             membership=membership,
             role=MemberRole.objects.first(),
         )
-        data1 = {"extension": 30}
-        data2 = {"extension": 40}
-        data3 = {"extension": 50}
+        data1 = {"new_agreement_end": date(2021, 3, 31)}
+        data2 = {"new_agreement_end": date(2021, 5, 10)}
+        data3 = {"new_agreement_end": date(2021, 6, 29)}
 
         self.client.post(reverse("membership_extend", args=[membership.pk]), data=data1)
         self.client.post(reverse("membership_extend", args=[membership.pk]), data=data2)
@@ -1025,11 +1027,10 @@ class TestMembershipExtension(TestBase):
             membership=membership,
             role=MemberRole.objects.first(),
         )
-        extension = 30
         comment = "Everything is awesome."
-        data = {"extension": extension, "comment": comment}
+        data = {"new_agreement_end": date(2021, 3, 31), "comment": comment}
         today = date.today()
-        expected_comment = f"""Extended membership by {extension} days on {today}.
+        expected_comment = f"""Extended membership by 30 days on {today} (new end date: 2021-03-31).
 
 ----
 

--- a/amy/static/membership_extend.js
+++ b/amy/static/membership_extend.js
@@ -6,11 +6,10 @@ window.addEventListener("load", (e) => {
 
     const one_day = 1000 * 60 * 60 * 24;
 
-    if (!!extension_input) {
-        let new_agreement_end_date = new Date();
-        extension_input.addEventListener("change", ({target}) => {
-            new_agreement_end_date.setTime(agreement_end_date.getTime() + target.value * one_day);
-            new_agreement_end_input.value = new_agreement_end_date.yyyymmdd();
+    if (!!new_agreement_end_input) {
+        $(new_agreement_end_input).on("changeDate", (event) => {
+            const new_agreement_end_date = new Date(event.target.value);
+            extension_input.value = (new_agreement_end_date - agreement_end_date) / one_day;
         });
     }
 });


### PR DESCRIPTION
This fixes #2005.

![membership_extend](https://user-images.githubusercontent.com/72821/128930771-fc6f9c37-bf13-40c8-8ee2-474eb53608f4.gif)
