### PR TITLE
1992 change host sponsor labels

### DIFF
--- a/amy/templates/includes/event_details_table.html
+++ b/amy/templates/includes/event_details_table.html
@@ -3,13 +3,15 @@
 {% load tags %}
 {% load attrs %}
 {% load utils %}
+{% load verbose_names %}
+
 <table class="table table-striped">
   <tr><th>Slug:</th><td colspan="2">{{ event.slug|default:"&mdash;" }}</td></tr>
   <tr><th>Completed:</th><td colspan="2">{{ event.completed|yesno }}</td></tr>
   <tr class="{% if event.start > event.end %}table-danger{% endif %}"><th>Start date:</th><td colspan="2">{{ event.start|default:"&mdash;" }}</td></tr>
   <tr class="{% if event.start > event.end %}table-danger{% endif %}"><th>End date: </th><td colspan="2">{{ event.end|default:"&mdash;" }}</td></tr>
-  <tr><th>Host:</th><td colspan="2"><a href="{% url 'organization_details' event.host.domain_quoted %}">{{ event.host }}</a></td></tr>
-  <tr><th>Sponsor:</th><td colspan="2">{% if event.sponsor %}<a href="{{ event.sponsor.get_absolute_url }}">{{ event.sponsor }}</a>{% else %}&mdash;{% endif %}</td></tr>
+  <tr><th>{% get_verbose_field_name_by_instance event 'host' %}:</th><td colspan="2"><a href="{% url 'organization_details' event.host.domain_quoted %}">{{ event.host }}</a></td></tr>
+  <tr><th>{% get_verbose_field_name_by_instance event 'sponsor' %}:</th><td colspan="2">{% if event.sponsor %}<a href="{{ event.sponsor.get_absolute_url }}">{{ event.sponsor }}</a>{% else %}&mdash;{% endif %}</td></tr>
   <tr><th>Membership:</th><td colspan="2">{% if event.membership %}<a href="{{ event.membership.get_absolute_url }}">{{ event.membership }}</a>{% else %}&mdash;{% endif %}</td></tr>
   <tr><th>Administrator:</th><td colspan="2">{% if event.administrator %}<a href="{{ event.administrator.get_absolute_url }}">{{ event.administrator }}</a>{% else %}&mdash;{% endif %}</td></tr>
   <tr><th>Is this workshop public?<br><small>Public workshops will show up in public Carpentries feeds.</small></th><td colspan="2">{{ event.get_public_status_display|default:"&mdash;" }}</td></tr>

--- a/amy/templates/workshops/all_events.html
+++ b/amy/templates/workshops/all_events.html
@@ -3,6 +3,7 @@
 {% load links %}
 {% load pagination %}
 {% load tags %}
+{% load verbose_names %}
 
 {% block content %}
   {% if perms.workshops.add_event %}
@@ -18,7 +19,7 @@
         <th>Tags</th>
         <th>URL</th>
         <th>Instructors</th>
-        <th>Host</th>
+        <th>{% get_verbose_field_name_by_model_name 'Event' 'host' %}</th>
         <th>Dates</th>
         <th>Completed</th>
         <th class="additional-links"></th>

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -1263,6 +1263,7 @@ class Event(AssignmentMixin, RQJobsMixin, models.Model):
         blank=False,
         related_name="hosted_events",
         help_text="Organisation hosting the event.",
+        verbose_name="Host Site",
     )
     sponsor = models.ForeignKey(
         Organization,
@@ -1271,6 +1272,7 @@ class Event(AssignmentMixin, RQJobsMixin, models.Model):
         blank=False,
         related_name="sponsored_events",
         help_text="Institution that is funding or organising the workshop.",
+        verbose_name="Organiser",
     )
     membership = models.ForeignKey(
         Membership,

--- a/amy/workshops/templatetags/verbose_names.py
+++ b/amy/workshops/templatetags/verbose_names.py
@@ -1,0 +1,29 @@
+from django import template
+from django.apps import apps
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_verbose_field_name_by_instance(instance, field_name):
+	"""Return the verbose_name of a model field."""			
+	if not hasattr(instance, '_meta'):
+		raise TypeError("Invalid model instance.")	
+
+	return instance._meta.get_field(field_name).verbose_name
+
+@register.simple_tag
+def get_verbose_field_name_by_model_name(model_name, field_name):
+	"""Return the verbose_name of a model field."""	
+	model = model_name
+
+	if isinstance(model_name, str):
+		for apps_model in apps.get_models():
+			if apps_model.__name__ == model_name:
+				model = apps_model							
+	if not hasattr(model, '_meta'):
+		raise TypeError("Invalid model name.")
+		
+	return model._meta.get_field(field_name).verbose_name
+

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -275,6 +275,20 @@ class TestEvent(TestBase):
         host_label = event._meta.get_field('host').verbose_name
         self.assertEqual(host_label, 'Host Site')
 
+class TestEventForm(TestBase):
+    def test_sponsor_field_is_required(self):
+        form = EventForm()
+        self.assertTrue(form.fields['sponsor'].required)
+
+    def test_host_field_is_required(self):
+        form = EventForm()
+        self.assertTrue(form.fields['host'].required)
+
+    def test_membership_field_is_optional(self):
+        form = EventForm()
+        self.assertFalse(form.fields['membership'].required)
+
+
 class TestEventFormComments(TestBase):
     form = EventForm
 

--- a/amy/workshops/tests/test_event.py
+++ b/amy/workshops/tests/test_event.py
@@ -255,6 +255,25 @@ class TestEvent(TestBase):
         event.tags.set([self.TTT_tag])
         event.full_clean()
 
+    def test_sponsor_label(self):
+        event = Event.objects.create(
+            slug="test-event",
+            host=self.org_alpha,
+            sponsor=self.org_alpha,
+            administrator=self.org_alpha,
+        )
+        sponsor_label = event._meta.get_field('sponsor').verbose_name
+        self.assertEqual(sponsor_label, 'Organiser')
+
+    def test_host_label(self):
+        event = Event.objects.create(
+            slug="test-event",
+            host=self.org_alpha,
+            sponsor=self.org_alpha,
+            administrator=self.org_alpha,
+        )
+        host_label = event._meta.get_field('host').verbose_name
+        self.assertEqual(host_label, 'Host Site')
 
 class TestEventFormComments(TestBase):
     form = EventForm

--- a/amy/workshops/tests/test_template_tags.py
+++ b/amy/workshops/tests/test_template_tags.py
@@ -1,0 +1,72 @@
+from datetime import date
+
+from django.template import Context, Template
+from django.test import TestCase
+
+from workshops.models import Event
+from workshops.templatetags.verbose_names import (
+	get_verbose_field_name_by_instance,	
+	get_verbose_field_name_by_model_name,
+)
+
+
+class TestVerboseNamesTemplateTags(TestCase):		
+	def test_get_verbose_field_name_by_instance_for_event_host(self):
+		event = Event(
+			slug="2022-01-01-test", start=date(2022, 1, 1), end=date(2022, 1, 2)
+        )
+		field_name = 'host'
+		expected_out = event._meta.get_field(field_name).verbose_name
+		out = Template(
+			"{% load verbose_names %}"
+			"{% get_verbose_field_name_by_instance event field_name %}"
+		).render(Context({'event': event, 'field_name': field_name}))
+		self.assertEqual(expected_out, out)
+
+	def test_get_verbose_field_name_by_instance_for_event_sponsor(self):
+		event = Event(
+			slug="2022-01-01-test", start=date(2022, 1, 1), end=date(2022, 1, 2)
+        )
+		field_name = 'sponsor'
+		expected_out = event._meta.get_field(field_name).verbose_name
+		out = Template(
+			"{% load verbose_names %}"
+			"{% get_verbose_field_name_by_instance event field_name %}"
+		).render(Context({'event': event, 'field_name': field_name}))
+		self.assertEqual(expected_out, out)
+
+	def test_get_verbose_field_name_by_instance_when_event_is_not_model_instance(self):
+		event = 'not model instance'
+		with self.assertRaises(TypeError):
+			get_verbose_field_name_by_instance(event, 'host')
+
+	def test_get_verbose_field_name_by_model_name_cls_for_event_model_for_host_field(self):
+		event = Event(
+			slug="2022-01-01-test", start=date(2022, 1, 1), end=date(2022, 1, 2)
+        )		
+		field_name = 'host'
+		expected_out = event._meta.get_field(field_name).verbose_name
+		out = Template(
+			"{% load verbose_names %}"
+			"{% get_verbose_field_name_by_model_name model_name field_name %}"
+		).render(Context({'model_name': Event, 'field_name': field_name}))
+		self.assertEqual(expected_out, out)
+
+	def test_get_verbose_field_name_by_model_name_str_for_event_model_for_host_field(self):
+		event = Event(
+			slug="2022-01-01-test", start=date(2022, 1, 1), end=date(2022, 1, 2)
+        )		
+		field_name = 'host'
+		expected_out = event._meta.get_field(field_name).verbose_name
+		out = Template(
+			"{% load verbose_names %}"
+			"{% get_verbose_field_name_by_model_name model_name field_name %}"
+		).render(Context({'model_name': 'Event', 'field_name': field_name}))
+		self.assertEqual(expected_out, out)
+
+	def test_get_verbose_field_name_by_model_name_for_faulty_model_name(self):
+		bad_model_name = 'not model instance'
+		with self.assertRaises(TypeError):
+			get_verbose_field_name_by_model_name(bad_model_name, 'host')
+
+


### PR DESCRIPTION
This accomplishes changes requested in #1992. 
- [x] Host should be renamed "Host Site" and should be required.
- [x] Sponsor should be renamed "Organiser" and should be required.
- [x] Membership can remain as is, and should be optional.


The code changes are done to make sure:
1. renamed values("Host Site" and "Organiser") are used in the event edit and creation forms.
2. the host and sponsor fields are required in forms; the membership field remains as optional.
3. the all-events and event detail views(templates) display the renamed values.

Note: the model field names are not changed; only the display(human-readable) names are.
