### PR TITLE
Build docs not from main, but from develop

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,7 +2,7 @@ name: build docs
 on:
   push:
     branches:
-      - main
+      - develop
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
This changes docs automation to run from develop branch instead of main. Thanks to that, changes in docs will be reflected sooner than every release.