### PR TITLE
[#1657] Null event latitude and longitude

### DIFF
--- a/amy/static/online_country.js
+++ b/amy/static/online_country.js
@@ -1,52 +1,35 @@
-var prev_venue,
-    prev_address,
-    prev_latitude,
-    prev_longitude,
-    online_selected_before = false;
-
-var id_country = '#id_country, #id_event-country',
-    id_venue = '#id_venue, #id_event-venue',
-    id_address = '#id_address, #id_event-address',
-    id_latitude = '#id_latitude, #id_event-latitude',
-    id_longitude = '#id_longitude, #id_event-longitude';
-
-if ($(id_country).val() == 'W3') {
-    online_selected_before = true;
-    $(id_venue).prop('disabled', true);
-    $(id_address).prop('disabled', true);
-    $(id_latitude).prop('disabled', true);
-    $(id_longitude).prop('disabled', true);
-}
-
 // disable latitude, longitude inputs if online country selected
-$(function() {
-  $(id_country).change(function(e) {
+$(function () {
+  const id_country = "#id_country, #id_event-country";
+  const id_venue = "#id_venue, #id_event-venue";
+  const id_address = "#id_address, #id_event-address";
+  const id_latitude = "#id_latitude, #id_event-latitude";
+  const id_longitude = "#id_longitude, #id_event-longitude";
+
+  if ($(id_country).val() == "W3") {
+    $(id_venue).prop("disabled", true);
+    $(id_address).prop("disabled", true);
+    $(id_latitude).prop("disabled", true);
+    $(id_longitude).prop("disabled", true);
+  }
+
+  $(id_country).change(function (e) {
     var new_country = $(e.target).val();
 
-    if (new_country == 'W3') {
-      prev_venue = $(id_venue).val();
-      prev_address = $(id_address).val();
-      prev_latitude = $(id_latitude).val();
-      prev_longitude = $(id_longitude).val();
-      $(id_venue).val('Internet');
-      $(id_address).val('Internet');
-      $(id_latitude).val('-48.876667');
-      $(id_longitude).val('-123.393333');
-      $(id_venue).prop('disabled', true);
-      $(id_address).prop('disabled', true);
-      $(id_latitude).prop('disabled', true);
-      $(id_longitude).prop('disabled', true);
-      online_selected_before = true;
-    } else if (online_selected_before) {
-      $(id_venue).val(prev_venue);
-      $(id_address).val(prev_address);
-      $(id_latitude).val(prev_latitude);
-      $(id_longitude).val(prev_longitude);
-      $(id_venue).prop('disabled', false);
-      $(id_address).prop('disabled', false);
-      $(id_latitude).prop('disabled', false);
-      $(id_longitude).prop('disabled', false);
-      online_selected_before = false;
+    if (new_country == "W3") {
+      $(id_venue).val("Internet");
+      $(id_address).val("Internet");
+      $(id_latitude).val("");
+      $(id_longitude).val("");
+      $(id_venue).prop("disabled", true);
+      $(id_address).prop("disabled", true);
+      $(id_latitude).prop("disabled", true);
+      $(id_longitude).prop("disabled", true);
+    } else {
+      $(id_venue).prop("disabled", false);
+      $(id_address).prop("disabled", false);
+      $(id_latitude).prop("disabled", false);
+      $(id_longitude).prop("disabled", false);
     }
   });
 });

--- a/amy/static/online_country.js
+++ b/amy/static/online_country.js
@@ -5,8 +5,9 @@ $(function () {
   const id_address = "#id_address, #id_event-address";
   const id_latitude = "#id_latitude, #id_event-latitude";
   const id_longitude = "#id_longitude, #id_event-longitude";
+  const online_country = "W3";
 
-  if ($(id_country).val() == "W3") {
+  if ($(id_country).val() == online_country) {
     $(id_venue).prop("disabled", true);
     $(id_address).prop("disabled", true);
     $(id_latitude).prop("disabled", true);
@@ -16,7 +17,7 @@ $(function () {
   $(id_country).change(function (e) {
     var new_country = $(e.target).val();
 
-    if (new_country == "W3") {
+    if (new_country == online_country) {
       $(id_venue).val("Internet");
       $(id_address).val("Internet");
       $(id_latitude).val("");

--- a/amy/templates/dashboard/admin_dashboard.html
+++ b/amy/templates/dashboard/admin_dashboard.html
@@ -69,7 +69,7 @@
         <td class="text-success">&#10003;</td>
         {% endif %}
         <!-- LOCATION -->
-        {% if not event.address or not event.venue or not event.country or not event.latitude or not event.longitude %}
+        {% if not event.address or not event.venue or not event.country or event.latitude is None or event.longitude is None %}
         <td class="text-danger">&times;</td>
         {% else %}
         <td class="text-success">&#10003;</td>

--- a/amy/templates/includes/event_details_table.html
+++ b/amy/templates/includes/event_details_table.html
@@ -57,11 +57,11 @@
   </tr>
   <tr class="{% if not event.venue %}table-danger{% endif %}"><th>Venue:</th><td>{{ event.venue|default:"&mdash;" }}</td></tr>
   <tr class="{% if not event.address %}table-danger{% endif %}"><th>Address:</th><td>{{ event.address|default:"&mdash;" }}</td></tr>
-  <tr class="{% if not event.latitude or not event.longitude %}table-danger{% endif %}">
+  <tr class="{% if event.latitude is None or event.longitude is None %}table-danger{% endif %}">
     <th>Lat/long:</th>
     <td>
-      {{ event.latitude|default:"&mdash;" }} / {{ event.longitude|default:"&mdash;" }}
-      {% if event.latitude and event.longitude %}
+      {{ event.latitude|default_if_none:"&mdash;" }} / {{ event.longitude|default_if_none:"&mdash;" }}
+      {% if event.latitude is not None and event.longitude is not None %}
         <a href="https://www.google.com/maps/place/{{ event.latitude }},{{ event.longitude }}" target="_blank" rel="noreferrer">(map)</a>
         <a href="{% url 'workshop_staff' %}?latitude={{ event.latitude|unlocalize }}&amp;longitude={{ event.longitude|unlocalize }}&amp;submit=Submit" class="btn btn-primary btn-sm float-right" id="find_closest_instructors">Find closest instructors</a>
       {% else %}

--- a/amy/templates/includes/event_details_table.html
+++ b/amy/templates/includes/event_details_table.html
@@ -63,9 +63,9 @@
       {{ event.latitude|default_if_none:"&mdash;" }} / {{ event.longitude|default_if_none:"&mdash;" }}
       {% if event.latitude is not None and event.longitude is not None %}
         <a href="https://www.google.com/maps/place/{{ event.latitude }},{{ event.longitude }}" target="_blank" rel="noreferrer">(map)</a>
-        <a href="{% url 'workshop_staff' %}?latitude={{ event.latitude|unlocalize }}&amp;longitude={{ event.longitude|unlocalize }}&amp;submit=Submit" class="btn btn-primary btn-sm float-right" id="find_closest_instructors">Find closest instructors</a>
+        <a href="{% url 'workshop_staff' %}?latitude={{ event.latitude|unlocalize }}&amp;longitude={{ event.longitude|unlocalize }}&amp;submit=Submit" class="btn btn-primary btn-sm float-right" id="find_nearest_instructors">Find nearest instructors</a>
       {% else %}
-        <a class="btn btn-danger btn-sm float-right" id="error_closest_instructors" tabindex="0" role="button" data-toggle="popover" title="Search error" data-content="Cannot search for closest instructors without latitude and longitude of event's location.">Error</a>
+        <a class="btn btn-danger btn-sm float-right" id="error_nearest_instructors" tabindex="0" role="button" data-toggle="popover" title="Search error" data-content="Cannot search for nearest instructors without latitude and longitude of event's location.">Error</a>
       {% endif %}
     </td>
   </tr>

--- a/amy/templates/workshops/event.html
+++ b/amy/templates/workshops/event.html
@@ -178,6 +178,7 @@
 {% endblock %}
 
 {% block extrajs %}
+{{ event_location|json_script:"event-location" }}
 <script src="https://maps.googleapis.com/maps/api/js?api=AIzaSyC2WQkpSyrmJhXRcBdqsonpcQjyy8BtPrA&v=3.exp"></script>
 <script type="text/javascript">
   var gmap = null;
@@ -189,23 +190,24 @@
     });
 
     // draw a pin on the map in website preview
-    var mapOptions = {
+    const mapOptions = {
       zoom: 1,
       // by trial and error, these values lets us see the most w/o scrolling
       center: {lat: 0, lng: 0},
       mapTypeId: google.maps.MapTypeId.ROADMAP
     };
-    gmap = new google.maps.Map(document.getElementById("map_canvas"),
-                               mapOptions);
-    {% if event.latitude and event.longitude %}
-    var marker = new google.maps.Marker({
-      position: new google.maps.LatLng({{ event.latitude }},
-                                       {{ event.longitude }}),
-      map: gmap,
-      title: "{{ event.venue|escapejs }}: {{ event.humandate|escapejs }}",
-      visible: true   // marker shown directly, not clustered
-    });
-    {% endif %}
+    gmap = new google.maps.Map(document.getElementById("map_canvas"), mapOptions);
+
+    const eventLocation = JSON.parse(document.getElementById('event-location').textContent);
+
+    if (eventLocation.latitude !== null && eventLocation.longitude !== null) {
+      const marker = new google.maps.Marker({
+        position: new google.maps.LatLng(eventLocation.latitude, eventLocation.longitude),
+        map: gmap,
+        title: `${eventLocation.venue}: ${eventLocation.humandate}`,
+        visible: true  // marker shown directly, not clustered
+      });
+    }
 
     // https://github.com/select2/select2/issues/1645#issuecomment-24296615
     $.fn.modal.Constructor.prototype.enforceFocus = function() {};

--- a/amy/templates/workshops/event_review_metadata_changes.html
+++ b/amy/templates/workshops/event_review_metadata_changes.html
@@ -52,13 +52,13 @@
     </tr>
     <tr>
       <th>Latitude</th>
-      <td>{{ event.latitude }}</td>
-      <td>{{ metadata.latitude }}</td>
+      <td>{{ event.latitude|default_if_none:"&mdash;" }}</td>
+      <td>{{ metadata.latitude|default_if_none:"&mdash;" }}</td>
     </tr>
     <tr>
       <th>Longitude</th>
-      <td>{{ event.longitude }}</td>
-      <td>{{ metadata.longitude }}</td>
+      <td>{{ event.longitude|default_if_none:"&mdash;" }}</td>
+      <td>{{ metadata.longitude|default_if_none:"&mdash;" }}</td>
     </tr>
     <tr>
       <th>Eventbrite key</th>

--- a/amy/templates/workshops/events_merge.html
+++ b/amy/templates/workshops/events_merge.html
@@ -109,12 +109,12 @@
   </tr>
   <tr>
     <th scope="row">Latitude</th>
-    <td>{{ obj_a.latitude|default:"—" }}</td><td>{{ obj_b.latitude|default:"—" }}</td>
+    <td>{{ obj_a.latitude|default_if_none:"&mdash;" }}</td><td>{{ obj_b.latitude|default_if_none:"&mdash;" }}</td>
     <th>{% include "includes/merge_radio.html" with field=form.latitude %}</th>
   </tr>
   <tr>
     <th scope="row">Longitude</th>
-    <td>{{ obj_a.longitude|default:"—" }}</td><td>{{ obj_b.longitude|default:"—" }}</td>
+    <td>{{ obj_a.longitude|default_if_none:"&mdash;" }}</td><td>{{ obj_b.longitude|default_if_none:"&mdash;" }}</td>
     <th>{% include "includes/merge_radio.html" with field=form.longitude %}</th>
   </tr>
   <tr>

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -1592,8 +1592,8 @@ class Event(AssignmentMixin, RQJobsMixin, models.Model):
             # enforce location data for 'Online' country
             self.venue = "Internet"
             self.address = "Internet"
-            self.latitude = -48.876667
-            self.longitude = -123.393333
+            self.latitude = None
+            self.longitude = None
 
         super().save(*args, **kwargs)
 

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -67,8 +67,8 @@ class TestEvent(TestBase):
         )
         self.assertEqual(e.venue, "Internet")
         self.assertEqual(e.address, "Internet")
-        self.assertAlmostEqual(e.latitude, -48.876667)
-        self.assertAlmostEqual(e.longitude, -123.393333)
+        self.assertEqual(e.latitude, None)
+        self.assertEqual(e.longitude, None)
 
         e = Event.objects.create(
             slug="offline-event", country="US", host=Organization.objects.first()

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -1016,6 +1016,12 @@ def event_details(request, slug):
         .values_list("person__email", flat=True),
         "today": datetime.date.today(),
         "admin_lookup_form": admin_lookup_form,
+        "event_location": {
+            "venue": event.venue,
+            "humandate": event.human_readable_date,
+            "latitude": event.latitude,
+            "longitude": event.longitude,
+        },
     }
     return render(request, "workshops/event.html", context)
 


### PR DESCRIPTION
This fixes #1657 by changing logic for handling event latitude and longitude.

Apart from small fixes to how these values are displayed, there's some fixes to various Javascript scripts used with them.