### PR TITLE
#2225 updates after last meeting

### DIFF
--- a/amy/communityroles/forms.py
+++ b/amy/communityroles/forms.py
@@ -116,10 +116,10 @@ class CommunityRoleForm(WidgetOverrideMixin, forms.ModelForm):
                 ValidationError(f"Membership is required with community role {config}")
             )
 
-        # Additional URL supported?
-        if not config.additional_url and cleaned_data.get("url"):
+        # Additional URL supported and required?
+        if config.additional_url and not cleaned_data.get("url"):
             errors["url"].append(
-                ValidationError(f"URL is not supported for community role {config}")
+                ValidationError(f"URL is required for community role {config}")
             )
 
         # Generic relation object must exist

--- a/amy/communityroles/forms.py
+++ b/amy/communityroles/forms.py
@@ -85,6 +85,7 @@ class CommunityRoleForm(WidgetOverrideMixin, forms.ModelForm):
         )
         start_date: Optional[date] = cleaned_data.get("start")
         end_date: Optional[date] = cleaned_data.get("end")
+        url: Optional[str] = cleaned_data.get("url")
 
         # Config is required, but field validation for 'config' should raise
         # validation error first.
@@ -117,7 +118,7 @@ class CommunityRoleForm(WidgetOverrideMixin, forms.ModelForm):
             )
 
         # Additional URL supported and required?
-        if config.additional_url and not cleaned_data.get("url"):
+        if config.additional_url and not url:
             errors["url"].append(
                 ValidationError(f"URL is required for community role {config}")
             )
@@ -148,7 +149,7 @@ class CommunityRoleForm(WidgetOverrideMixin, forms.ModelForm):
         # Person should not have any concurrent Community Roles of the same type in the
         # same time.
         if concurrent_roles := self.find_concurrent_roles(
-            config, person, start_date, end_date
+            config, person, start_date, end_date, url
         ):
             errors["person"].append(
                 ValidationError(
@@ -187,16 +188,23 @@ class CommunityRoleForm(WidgetOverrideMixin, forms.ModelForm):
         person: Optional[Person] = None,
         start_date: Optional[date] = None,
         end_date: Optional[date] = None,
+        url: Optional[str] = None,
     ) -> Optional[QuerySet[CommunityRole]]:
         """Lookup concurrent Community Roles."""
         # These are required fields in the form, so they should be present.
         if config and person and start_date:
-            same_time = Q(end__gt=start_date) | Q(end__isnull=True)
+            initial_conditions = Q(end__gt=start_date) | Q(end__isnull=True)
+
+            # if `end_date` is present, introduce additional condition
             if end_date:
-                # if `end_date` is present, introduce additional condition
-                same_time &= Q(start__lt=end_date) | Q(start__isnull=True)
-            roles = CommunityRole.objects.filter(person=person, config=config).filter(
-                same_time
+                initial_conditions &= Q(start__lt=end_date) | Q(start__isnull=True)
+
+            # if configuration requires URL, add URL to conditions
+            if config.additional_url:
+                initial_conditions &= Q(url=url)
+
+            roles = CommunityRole.objects.filter(
+                initial_conditions, person=person, config=config
             )
             return roles
         return None
@@ -226,6 +234,7 @@ class CommunityRoleUpdateForm(CommunityRoleForm):
         person: Optional[Person] = None,
         start_date: Optional[date] = None,
         end_date: Optional[date] = None,
+        url: Optional[str] = None,
     ) -> Optional[QuerySet[CommunityRole]]:
         """When updating a CommunityRole, we shouldn't check for concurrent roles."""
         return None

--- a/amy/communityroles/tests/test_community_role_forms.py
+++ b/amy/communityroles/tests/test_community_role_forms.py
@@ -259,7 +259,42 @@ class TestCommunityRoleForm(TestBase):
                 self.assertEqual(form.cleaned_data.get("end"), p2)
                 self.assertNotIn("end", form.errors.keys())
 
-    def test_additional_url_supported(self):
+    def test_additional_url_required(self):
+        # Arrange
+        test_config = CommunityRoleConfig.objects.create(
+            name="test",
+            display_name="Test",
+            link_to_award=True,
+            award_badge_limit=None,
+            link_to_membership=True,
+            additional_url=True,
+            generic_relation_content_type=None,
+        )
+        data = {
+            "config": test_config.pk,
+            "person": self.hermione.pk,
+            "award": self.award.pk,
+            "start": "2021-11-14",
+            "end": "2022-11-14",
+            "inactivation": None,
+            "membership": self.membership.pk,
+            "url": "",  # shouldn't be empty
+            "generic_relation_content_type": None,
+            "generic_relation_pk": None,
+        }
+
+        # Act
+        form = CommunityRoleForm(data)
+
+        # Assert
+        self.assertFalse(form.is_valid())  # errors expected
+        self.assertEqual(form.errors.keys(), {"url"})
+        self.assertEqual(
+            form.errors["url"],
+            ["URL is required for community role Test"],
+        )
+
+    def test_additional_url_not_required(self):
         # Arrange
         test_config = CommunityRoleConfig.objects.create(
             name="test",
@@ -278,7 +313,7 @@ class TestCommunityRoleForm(TestBase):
             "end": "2022-11-14",
             "inactivation": None,
             "membership": self.membership.pk,
-            "url": "https://example.org",  # should be empty
+            "url": "",  # it's okay
             "generic_relation_content_type": None,
             "generic_relation_pk": None,
         }
@@ -287,12 +322,8 @@ class TestCommunityRoleForm(TestBase):
         form = CommunityRoleForm(data)
 
         # Assert
-        self.assertFalse(form.is_valid())  # errors expected
-        self.assertEqual(form.errors.keys(), {"url"})
-        self.assertEqual(
-            form.errors["url"],
-            ["URL is not supported for community role Test"],
-        )
+        self.assertTrue(form.is_valid())  # errors not expected
+        self.assertEqual(form.errors.keys(), set())
 
     def test_generic_relation_object_doesnt_exist(self):
         # Arrange

--- a/amy/static/communityrole_form.js
+++ b/amy/static/communityrole_form.js
@@ -58,6 +58,7 @@ jQuery(function () {
     award_badge = data.award_badge_limit;
     $("#id_communityrole-membership").prop("required", data.link_to_membership);
     $("#id_communityrole-url").prop("disabled", !data.additional_url);
+    $("#id_communityrole-url").prop("required", data.additional_url);
     if (!data.additional_url) {
       $("#id_communityrole-url").val("");
     }


### PR DESCRIPTION
This fixes #2225 and some additional requirements:

* URL field is required in Community Role form if the config specifies so
* Awards for old instructor badges are removed when single instructor badge is awarded to a person