### PR TITLE
[#1875] Fix Sites framework issue when running tests

### DIFF
--- a/amy/dashboard/tests/test_search.py
+++ b/amy/dashboard/tests/test_search.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime, timedelta, timezone
 
-from django.contrib.sites.models import Site
 from django.urls import reverse
 from django_comments.models import Comment
 
@@ -147,7 +146,7 @@ class TestSearch(TestBase):
             user=self.hermione,
             comment="Testing commenting system for Alpha Organization",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
 
         response = self.search_for("Alpha")
@@ -215,7 +214,7 @@ class TestSearch(TestBase):
             user=self.hermione,
             comment="Testing commenting system for Alpha Organization",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
 
         response = self.search_for("Alpha", no_redirect=False, follow=False)
@@ -234,7 +233,7 @@ class TestSearch(TestBase):
             user=self.hermione,
             comment="Testing commenting system for Alpha Organization",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
 
         Comment.objects.create(
@@ -242,7 +241,7 @@ class TestSearch(TestBase):
             user=self.hermione,
             comment="Cross-posting an Alpha comment on Beta Organization page.",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
 
         response = self.search_for("Alpha", no_redirect=False, follow=False)

--- a/amy/extrequests/tests/test_training_request.py
+++ b/amy/extrequests/tests/test_training_request.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode
 from django.contrib.messages import WARNING
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.template import Context, Template
 from django.test import RequestFactory
@@ -791,6 +790,7 @@ class TestTrainingRequestMerging(TestBase):
         self._setUpRoles()
         self._setUpTags()
         self._setUpUsersAndLogin()
+        self._setUpSites()
 
         self.first_req = create_training_request(state="d", person=self.spiderman)
         self.first_req.secondary_email = "notused@example.org"
@@ -804,7 +804,7 @@ class TestTrainingRequestMerging(TestBase):
             user=self.spiderman,
             comment="Comment from admin on first_req",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
         # comments regarding second request
         self.cb = Comment.objects.create(
@@ -812,7 +812,7 @@ class TestTrainingRequestMerging(TestBase):
             user=self.ironman,
             comment="Comment from admin on second_req",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
 
         # assign roles (previous involvement with The Carpentries) and

--- a/amy/workshops/tests/base.py
+++ b/amy/workshops/tests/base.py
@@ -72,7 +72,6 @@ class TestBase(
     def setUp(self):
         """Create standard objects."""
 
-        # self.clear_sites_cache()
         self._setUpOrganizations()
         self._setUpAirports()
         self._setUpLessons()
@@ -80,20 +79,23 @@ class TestBase(
         self._setUpInstructors()
         self._setUpNonInstructors()
         self._setUpPermissions()
+        self._setUpSites()
 
-        self._setupSites()
+    def _setUpSites(self):
+        """Sometimes (depending on the test execution order) tests, using
+        `Site.objects.get_current()`, would throw error:
 
-    def clear_sites_cache(self):
-        # we need to clear Sites' cache, because after post_migration signal,
-        # there's some junk in the cache that prevents from adding comments
-        # (the site in CACHE is not a real Site)
-        Site.objects.clear_cache()
+          ValueError: Cannot assign "<Site: Site object (2)>": "Comment.site" must be
+          a "Site" instance.
 
-    def _setupSites(self):
+        Possibly some junk site was residing in the cache. Since the test execution
+        order may not be a deterministic one (especially when running tests in parallel)
+        we need to clear the cache whenever Sites framework is used.
+        """
         from django.conf import settings
 
         Site.objects.clear_cache()
-        Site.objects.get_or_create(
+        self.current_site, _ = Site.objects.get_or_create(
             pk=settings.SITE_ID,
             defaults=dict(domain="amy.carpentries.org", name="AMY server"),
         )

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime, timedelta, timezone
 from urllib.parse import urlencode
 
-from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.db import connection
 from django.db.utils import IntegrityError
@@ -804,6 +803,7 @@ class TestEventMerging(TestBase):
         self._setUpUsersAndLogin()
         self._setUpTags()
         self._setUpLanguages()
+        self._setUpSites()
 
         today = date.today()
         tomorrow = today + timedelta(days=1)
@@ -847,7 +847,7 @@ class TestEventMerging(TestBase):
             user=self.harry,
             comment="Comment from admin on event_a",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
 
         self.event_b = Event.objects.create(
@@ -884,7 +884,7 @@ class TestEventMerging(TestBase):
             user=self.hermione,
             comment="Comment from admin on event_b",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
 
         # some "random" strategy for testing

--- a/amy/workshops/tests/test_person.py
+++ b/amy/workshops/tests/test_person.py
@@ -1,12 +1,9 @@
-# coding: utf-8
-
 from datetime import date, datetime, timezone
 from unittest.mock import patch
 from urllib.parse import urlencode
 
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import Group, Permission
-from django.contrib.sites.models import Site
 from django.core.validators import ValidationError
 from django.urls import reverse
 from django_comments.models import Comment
@@ -40,7 +37,7 @@ from workshops.tests.base import TestBase
 
 @patch("workshops.github_auth.github_username_to_uid", lambda username: None)
 class TestPerson(TestBase):
-    """ Test cases for persons. """
+    """Test cases for persons."""
 
     def setUp(self):
         super().setUp()
@@ -193,7 +190,7 @@ class TestPerson(TestBase):
         self.assertEqual(self.spiderman.task_set.first().role, role)
 
     def test_edit_person_permissions(self):
-        """ Make sure we can set up user permissions correctly. """
+        """Make sure we can set up user permissions correctly."""
 
         # make sure Hermione does not have any perms, nor groups
         assert not self.hermione.is_superuser
@@ -686,7 +683,7 @@ class TestPersonMerging(TestBase):
         self._setUpLessons()
         self._setUpRoles()
         self._setUpEvents()
-        self._setupSites()
+        self._setUpSites()
         self._setUpUsersAndLogin()
 
         # create training requirement
@@ -730,7 +727,7 @@ class TestPersonMerging(TestBase):
             user=self.person_a,
             comment="Comment from person_a on admin",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
         # comments regarding this person
         self.ca_2 = Comment.objects.create(
@@ -738,7 +735,7 @@ class TestPersonMerging(TestBase):
             user=self.admin,
             comment="Comment from admin on person_a",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
         term_options_by_term_slug = {
             term.slug: iter(term.options)
@@ -796,7 +793,7 @@ class TestPersonMerging(TestBase):
             user=self.person_b,
             comment="Comment from person_b on admin",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
         # comments regarding this person
         self.cb_2 = Comment.objects.create(
@@ -804,7 +801,7 @@ class TestPersonMerging(TestBase):
             user=self.admin,
             comment="Comment from admin on person_b",
             submit_date=datetime.now(tz=timezone.utc),
-            site=Site.objects.get_current(),
+            site=self.current_site,
         )
 
         # consents for person_b
@@ -1131,7 +1128,7 @@ def github_username_to_uid_mock(username):
 
 @patch("workshops.github_auth.github_username_to_uid", github_username_to_uid_mock)
 class TestPersonAndUserSocialAuth(TestBase):
-    """ Test Person.synchronize_usersocialauth and Person.save."""
+    """Test Person.synchronize_usersocialauth and Person.save."""
 
     def test_basic(self):
         user = Person.objects.create_user(
@@ -1460,7 +1457,7 @@ class TestRegression1076(TestBase):
 
 
 class TestArchivePerson(TestBase):
-    """ Test cases for person archive endpoint. """
+    """Test cases for person archive endpoint."""
 
     @patch("workshops.github_auth.github_username_to_uid", github_username_to_uid_mock)
     def setUp(self):


### PR DESCRIPTION
The issue appeared when running tests in parallel in a fresh database.
Most likely it was due to some junk left in sites cache after
migrations. The solution clears the cache whenever Sites framework is
used.
