### PR TITLE
[#2249] Fix issues with empty event dates on upcoming teaching opportunities

### DIFF
--- a/amy/recruitment/templatetags/instructorrecruitment.py
+++ b/amy/recruitment/templatetags/instructorrecruitment.py
@@ -23,11 +23,19 @@ def is_instructor_recruitment_enabled() -> bool:
 
 
 @register.simple_tag
-def get_event_conflicts(events: Sequence[Event], event: Event) -> list[Event]:
+def get_event_conflicts(events_to_check: Sequence[Event], event: Event) -> list[Event]:
     conflicts: list[Event] = []
 
-    for event_to_check in events:
+    # event must have start and end dates, otherwise we can't get conflicts
+    if not (event.start and event.end):
+        return conflicts
+
+    for event_to_check in events_to_check:
         if event == event_to_check:
+            continue
+
+        # event getting checked must have start and end dates
+        if not (event_to_check.start and event_to_check.end):
             continue
 
         if event.start <= event_to_check.end and event.end >= event_to_check.start:
@@ -38,12 +46,24 @@ def get_event_conflicts(events: Sequence[Event], event: Event) -> list[Event]:
 
 @register.simple_tag
 def get_events_nearby(
-    events: Sequence[Event], event: Event, days_before: int = 14, days_after: int = 14
+    events_to_check: Sequence[Event],
+    event: Event,
+    days_before: int = 14,
+    days_after: int = 14,
 ) -> list[Event]:
+    """Get events nearby another event time-wise."""
     nearby: list[Event] = []
 
-    for event_to_check in events:
+    # event must have start and end dates, otherwise we can't get nearby events
+    if not (event.start and event.end):
+        return nearby
+
+    for event_to_check in events_to_check:
         if event == event_to_check:
+            continue
+
+        # event getting checked must have start and end dates
+        if not (event_to_check.start and event_to_check.end):
             continue
 
         if (
@@ -57,12 +77,24 @@ def get_events_nearby(
 
 @register.simple_tag
 def get_signup_conflicts(
-    signups: Sequence[InstructorRecruitmentSignup], recruitment: InstructorRecruitment
+    signups_to_check: Sequence[InstructorRecruitmentSignup],
+    recruitment: InstructorRecruitment,
 ) -> list[InstructorRecruitmentSignup]:
     conflicts: list[InstructorRecruitmentSignup] = []
 
-    for signup_to_check in signups:
+    # recruitment event must have start and end dates, otherwise we can't get conflicts
+    if not (recruitment.event.start and recruitment.event.end):
+        return conflicts
+
+    for signup_to_check in signups_to_check:
         if recruitment == signup_to_check.recruitment:
+            continue
+
+        # event getting checked must have start and end dates
+        if not (
+            signup_to_check.recruitment.event.start
+            and signup_to_check.recruitment.event.end
+        ):
             continue
 
         if (

--- a/amy/recruitment/tests/test_template_tags.py
+++ b/amy/recruitment/tests/test_template_tags.py
@@ -51,6 +51,24 @@ class TestInstructorRecruitmentTemplateTags(TestCase):
         # Assert
         self.assertEqual(results, [event2])
 
+    def test_get_event_conflicts_no_start_or_end_dates(self) -> None:
+        """Regression test for #2243."""
+        # Arrange
+        event1 = Event(
+            slug="2022-01-01-test", start=date(2022, 1, 1), end=date(2022, 1, 2)
+        )
+        event2 = Event(slug="2022-02-01-test", start=None, end=date(2022, 2, 2))
+        event3 = Event(slug="2022-03-01-test", start=date(2022, 3, 1), end=None)
+        event4 = Event(slug="2022-xx-xx-test", start=None, end=None)
+        events = [event1, event2, event3, event4]
+        event = Event(
+            slug="2022-01-02-test", start=date(2022, 1, 2), end=date(2022, 1, 3)
+        )
+        # Act
+        results = get_event_conflicts(events, event)
+        # Assert
+        self.assertEqual(results, [event1])
+
     def test_get_events_nearby(self) -> None:
         # Arrange
         event1 = Event(
@@ -70,6 +88,24 @@ class TestInstructorRecruitmentTemplateTags(TestCase):
         results = get_events_nearby(events, event, days_before=100)
         # Assert
         self.assertEqual(results, [event1, event2])
+
+    def test_get_events_nearby_no_start_or_end_dates(self) -> None:
+        """Regression test for #2243."""
+        # Arrange
+        event1 = Event(
+            slug="2022-01-01-test", start=date(2022, 1, 1), end=date(2022, 1, 2)
+        )
+        event2 = Event(slug="2022-02-01-test", start=None, end=date(2022, 2, 2))
+        event3 = Event(slug="2022-03-01-test", start=date(2022, 3, 1), end=None)
+        event4 = Event(slug="2022-xx-xx-test", start=None, end=None)
+        events = [event1, event2, event3, event4]
+        event = Event(
+            slug="2021-12-22-test", start=date(2021, 12, 22), end=date(2021, 12, 23)
+        )
+        # Act
+        results = get_events_nearby(events, event)
+        # Assert
+        self.assertEqual(results, [event1])
 
     def test_get_signup_conflicts(self) -> None:
         # Arrange
@@ -104,6 +140,42 @@ class TestInstructorRecruitmentTemplateTags(TestCase):
         results = get_signup_conflicts(signups, recruitment)
         # Assert
         self.assertEqual(results, [signup2])
+
+    def test_get_signup_conflicts_no_start_or_end_dates(self) -> None:
+        """Regression test for #2243."""
+        # Arrange
+        signup1 = InstructorRecruitmentSignup(
+            recruitment=InstructorRecruitment(
+                event=Event(
+                    slug="2022-01-01-test", start=date(2022, 1, 1), end=date(2022, 1, 2)
+                )
+            )
+        )
+        signup2 = InstructorRecruitmentSignup(
+            recruitment=InstructorRecruitment(
+                event=Event(slug="2022-02-01-test", start=None, end=date(2022, 2, 2))
+            )
+        )
+        signup3 = InstructorRecruitmentSignup(
+            recruitment=InstructorRecruitment(
+                event=Event(slug="2022-03-01-test", start=date(2022, 3, 1), end=None)
+            )
+        )
+        signup4 = InstructorRecruitmentSignup(
+            recruitment=InstructorRecruitment(
+                event=Event(slug="2022-xx-xx-test", start=None, end=None)
+            )
+        )
+        signups = [signup1, signup2, signup3, signup4]
+        recruitment = InstructorRecruitment(
+            event=Event(
+                slug="2022-01-02-test", start=date(2022, 1, 2), end=date(2022, 1, 3)
+            )
+        )
+        # Act
+        results = get_signup_conflicts(signups, recruitment)
+        # Assert
+        self.assertEqual(results, [signup1])
 
     def test_priority_label__success(self) -> None:
         # Arrange


### PR DESCRIPTION
This fixes #2249.