### PR TITLE
[#2055] Fix wrong template variable displayed in Organization page

### DIFF
--- a/amy/templates/fiscal/organization.html
+++ b/amy/templates/fiscal/organization.html
@@ -152,7 +152,7 @@
     <td>{{ membership.get_contribution_type_display }}</td>
     <!-- centrally-organised -->
     <td>
-      {{ membership.workshops_without_admin_fee_per_agreement|default_if_none:"&mdash;" }}
+      {{ membership.workshops_without_admin_fee_total_allowed|default_if_none:"&mdash;" }}
       <p class="small">Inc. {{ membership.workshops_without_admin_fee_rolled_from_previous|default:0 }} rolled from prev.</p>
     </td>
     <td>{{ membership.workshops_without_admin_fee_completed|default_if_none:"&mdash;" }}</td>


### PR DESCRIPTION
This fixes #2055.

The template used DB value instead of property calculating sum of two DB values.