### PR TITLE
[#2168] Update workshop staff searching with instructor community role

### DIFF
--- a/amy/templates/workshops/workshop_staff.html
+++ b/amy/templates/workshops/workshop_staff.html
@@ -15,9 +15,9 @@
     <table class="table table-striped">
       <tr>
         <th><input type="checkbox" value="Select all" select-all-checkbox /></th>
-        <th class="badges-column">Some badges <i class="fas fa-question-circle" data-toggle="tooltip"
-            title="Only Instructor or Trainer badges shown."></i></th>
-        <th>Has Trainer badge</th>
+        <th class="badges-column">Instructor <i class="fas fa-question-circle" data-toggle="tooltip"
+            title="Has an active Instructor Community Role."></i></th>
+        <th>Trainer</th>
         <th>Person</th>
         <th>Taught (inc. TTT)</th>
         <th>Trainee</th>
@@ -29,10 +29,8 @@
       {% for p in persons %}
       <tr>
         <td><input type="checkbox" email="{{ p.email }}" respond-to-select-all-checkbox /></td>
-        <td>{% for badge in p.important_badges %}
-          {% bootstrap_tag badge.name|cut:"-instructor"|upper %}
-          {% empty %}&mdash;{% endfor %}</td>
-        <td>{{ p.is_trainer|yesno }}</td>
+        <td>{% if p.is_instructor %}{% bootstrap_tag 'INSTRUCTOR' %}{% else %}&mdash;{% endif %}</td>
+        <td>{% if p.is_trainer %}{% bootstrap_tag 'TRAINER' %}{% else %}&mdash;{% endif %}</td>
         <td><a href="{{ p.get_absolute_url }}">{{ p.full_name }}</a>{% if p.email and p.may_contact %} &lt;{{ p.email|urlize }}&gt;{% endif %}</td>
         <td>{{ p.num_instructor|add:p.num_trainer }}</td>
         <td>{{ p.is_trainee|yesno }}</td>

--- a/amy/workshops/filters.py
+++ b/amy/workshops/filters.py
@@ -400,10 +400,9 @@ class WorkshopStaffFilter(AMYFilterSet):
         queryset=Lesson.objects.all(),
         conjoined=True,  # `AND`
     )
-    badges = django_filters.ModelMultipleChoiceFilter(
-        label="Badges",
-        queryset=Badge.objects.instructor_badges(),
-        conjoined=False,  # `OR`
+    is_instructor = django_filters.BooleanFilter(
+        widget=widgets.CheckboxInput,
+        method="filter_instructor",
     )
     is_trainer = django_filters.BooleanFilter(
         widget=widgets.CheckboxInput,
@@ -439,6 +438,11 @@ class WorkshopStaffFilter(AMYFilterSet):
     def filter_country(self, qs, n, v):
         if v:
             return qs.filter(Q(airport__country__in=v) | Q(country__in=v))
+        return qs
+
+    def filter_instructor(self, qs, n, v):
+        if v:
+            return qs.filter(is_instructor__gte=1)
         return qs
 
     def filter_trainer(self, qs, n, v):

--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -29,7 +29,6 @@ from workshops.fields import (
 from workshops.models import (
     Airport,
     Award,
-    Badge,
     Event,
     GenderMixin,
     KnowledgeDomain,
@@ -281,12 +280,9 @@ class WorkshopStaffForm(forms.Form):
         required=False,
     )
 
-    badges = forms.ModelMultipleChoiceField(
-        queryset=Badge.objects.instructor_badges(),
-        widget=CheckboxSelectMultiple(),
-        required=False,
+    is_instructor = forms.BooleanField(
+        required=False, label="Has active Instructor Community Role"
     )
-
     is_trainer = forms.BooleanField(required=False, label="Has Trainer badge")
 
     GENDER_CHOICES = ((None, "---------"),) + Person.GENDER_CHOICES
@@ -324,7 +320,7 @@ class WorkshopStaffForm(forms.Form):
                 ),
                 css_class="card",
             ),
-            "badges",
+            "is_instructor",
             "is_trainer",
             HTML("<hr>"),
             "was_helper",

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -1812,7 +1812,12 @@ class BadgeQuerySet(models.query.QuerySet):
     """Custom QuerySet that provides easy way to get instructor badges
     (we use that a lot)."""
 
-    INSTRUCTOR_BADGES = ("dc-instructor", "swc-instructor", "lc-instructor")
+    INSTRUCTOR_BADGES = (
+        "dc-instructor",
+        "swc-instructor",
+        "lc-instructor",
+        "instructor",
+    )
 
     def instructor_badges(self):
         """Filter for instructor badges only."""

--- a/amy/workshops/tests/base.py
+++ b/amy/workshops/tests/base.py
@@ -6,6 +6,7 @@ from django.contrib.sites.models import Site
 from django_webtest import WebTest
 import webtest.forms
 
+from communityroles.models import CommunityRole, CommunityRoleConfig
 from consents.models import Consent, Term, TermOption
 from workshops.models import (
     Airport,
@@ -195,6 +196,11 @@ class TestBase(
         )
         # lc-instructor is provided via a migration
         self.lc_instructor = Badge.objects.get(name="lc-instructor")
+
+        self.instructor_badge, _ = Badge.objects.get_or_create(
+            name="instructor",
+            defaults=dict(title="Single Instructor Badge"),
+        )
 
     def _setUpInstructors(self):
         """Set up person objects representing instructors."""
@@ -480,6 +486,51 @@ class TestBase(
                     name="supporting-instructor", verbose_name="Supporting Instructor"
                 ),
             ]
+        )
+
+    def _setUpSingleInstructorBadges(self) -> None:
+        """Add single Instructor Badges for Hermione, Harry and Ron."""
+        Award.objects.create(
+            person=self.hermione,
+            badge=self.instructor_badge,
+            awarded=datetime.date(2022, 7, 17),
+        )
+        Award.objects.create(
+            person=self.harry,
+            badge=self.instructor_badge,
+            awarded=datetime.date(2022, 7, 17),
+        )
+        Award.objects.create(
+            person=self.ron,
+            badge=self.instructor_badge,
+            awarded=datetime.date(2022, 7, 17),
+        )
+
+    def _setUpCommunityRoles(self) -> None:
+        """Add Instructor Community Roles to Hermione, Harry and Ron."""
+        instructor_config, _ = CommunityRoleConfig.objects.get_or_create(
+            name="instructor",
+            defaults=dict(
+                link_to_award=True,
+                award_badge_limit=self.instructor_badge,
+                link_to_membership=False,
+                additional_url=False,
+            ),
+        )
+        CommunityRole.objects.create(
+            config=instructor_config,
+            person=self.hermione,
+            award=Award.objects.get(person=self.hermione, badge=self.instructor_badge),
+        )
+        CommunityRole.objects.create(
+            config=instructor_config,
+            person=self.harry,
+            award=Award.objects.get(person=self.harry, badge=self.instructor_badge),
+        )
+        CommunityRole.objects.create(
+            config=instructor_config,
+            person=self.ron,
+            award=Award.objects.get(person=self.ron, badge=self.instructor_badge),
         )
 
     @staticmethod

--- a/amy/workshops/tests/test_lookups.py
+++ b/amy/workshops/tests/test_lookups.py
@@ -167,7 +167,8 @@ class TestGenericObjectLookupView(TestBase):
             '{"text": "Trainer", "id": 4}, '
             '{"text": "Mentor", "id": 5}, '
             '{"text": "Mentee", "id": 6}, '
-            '{"text": "Library Carpentry Instructor", "id": 7}]}',
+            '{"text": "Library Carpentry Instructor", "id": 7}, '
+            '{"text": "Single Instructor Badge", "id": 60}]}',
         )
 
     def test_permissions_no_content_type(self):

--- a/amy/workshops/tests/test_lookups.py
+++ b/amy/workshops/tests/test_lookups.py
@@ -155,6 +155,7 @@ class TestGenericObjectLookupView(TestBase):
         content_type = ContentType.objects.get_for_model(Badge)
         view = self.setUpView(content_type=content_type)
         request = self.setUpRequest("/")
+
         # Act
         result = view.get(request)
         # Assert
@@ -168,7 +169,9 @@ class TestGenericObjectLookupView(TestBase):
             '{"text": "Mentor", "id": 5}, '
             '{"text": "Mentee", "id": 6}, '
             '{"text": "Library Carpentry Instructor", "id": 7}, '
-            '{"text": "Single Instructor Badge", "id": 60}]}',
+            '{"text": "Single Instructor Badge", "id": '
+            f"{self.instructor_badge.pk}"
+            "}]}",
         )
 
     def test_permissions_no_content_type(self):

--- a/amy/workshops/tests/test_workshop_staff_searching.py
+++ b/amy/workshops/tests/test_workshop_staff_searching.py
@@ -16,6 +16,8 @@ class TestLocateWorkshopStaff(TestBase):
         self._setUpTags()
         self._setUpRoles()
         self._setUpUsersAndLogin()
+        self._setUpSingleInstructorBadges()
+        self._setUpCommunityRoles()
         self.url = reverse("workshop_staff")
 
     def test_non_instructors_and_instructors_returned_by_search(self):
@@ -140,18 +142,13 @@ class TestLocateWorkshopStaff(TestBase):
         self.assertNotIn(self.ironman, response.context["persons"])
         self.assertIn(self.blackwidow, response.context["persons"])
 
-    def test_instructor_badges(self):
+    def test_is_instructor(self):
         """Ensure people with instructor badges are returned by search. The
         search is OR'ed, so should return people with any of the selected
         badges."""
         response = self.client.get(
             self.url,
-            {
-                "airport": self.airport_0_0.pk,
-                "badges": Badge.objects.filter(
-                    name__in=["swc-instructor", "dc-instructor"]
-                ).values_list("pk", flat=True),
-            },
+            {"airport": self.airport_0_0.pk, "is_instructor": True},
         )
         self.assertEqual(response.status_code, 200)
 
@@ -164,25 +161,17 @@ class TestLocateWorkshopStaff(TestBase):
         self.assertNotIn(self.ironman, response.context["persons"])
         self.assertNotIn(self.blackwidow, response.context["persons"])
 
-        response = self.client.get(
-            self.url,
-            {
-                "airport": self.airport_0_0.pk,
-                "badges": Badge.objects.filter(
-                    name__in=["dc-instructor", "lc-instructor"]
-                ).values_list("pk", flat=True),
-            },
-        )
+        response = self.client.get(self.url, {"airport": self.airport_0_0.pk})
         self.assertEqual(response.status_code, 200)
 
         # instructors
         self.assertIn(self.hermione, response.context["persons"])  # SWC, DC,LC
         self.assertIn(self.harry, response.context["persons"])  # SWC, DC
-        self.assertNotIn(self.ron, response.context["persons"])  # SWC only
+        self.assertIn(self.ron, response.context["persons"])  # SWC only
         # non-instructors
-        self.assertNotIn(self.spiderman, response.context["persons"])
-        self.assertNotIn(self.ironman, response.context["persons"])
-        self.assertNotIn(self.blackwidow, response.context["persons"])
+        self.assertIn(self.spiderman, response.context["persons"])
+        self.assertIn(self.ironman, response.context["persons"])
+        self.assertIn(self.blackwidow, response.context["persons"])
 
     def test_match_on_one_language(self):
         """Ensure people with one particular language preference
@@ -425,7 +414,7 @@ class TestWorkshopStaffCSV(TestBase):
         rv = self.client.get(self.url)
         first_row = rv.content.decode("utf-8").splitlines()[0]
         first_row_expected = (
-            "Name,Email,Some badges,Has Trainer badge,Taught times,"
+            "Name,Email,Is instructor,Is trainer,Taught times,"
             "Is trainee,Airport,Country,Lessons,Affiliation"
         )
 
@@ -440,12 +429,10 @@ class TestWorkshopStaffCSV(TestBase):
             self.assertEqual(row["Name"], expected.full_name)
             self.assertEqual(row["Email"] or None, expected.email)
             self.assertEqual(
-                row["Some badges"],
-                " ".join(map(lambda x: x.name, expected.important_badges)),
+                row["Is instructor"],
+                "yes" if expected.is_instructor else "no",
             )
-            self.assertEqual(
-                row["Has Trainer badge"], "yes" if expected.is_trainer else "no"
-            )
+            self.assertEqual(row["Is trainer"], "yes" if expected.is_trainer else "no")
             self.assertEqual(row["Taught times"], str(expected.num_instructor))
             self.assertEqual(row["Is trainee"], "yes" if expected.is_trainee else "no")
             self.assertEqual(row["Airport"], str(expected.airport))


### PR DESCRIPTION
This fixes #2168 by changing how workshop staff searching works. It's now based on instructor community role instead of a badge selection.

~~TODO: fix broken test.~~ fixed