### PR TITLE
[#2051] Membership counting queryset adjustment

### DIFF
--- a/amy/fiscal/tests/test_membership.py
+++ b/amy/fiscal/tests/test_membership.py
@@ -172,8 +172,8 @@ class TestMembership(TestBase):
         self.setUpTasks()
         self.assertEqual(self.current.workshops_without_admin_fee_per_agreement, 10)
         self.assertEqual(self.current.workshops_without_admin_fee_total_allowed, 10)
-        self.assertEqual(self.current.workshops_without_admin_fee_completed, 6)
-        self.assertEqual(self.current.workshops_without_admin_fee_planned, 4)
+        self.assertEqual(self.current.workshops_without_admin_fee_completed, 7)
+        self.assertEqual(self.current.workshops_without_admin_fee_planned, 3)
         self.assertEqual(self.current.workshops_without_admin_fee_remaining, 0)
 
     def test_delete_membership(self):

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -314,13 +314,9 @@ class Membership(models.Model):
     def _workshops_without_admin_fee_queryset(self):
         """Provide universal queryset for looking up centrally-organised workshops for
         this membership."""
-        during_membership = Q(
-            start__gte=self.agreement_start, start__lt=self.agreement_end
-        )
         cancelled = Q(tags__name="cancelled") | Q(tags__name="stalled")
         return (
-            Event.objects.filter(during_membership)
-            .filter(membership=self)
+            Event.objects.filter(membership=self)
             .filter(administrator__in=Organization.objects.administrators())
             .exclude(administrator__domain="self-organized")
             .exclude(cancelled)
@@ -365,7 +361,7 @@ class Membership(models.Model):
 
     @cached_property
     def workshops_without_admin_fee_completed(self) -> int:
-        """Count centrally-organised workshops already hosted during the agreement.
+        """Count centrally-organised workshops already hosted by this membership.
 
         This value must not be higher than "contracted" (or available for counting)
         no-fee workshops.
@@ -378,7 +374,7 @@ class Membership(models.Model):
 
     @cached_property
     def workshops_without_admin_fee_planned(self) -> int:
-        """Count centrally-organised workshops hosted in future during the agreement.
+        """Count centrally-organised workshops hosted in future by this membership.
 
         This value must not be higher than "contracted" (or available for counting)
         no-fee workshops reduced by already completed no-fee workshops.
@@ -423,16 +419,12 @@ class Membership(models.Model):
     def _self_organized_workshops_queryset(self):
         """Provide universal queryset for looking up self-organised events for this
         membership."""
-        during_membership = Q(
-            start__gte=self.agreement_start, start__lt=self.agreement_end
-        )
         cancelled = Q(tags__name="cancelled") | Q(tags__name="stalled")
         self_organized = Q(administrator=None) | Q(
             administrator__domain="self-organized"
         )
         return (
-            Event.objects.filter(during_membership)
-            .filter(membership=self)
+            Event.objects.filter(membership=self)
             .filter(self_organized)
             .exclude(cancelled)
             .distinct()


### PR DESCRIPTION
This fixes #2051 by removing constraint dates on calculation - now the membership start and end dates are not considered. The link to membership is enough.