### PR TITLE
Migrate trainers

### DIFF
--- a/amy/workshops/management/commands/assign_trainer_community_role.py
+++ b/amy/workshops/management/commands/assign_trainer_community_role.py
@@ -1,0 +1,61 @@
+from django.core.management.base import BaseCommand
+from django.db.models import QuerySet
+
+from communityroles.models import CommunityRole, CommunityRoleConfig
+from workshops.models import Award, Badge
+
+
+class Command(BaseCommand):
+    TRAINER_BADGE_NAME = "trainer"
+    TRAINER_COMMUNITY_ROLE_NAME = "trainer"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.trainer_badge = Badge.objects.get(name=self.TRAINER_BADGE_NAME)
+        self.community_role_config = CommunityRoleConfig.objects.get(
+            name=self.TRAINER_COMMUNITY_ROLE_NAME
+        )
+
+    def find_trainer_awards(self) -> QuerySet[Award]:
+        return Award.objects.filter(badge=self.trainer_badge)
+
+    def exclude_trainer_community_roles(self, qs: QuerySet[Award]) -> QuerySet[Award]:
+        return qs.exclude(person__communityrole__config=self.community_role_config)
+
+    def create_trainer_community_role(self, award: Award) -> CommunityRole:
+        return CommunityRole(
+            config=self.community_role_config,
+            person=award.person,
+            award=award,
+            start=award.awarded,
+            end=None,
+            inactivation=None,
+        )
+
+    def log(self, no_output: bool, msg: str) -> None:
+        if not no_output:
+            self.stdout.write(msg)
+
+    def handle(self, *args, **kwargs):
+        no_output = kwargs.get("no_output", False)
+
+        self.log(no_output, "Starting migration to a trainer community role...")
+
+        trainer_awards = self.exclude_trainer_community_roles(
+            self.find_trainer_awards()
+        )
+        self.log(
+            no_output, f"Found {len(trainer_awards)} trainers with a Trainer badge."
+        )
+
+        new_community_roles = [
+            self.create_trainer_community_role(trainer_award)
+            for trainer_award in trainer_awards
+        ]
+        self.log(
+            no_output,
+            f"Bulk-creating {len(new_community_roles)} new Trainer community roles...",
+        )
+
+        CommunityRole.objects.bulk_create(new_community_roles)
+        self.log(no_output, "Done.")

--- a/amy/workshops/management/commands/migrate_inactive_trainers_to_trainer_badges.py
+++ b/amy/workshops/management/commands/migrate_inactive_trainers_to_trainer_badges.py
@@ -1,0 +1,65 @@
+from django.core.management.base import BaseCommand
+from django.db.models import QuerySet
+
+from communityroles.models import CommunityRoleConfig
+from workshops.models import Award, Badge, Person
+
+
+class Command(BaseCommand):
+    TRAINER_BADGE_NAME = "trainer"
+    TRAINER_INACTIVE_BADGE_NAME = "trainer-inactive"
+    TRAINER_COMMUNITY_ROLE_NAME = "trainer"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.trainer_badge = Badge.objects.get(name=self.TRAINER_BADGE_NAME)
+        self.trainer_inactive_badge = Badge.objects.get(
+            name=self.TRAINER_INACTIVE_BADGE_NAME
+        )
+        self.community_role_config = CommunityRoleConfig.objects.get(
+            name=self.TRAINER_COMMUNITY_ROLE_NAME
+        )
+
+    def find_people_with_trainer_community_role(self) -> QuerySet[Person]:
+        return Person.objects.filter(communityrole__config=self.community_role_config)
+
+    def find_trainer_inactive_awards(self) -> QuerySet[Award]:
+        return Award.objects.filter(badge=self.trainer_inactive_badge)
+
+    def log(self, no_output: bool, msg: str) -> None:
+        if not no_output:
+            self.stdout.write(msg)
+
+    def handle(self, *args, **kwargs):
+        no_output = kwargs.get("no_output", False)
+
+        self.log(
+            no_output, "Starting migration of inactive trainers to trainer badges..."
+        )
+
+        people_with_trainer_community_role = (
+            self.find_people_with_trainer_community_role()
+        )
+        self.log(
+            no_output,
+            f"Found {len(people_with_trainer_community_role)} people with Trainer "
+            "community role.",
+        )
+
+        inactive_trainers = self.find_trainer_inactive_awards()
+        self.log(
+            no_output,
+            f"Found {len(inactive_trainers)} people with 'Trainer - Inactive' badge.",
+        )
+
+        replace_badge = inactive_trainers.exclude(
+            person__in=people_with_trainer_community_role
+        )
+        self.log(
+            no_output,
+            f"{len(replace_badge)} people will have their 'Trainer - Inactive' badge "
+            "replaced with 'Trainer'.",
+        )
+
+        replace_badge.update(badge=self.trainer_badge)
+        self.log(no_output, "Done.")

--- a/amy/workshops/management/commands/migrate_to_single_instructor_badge.py
+++ b/amy/workshops/management/commands/migrate_to_single_instructor_badge.py
@@ -26,7 +26,13 @@ class Command(BaseCommand):
         )
 
     def earliest_award(self, person: Person) -> Award:
-        return person.award_set.order_by("awarded").first()  # type: ignore
+        return (
+            person.award_set.filter(  # type: ignore
+                badge__name__in=self.OLD_INSTRUCTOR_BADGE_NAMES,
+            )
+            .order_by("awarded")
+            .first()
+        )
 
     def remove_awards_for_old_instructor_badges(self) -> None:
         Award.objects.filter(


### PR DESCRIPTION
1. Small improvements made in migration to single instructor badge
2. New command: assign trainer community role to people with trainer badge
3. New command: migrate trainer-inactive awards to trainer awards
