### PR TITLE
[#2069] Resign from recruitment

### DIFF
--- a/amy/dashboard/tests/test_instructor_recruitment_views.py
+++ b/amy/dashboard/tests/test_instructor_recruitment_views.py
@@ -11,7 +11,11 @@ from communityroles.models import (
     CommunityRoleConfig,
     CommunityRoleInactivation,
 )
-from dashboard.views import SignupForRecruitment, UpcomingTeachingOpportunitiesList
+from dashboard.views import (
+    ResignFromRecruitment,
+    SignupForRecruitment,
+    UpcomingTeachingOpportunitiesList,
+)
 from recruitment.models import InstructorRecruitment, InstructorRecruitmentSignup
 from workshops.models import Event, Organization, Person, Role, Task
 
@@ -442,3 +446,148 @@ class TestSignupForRecruitment(TestCase):
         )
         # new object created
         self.assertTrue(isinstance(view.object, InstructorRecruitmentSignup))
+
+
+class TestResignFromRecruitment(TestCase):
+    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    def test_view_enabled__no_community_role(self):
+        # Arrange
+        request = RequestFactory().post("/")
+        request.user = Person(personal="Test", family="User", email="test@user.com")
+        # Act
+        view = ResignFromRecruitment(request=request)
+        # Assert
+        self.assertEqual(view.get_view_enabled(), False)
+
+    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    def test_view_enabled__community_role_inactive(self):
+        # Arrange
+        request = RequestFactory().post("/")
+        person = Person.objects.create(
+            personal="Test", family="User", email="test@user.com"
+        )
+        request.user = person
+        config = CommunityRoleConfig.objects.create(
+            name="instructor",
+            display_name="Instructor",
+            link_to_award=False,
+            link_to_membership=False,
+            additional_url=False,
+        )
+        inactivation = CommunityRoleInactivation.objects.create(name="inactivation")
+        role = CommunityRole.objects.create(
+            config=config,
+            person=person,
+            inactivation=inactivation,
+        )
+        # Act
+        view = ResignFromRecruitment(request=request)
+        # Assert
+        self.assertEqual(role.is_active(), False)
+        self.assertEqual(view.get_view_enabled(), False)
+
+    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    def test_view_enabled__community_role_active(self):
+        # Arrange
+        request = RequestFactory().post("/")
+        person = Person.objects.create(
+            personal="Test", family="User", email="test@user.com"
+        )
+        request.user = person
+        config = CommunityRoleConfig.objects.create(
+            name="instructor",
+            display_name="Instructor",
+            link_to_award=False,
+            link_to_membership=False,
+            additional_url=False,
+        )
+        role = CommunityRole.objects.create(
+            config=config,
+            person=person,
+        )
+        # Act
+        view = ResignFromRecruitment(request=request)
+        # Assert
+        self.assertEqual(role.is_active(), True)
+        self.assertEqual(view.get_view_enabled(), True)
+
+    def test_get_queryset(self):
+        # Arrange
+        host = Organization.objects.create(domain="test.com", fullname="Test")
+        person1 = Person.objects.create(
+            personal="Test1", family="User1", email="test1@user1.com", username="test1"
+        )
+        person2 = Person.objects.create(
+            personal="Test2", family="User2", email="test2@user2.com", username="test2"
+        )
+        event1 = Event.objects.create(slug="test-event1", host=host)
+        event2 = Event.objects.create(slug="test-event2", host=host)
+        recruitment1 = InstructorRecruitment.objects.create(status="c", event=event1)
+        recruitment2 = InstructorRecruitment.objects.create(status="o", event=event2)
+        signup1 = InstructorRecruitmentSignup(recruitment=recruitment1, person=person1)
+        signup2 = InstructorRecruitmentSignup(recruitment=recruitment1, person=person2)
+        signup3 = InstructorRecruitmentSignup(recruitment=recruitment2, person=person1)
+        signup4 = InstructorRecruitmentSignup(recruitment=recruitment2, person=person2)
+        InstructorRecruitmentSignup.objects.bulk_create(
+            [signup1, signup2, signup3, signup4]
+        )
+
+        request = RequestFactory().post("/")
+        request.user = person1
+        view = ResignFromRecruitment(request=request)
+
+        # Act
+        signups = view.get_queryset()
+
+        # Assert
+        self.assertEqual(list(signups), [signup3])
+
+    def test_get_redirect_url__no_next_param(self):
+        # Arrange
+        request = RequestFactory().post("/")
+        view = ResignFromRecruitment(request=request)
+        # Act
+        url = view.get_redirect_url()
+        # Assert
+        self.assertEqual(url, reverse("upcoming-teaching-opportunities"))
+
+    def test_get_redirect_url__with_next_param(self):
+        # Arrange
+        next_url = "/dashboard"
+        request = RequestFactory().post("/", {"next": next_url})
+        view = ResignFromRecruitment(request=request)
+        # Act
+        url = view.get_redirect_url()
+        # Assert
+        self.assertEqual(url, next_url)
+
+    @patch("dashboard.views.messages")
+    def test_post(self, mock_messages):
+        # Arrange
+        host = Organization.objects.create(domain="test.com", fullname="Test")
+        person = Person.objects.create(
+            personal="Test", family="User", email="test@user.com"
+        )
+        event = Event.objects.create(
+            slug="test-event", host=host, start=date(2022, 2, 19), end=date(2022, 2, 20)
+        )
+        recruitment = InstructorRecruitment.objects.create(status="o", event=event)
+        signup = InstructorRecruitmentSignup.objects.create(
+            recruitment=recruitment, person=person
+        )
+
+        request = RequestFactory().post("/")
+        request.user = person
+        view = ResignFromRecruitment(kwargs={"signup_pk": signup.pk})
+
+        # Act
+        result = view.post(request)
+
+        # Assert
+        mock_messages.success.assert_called_once_with(
+            request, f"Your teaching request was removed from recruitment {event}"
+        )
+        with self.assertRaises(InstructorRecruitmentSignup.DoesNotExist):
+            signup.refresh_from_db()
+
+        self.assertEqual(result.status_code, 302)

--- a/amy/dashboard/urls.py
+++ b/amy/dashboard/urls.py
@@ -41,6 +41,11 @@ urlpatterns = [
                     views.SignupForRecruitment.as_view(),
                     name="signup-for-recruitment",
                 ),
+                path(
+                    "teaching_opportunities/signups/<int:signup_pk>/resign",
+                    views.ResignFromRecruitment.as_view(),
+                    name="resign-from-recruitment",
+                ),
             ]
         ),
     ),

--- a/amy/templates/dashboard/upcoming_teaching_opportunities.html
+++ b/amy/templates/dashboard/upcoming_teaching_opportunities.html
@@ -59,15 +59,21 @@
 
       {% else %}
         {% if signup.state == "p" %}
-          TODO
-          <button class="btn btn-outline-primary btn-disabled" disabled>Interest expressed, confirmation pending...</button>
-          <a href="#" class="btn btn-danger">Cancel teaching request.</a>
+          <div class="alert alert-info" role="alert">
+            <p>You expressed interest in this workshop, the confirmation is pending...</p>
+            <form action="{% url 'resign-from-recruitment' signup.pk %}" onsubmit='return confirm("Do you want to cancel your teaching request?")' method="POST">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-danger">Cancel teaching request</button>
+            </form>
+          </div>
         {% elif signup.state == "a" %}
-          TODO
-          <button class="btn btn-outline-success btn-disabled" disabled>Teaching confirmed.</button>
+          <div class="alert alert-success" role="alert">
+           <p>Your teaching request has been confirmed.</p>
+          </div>
         {% elif signup.state == "d" %}
-          TODO
-          <button class="btn btn-outline-warning btn-disabled" disabled>Teaching discarded.</button>
+          <div class="alert alert-warning" role="alert">
+           <p>Your teaching request has been declined.</p>
+          </div>
         {% endif %}
       {% endif %}
     {% endwith %}


### PR DESCRIPTION
This fixes #2069.

Upon resignation, user's signup is completely removed from the system. They are able to re-apply to the same recruitment again.