### PR TITLE
[#2114] Community role award limited to person

### DIFF
--- a/amy/communityroles/tests/test_community_role_views.py
+++ b/amy/communityroles/tests/test_community_role_views.py
@@ -7,7 +7,7 @@ from communityroles.models import (
     CommunityRoleConfig,
     CommunityRoleInactivation,
 )
-from workshops.models import Award, Person
+from workshops.models import Award, Badge, Person
 from workshops.tests.base import TestBase
 
 
@@ -58,10 +58,14 @@ class TestCommunityRoleCreateView(TestCommunityRoleMixin, TestBase):
         super()._setUpBadges()
         super()._setUpInstructors()
         super()._setUpUsersAndLogin()
+        award = Award.objects.create(
+            badge=Badge.objects.first(),
+            person=self.person,
+        )
         self.data = {
             "communityrole-config": self.config.pk,
             "communityrole-person": self.person.pk,
-            "communityrole-award": Award.objects.first().pk,
+            "communityrole-award": award.pk,
             "communityrole-start": date(2021, 11, 26),
             "communityrole-end": date(2022, 11, 26),
             "communityrole-inactivation": self.inactivation.pk,
@@ -88,10 +92,14 @@ class TestCommunityRoleUpdateView(TestCommunityRoleMixin, TestBase):
         super()._setUpBadges()
         super()._setUpInstructors()
         super()._setUpUsersAndLogin()
+        award = Award.objects.create(
+            badge=Badge.objects.first(),
+            person=self.person,
+        )
         self.data = {
             "communityrole-config": self.config.pk,
             "communityrole-person": self.person.pk,
-            "communityrole-award": Award.objects.first().pk,
+            "communityrole-award": award.pk,
             "communityrole-start": date(2021, 11, 26),
             "communityrole-end": date(2022, 11, 26),
             "communityrole-inactivation": self.inactivation.pk,

--- a/amy/static/communityrole_form.js
+++ b/amy/static/communityrole_form.js
@@ -7,6 +7,7 @@ jQuery(function () {
 
   let award_badge; // hold badge filter for award selection
   let content_type;
+  let person = $("#id_communityrole-person").val();
   $("#id_communityrole-config").select2({
     ajax: {
       processResults: (data) => {
@@ -25,6 +26,7 @@ jQuery(function () {
       data: (params) => {
         const query = {
           badge: award_badge,
+          person,
           // `field_id` is required on backend by django-select2 views
           field_id: $("#id_communityrole-award").data("field_id"),
           ...params,
@@ -45,6 +47,10 @@ jQuery(function () {
         return query;
       },
     },
+  });
+  $("#id_communityrole-person").on("select2:select", (e) => {
+    const data = e.params.data;
+    person = data.id;
   });
   $("#id_communityrole-config").on("select2:select", (e) => {
     const data = e.params.data;

--- a/amy/workshops/lookups.py
+++ b/amy/workshops/lookups.py
@@ -357,6 +357,9 @@ class AwardLookupView(OnlyForAdminsNoRedirectMixin, AutoResponseView):
         if badge := self.request.GET.get("badge"):
             results = results.filter(badge__pk=badge)
 
+        if person := self.request.GET.get("person"):
+            results = results.filter(person__pk=person)
+
         if self.term:
             results = results.filter(
                 Q(person__personal__icontains=self.term)


### PR DESCRIPTION
This fixes #2114 by limiting Community Roles awards to only show and accept person's awards.