### PR TITLE
[#1710] Require instructor availability conditionally

### DIFF
--- a/amy/extrequests/forms.py
+++ b/amy/extrequests/forms.py
@@ -262,7 +262,7 @@ class WorkshopRequestBaseForm(forms.ModelForm):
         label=WorkshopRequest._meta.get_field("host_responsibilities").verbose_name,
     )
     instructor_availability = forms.BooleanField(
-        required=True,
+        required=False,
         label=WorkshopRequest._meta.get_field("instructor_availability").verbose_name,
     )
 
@@ -285,6 +285,9 @@ class WorkshopRequestBaseForm(forms.ModelForm):
     )
 
     helper = BootstrapHelper(add_cancel_button=False)
+
+    class Media:
+        js = ("instructor_availability_checkbox.js",)
 
     class Meta:
         model = WorkshopRequest
@@ -548,6 +551,20 @@ class WorkshopRequestBaseForm(forms.ModelForm):
                 'If you entered data in "Other" field, please select that ' "option."
             )
 
+        # 7: if workshop is less than 2mo away, or if the dates are unknown, require the
+        # confirmation in `instructor_availability`:
+        instructor_availability: bool = self.cleaned_data.get("instructor_availability")
+        two_months_away = datetime.date.today() + datetime.timedelta(days=60)
+        if (
+            preferred_dates and preferred_dates <= two_months_away
+        ) or not preferred_dates:
+            if not instructor_availability:
+                errors["instructor_availability"] = ValidationError(
+                    "Please confirm instructor availability, since the workshop is "
+                    'planned for less than 2 months away or "Other" arrangements '
+                    "were selected."
+                )
+
         # raise errors if any present
         if errors:
             raise ValidationError(errors)
@@ -628,7 +645,7 @@ class WorkshopInquiryRequestBaseForm(forms.ModelForm):
         ).verbose_name,
     )
     instructor_availability = forms.BooleanField(
-        required=True,
+        required=False,
         label=WorkshopInquiryRequest._meta.get_field(
             "instructor_availability"
         ).verbose_name,
@@ -670,6 +687,9 @@ class WorkshopInquiryRequestBaseForm(forms.ModelForm):
     )
 
     helper = BootstrapHelper(add_cancel_button=False)
+
+    class Media:
+        js = ("instructor_availability_checkbox.js",)
 
     class Meta:
         model = WorkshopInquiryRequest
@@ -1012,6 +1032,20 @@ class WorkshopInquiryRequestBaseForm(forms.ModelForm):
             errors["public_event"] = ValidationError(
                 'If you entered data in "Other" field, please select that ' "option."
             )
+
+        # 7: if workshop is less than 2mo away, or if the dates are unknown, require the
+        # confirmation in `instructor_availability`:
+        instructor_availability: bool = self.cleaned_data.get("instructor_availability")
+        two_months_away = datetime.date.today() + datetime.timedelta(days=60)
+        if (
+            preferred_dates and preferred_dates <= two_months_away
+        ) or not preferred_dates:
+            if not instructor_availability:
+                errors["instructor_availability"] = ValidationError(
+                    "Please confirm instructor availability, since the workshop is "
+                    'planned for less than 2 months away or "Other" arrangements '
+                    "were selected."
+                )
 
         # raise errors if any present
         if errors:

--- a/amy/extrequests/forms.py
+++ b/amy/extrequests/forms.py
@@ -1038,14 +1038,13 @@ class WorkshopInquiryRequestBaseForm(forms.ModelForm):
         instructor_availability: bool = self.cleaned_data.get("instructor_availability")
         two_months_away = datetime.date.today() + datetime.timedelta(days=60)
         if (
-            preferred_dates and preferred_dates <= two_months_away
-        ) or not preferred_dates:
-            if not instructor_availability:
-                errors["instructor_availability"] = ValidationError(
-                    "Please confirm instructor availability, since the workshop is "
-                    'planned for less than 2 months away or "Other" arrangements '
-                    "were selected."
-                )
+            not preferred_dates or preferred_dates <= two_months_away
+        ) and not instructor_availability:
+            errors["instructor_availability"] = ValidationError(
+                "Please confirm instructor availability, since the workshop is "
+                'planned for less than 2 months away or "Other" arrangements '
+                "were selected."
+            )
 
         # raise errors if any present
         if errors:

--- a/amy/extrequests/tests/test_workshop_inquiries.py
+++ b/amy/extrequests/tests/test_workshop_inquiries.py
@@ -347,6 +347,57 @@ class TestWorkshopInquiryBaseForm(FormTestHelper, TestBase):
             blank=True,
         )
 
+    def test_instructor_availability_required(self):
+        """Test requiredness of `instructor_availability` depending on selected
+        preferred dates."""
+        # Arrange
+        data1 = {
+            "preferred_dates": date.today() + timedelta(days=30),
+            "other_preferred_dates": "",
+            "instructor_availability": "",
+        }
+        data2 = {
+            "preferred_dates": "",
+            "other_preferred_dates": "sometime in future",
+            "instructor_availability": "",
+        }
+        # Act
+        form1 = WorkshopInquiryRequestBaseForm(data1)
+        form2 = WorkshopInquiryRequestBaseForm(data2)
+        # Assert
+        for form in (form1, form2):
+            self.assertNotIn("preferred_dates", form.errors)
+            self.assertNotIn("other_preferred_dates", form.errors)
+            self.assertIn("instructor_availability", form.errors)
+
+    def test_instructor_availability_not_required(self):
+        """Test `instructor_availability` not required in some circumstances."""
+        # Arrange
+        data1 = {
+            "preferred_dates": date.today() + timedelta(days=30),
+            "other_preferred_dates": "",
+            "instructor_availability": "1",
+        }
+        data2 = {
+            "preferred_dates": "",
+            "other_preferred_dates": "sometime in future",
+            "instructor_availability": "1",
+        }
+        data3 = {
+            "preferred_dates": date.today() + timedelta(days=61),
+            "other_preferred_dates": "",
+            "instructor_availability": "",
+        }
+        # Act
+        form1 = WorkshopInquiryRequestBaseForm(data1)
+        form2 = WorkshopInquiryRequestBaseForm(data2)
+        form3 = WorkshopInquiryRequestBaseForm(data3)
+        # Assert
+        for form in (form1, form2, form3):
+            self.assertNotIn("preferred_dates", form.errors)
+            self.assertNotIn("other_preferred_dates", form.errors)
+            self.assertNotIn("instructor_availability", form.errors)
+
 
 class TestWorkshopInquiryViews(TestBase):
     def setUp(self):

--- a/amy/extrequests/tests/test_workshop_requests.py
+++ b/amy/extrequests/tests/test_workshop_requests.py
@@ -293,6 +293,57 @@ class TestWorkshopRequestBaseForm(FormTestHelper, TestBase):
             first_when_other="other",
         )
 
+    def test_instructor_availability_required(self):
+        """Test requiredness of `instructor_availability` depending on selected
+        preferred dates."""
+        # Arrange
+        data1 = {
+            "preferred_dates": date.today() + timedelta(days=30),
+            "other_preferred_dates": "",
+            "instructor_availability": "",
+        }
+        data2 = {
+            "preferred_dates": "",
+            "other_preferred_dates": "sometime in future",
+            "instructor_availability": "",
+        }
+        # Act
+        form1 = WorkshopRequestBaseForm(data1)
+        form2 = WorkshopRequestBaseForm(data2)
+        # Assert
+        for form in (form1, form2):
+            self.assertNotIn("preferred_dates", form.errors)
+            self.assertNotIn("other_preferred_dates", form.errors)
+            self.assertIn("instructor_availability", form.errors)
+
+    def test_instructor_availability_not_required(self):
+        """Test `instructor_availability` not required in some circumstances."""
+        # Arrange
+        data1 = {
+            "preferred_dates": date.today() + timedelta(days=30),
+            "other_preferred_dates": "",
+            "instructor_availability": "1",
+        }
+        data2 = {
+            "preferred_dates": "",
+            "other_preferred_dates": "sometime in future",
+            "instructor_availability": "1",
+        }
+        data3 = {
+            "preferred_dates": date.today() + timedelta(days=61),
+            "other_preferred_dates": "",
+            "instructor_availability": "",
+        }
+        # Act
+        form1 = WorkshopRequestBaseForm(data1)
+        form2 = WorkshopRequestBaseForm(data2)
+        form3 = WorkshopRequestBaseForm(data3)
+        # Assert
+        for form in (form1, form2, form3):
+            self.assertNotIn("preferred_dates", form.errors)
+            self.assertNotIn("other_preferred_dates", form.errors)
+            self.assertNotIn("instructor_availability", form.errors)
+
 
 class TestWorkshopRequestViews(TestBase):
     def setUp(self):

--- a/amy/static/instructor_availability_checkbox.js
+++ b/amy/static/instructor_availability_checkbox.js
@@ -1,0 +1,40 @@
+// show 'id_instructor_availability' if preferred dates < 2mo away OR "other" specified
+jQuery(() => {
+    const cutoffTime = 1000 * 60 * 60 * 24 * 30 * 2; // default cutoff time: 60 days
+    const instructorAvail = $('#div_id_instructor_availability');
+    const instructorAvailInput = $('#id_instructor_availability');
+    const preferredDatesInput = $('#id_preferred_dates');
+    const otherDatesInput = $('#id_other_preferred_dates');
+    const klass = 'd-none';
+
+    const logic = () => {
+        if (preferredDatesInput.val()) {
+            const selectedDate = preferredDatesInput.datepicker('getDate');
+            const today = new Date();
+            if (selectedDate.getTime() - today.getTime() < cutoffTime) {
+                instructorAvail.removeClass(klass);
+                instructorAvailInput.prop('required', true);
+            } else {
+                instructorAvail.addClass(klass);
+                instructorAvailInput.prop('required', false);
+            }
+        } else if (otherDatesInput.val()) {
+            instructorAvail.removeClass(klass);
+            instructorAvailInput.prop('required', true);
+        } else {
+            instructorAvail.addClass(klass);
+            instructorAvailInput.prop('required', false);
+        }
+    };
+    logic();
+
+    preferredDatesInput.on("changeDate input", () => {
+        // update datepicker with current input value
+        $(this).datepicker('update');
+        logic();
+    });
+
+    otherDatesInput.on("change", () => {
+        logic();
+    });
+});


### PR DESCRIPTION
This fixes #1710. The `instructor_availability` checkbox will appear
conditionally based on the value in `preferred_dates` or any input
in `preferred_dates_other`.
