### PR TITLE
Curie -> Skłodowska-Curie

### DIFF
--- a/amy/workshops/tests/test_person.py
+++ b/amy/workshops/tests/test_person.py
@@ -362,12 +362,12 @@ class TestPerson(TestBase):
         url = reverse("person_add")
         self.client.post(url, data)
         person = Person.objects.get(username="curie_marie")
-        self.assertEqual(person.email, "m.curie@sorbonne.fr")
+        self.assertEqual(person.email, "m.sklodowska-curie@sorbonne.fr")
 
         url = reverse("person_edit", args=[person.pk])
         self.client.post(url, data)
         person.refresh_from_db()
-        self.assertEqual(person.email, "m.curie@sorbonne.fr")
+        self.assertEqual(person.email, "m.sklodowska-curie@sorbonne.fr")
 
     def test_edit_permission_of_person_without_email(self):
         """

--- a/amy/workshops/tests/test_person.py
+++ b/amy/workshops/tests/test_person.py
@@ -355,9 +355,9 @@ class TestPerson(TestBase):
         data = {
             "username": "curie_marie",
             "personal": "Marie",
-            "family": "Curie",
+            "family": "Skłodowska-Curie",
             "gender": "F",
-            "email": "M.CURIE@sorbonne.fr",
+            "email": "M.SKLODOWSKA-CURIE@sorbonne.fr",
         }
         url = reverse("person_add")
         self.client.post(url, data)


### PR DESCRIPTION
It would be great to comply with now common practice of acknowledging Marie Curie's Polish origins indicating both her surnames as she did herself:

- Here's her double-surname signature:
   https://en.wikipedia.org/wiki/Marie_Curie#/media/File:Marie_Curie_Sk%C5%82odowska_Signature_Polish.svg 
- Here's her Nobel prize diploma with both surnames:
   https://en.wikipedia.org/wiki/File:Marie_Sk%C5%82odowska-Curie%27s_Nobel_Prize_in_Chemistry_1911.jpg

Quoting the European Commission website comment regarding the renaming of the "Marie Curie Actions" into "Marie Skłodowska-Curie Actions" (https://ec.europa.eu/research-and-innovation/en/horizon-magazine/marie-sklodowska-curie-actions-supporting-europes-best-and-brightest-researchers-25-years):  "the programme was renamed the Marie Skłodowska-Curie Actions (MSCA), emphasising the namesake’s Polish heritage and diversity."