### PR TITLE
[#2097] Improve select2 widget keyboard navigation

### DIFF
--- a/amy/static/amy_utils.js
+++ b/amy/static/amy_utils.js
@@ -408,3 +408,8 @@ $(document).ready(function() {
     });
   }
 });
+
+// move focus to "search" field within select2 dropdown once it opens
+$(document).on('select2:open', () => {
+  document.querySelector('.select2-container--open .select2-search__field').focus();
+});


### PR DESCRIPTION
Once opened, the widget should get focus on it's search field.

See https://github.com/carpentries/amy/issues/2097#issuecomment-981094900 for more information and a video.

This fixes #2097.