### PR TITLE
add link to help guides to menu

### DIFF
--- a/amy/templates/navigation.html
+++ b/amy/templates/navigation.html
@@ -78,11 +78,10 @@
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Hello, {{ user.get_short_name }}</a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-              {% if user.is_admin %}
+
               <a class="dropdown-item" href="{% url 'person_details' user.id %}">Your profile</a>
-              {% else %}
-              <a class="dropdown-item" href="{% url 'autoupdate_profile' %}">Your profile</a>
-              {% endif %}
+              <a class="dropdown-item" href="https://carpentries.github.io/amy/users_guide/" target="_blank">Users Guide</a>
+
               <a class="dropdown-item" href="{% url 'api:export-person-data' %}?format=json">Download your data</a>
               <a class="dropdown-item" href="{% url 'person_password' user.id %}">Change password</a>
               <div class="dropdown-divider"></div>

--- a/amy/templates/navigation.html
+++ b/amy/templates/navigation.html
@@ -80,7 +80,7 @@
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
 
               <a class="dropdown-item" href="{% url 'person_details' user.id %}">Your profile</a>
-              <a class="dropdown-item" href="https://carpentries.github.io/amy/users_guide/" target="_blank">Users Guide</a>
+              <a class="dropdown-item" href="https://carpentries.github.io/amy/users_guide/" target="_blank" rel="noreferrer nofollow">Users Guide</a>
 
               <a class="dropdown-item" href="{% url 'api:export-person-data' %}?format=json">Download your data</a>
               <a class="dropdown-item" href="{% url 'person_password' user.id %}">Change password</a>

--- a/amy/templates/navigation_instructor_dashboard.html
+++ b/amy/templates/navigation_instructor_dashboard.html
@@ -30,7 +30,7 @@
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
               <a class="dropdown-item" href="{% url 'api:export-person-data' %}?format=json">Download your data</a>
               <a class="dropdown-item" href="{% url 'person_password' user.id %}">Change password</a>
-              <a class="dropdown-item" href="https://docs.carpentries.org/topic_folders/for_instructors/current_instructors.html#accessing-and-updating-your-instructor-profile" target="_blank">Help</a>
+              <a class="dropdown-item" href="https://docs.carpentries.org/topic_folders/for_instructors/current_instructors.html#accessing-and-updating-your-instructor-profile" target="_blank" rel="noreferrer nofollow">Help</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" href="{% url 'logout' %}">Log out</a>
             </div>

--- a/amy/templates/navigation_instructor_dashboard.html
+++ b/amy/templates/navigation_instructor_dashboard.html
@@ -30,6 +30,7 @@
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
               <a class="dropdown-item" href="{% url 'api:export-person-data' %}?format=json">Download your data</a>
               <a class="dropdown-item" href="{% url 'person_password' user.id %}">Change password</a>
+              <a class="dropdown-item" href="https://docs.carpentries.org/topic_folders/for_instructors/current_instructors.html#accessing-and-updating-your-instructor-profile" target="_blank">Help</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" href="{% url 'logout' %}">Log out</a>
             </div>


### PR DESCRIPTION
This addresses #2087 by adding a link to the admin help guide and the users help guide to the respective navigation menus.  In addition to adding the links to the menus, it also removes the conditional in [the admin navigation](https://github.com/carpentries/amy/blob/develop/amy/templates/navigation.html) because this view is already only available to admin users.