### PR TITLE
Remove covid-19 and add workshops webpage

### DIFF
--- a/amy/templates/mailing/workshopinquiry.txt
+++ b/amy/templates/mailing/workshopinquiry.txt
@@ -3,14 +3,13 @@ you are interested in bringing The Carpentries to your organisation. The
 information you included in the form will help us to provide the best
 workshop for your target audience. If you would like to learn more about
 how our workshops are organised please visit our website
-(https://carpentries.org/). For more information about our curricula go
+(https://carpentries.org/workshops/). For more information about our curricula go
 here (https://carpentries.org/workshops-curricula/). Please be advised that
 a workshop will not be scheduled until it has been confirmed by the host and
 The Carpentries Workshop Administrator. Our workshops are organised based on
 the order the Workshop Request Form is received and finalized.
 
-If you are interested in learning more about how we teach workshops online in
-response to the COVID-19 pandemic, you can read about it in our handbook
+If you are interested in learning more about how we teach workshops online in, you can read about it in our handbook
 (https://docs.carpentries.org/topic_folders/hosts_instructors/resources_for_online_workshops.html).
 
 A member from our team will be following up with you. We look forward to


### PR DESCRIPTION
now that online workshops are permanent we do not need to mention covid-19.
