### PR TITLE
[#2257] Fix: unquote ?next value for redirection

### DIFF
--- a/amy/dashboard/tests/test_instructor_recruitment_views.py
+++ b/amy/dashboard/tests/test_instructor_recruitment_views.py
@@ -1,5 +1,6 @@
 from datetime import date
 from unittest.mock import MagicMock, call, patch
+from urllib.parse import quote
 
 from django.contrib.messages.api import MessageFailure
 from django.test import TestCase, override_settings
@@ -313,24 +314,21 @@ class TestSignupForRecruitment(TestCase):
             "pending.",
         )
 
-    def test_get_success_url__no_next_param(self):
+    def test_get_success_url(self) -> None:
         # Arrange
-        request = RequestFactory().get("/")
-        view = SignupForRecruitment(request=request)
-        # Act
-        url = view.get_success_url()
-        # Assert
-        self.assertEqual(url, reverse("upcoming-teaching-opportunities"))
-
-    def test_get_success_url__with_next_param(self):
-        # Arrange
-        next_url = "/dashboard"
-        request = RequestFactory().get(f"/?next={next_url}")
-        view = SignupForRecruitment(request=request)
-        # Act
-        url = view.get_success_url()
-        # Assert
-        self.assertEqual(url, next_url)
+        url_redirect = {
+            "/asdasd": "/asdasd",
+            "/asdasd?status=o": "/asdasd?status=o",
+            "https://google.com/": reverse("upcoming-teaching-opportunities"),
+            None: reverse("upcoming-teaching-opportunities"),
+        }
+        for url, redirect in url_redirect.items():
+            request = RequestFactory().get(f"/?next={quote(url)}" if url else "/")
+            view = SignupForRecruitment(request=request)
+            # Act
+            result = view.get_success_url()
+            # Assert
+            self.assertEqual(result, redirect)
 
     def test_get_form_kwargs(self):
         # Arrange

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 import re
 from typing import Dict, Optional
+from urllib.parse import unquote
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -384,6 +385,8 @@ class SignupForRecruitment(
 
     def get_success_url(self) -> str:
         next_url = self.request.GET.get("next", None)
+        if next_url:
+            next_url = unquote(next_url)
         success_url = reverse("upcoming-teaching-opportunities")
         return safe_next_or_default_url(next_url, success_url)
 

--- a/amy/recruitment/tests/test_instructor_recruitment_views.py
+++ b/amy/recruitment/tests/test_instructor_recruitment_views.py
@@ -1,5 +1,6 @@
 from datetime import date, timedelta
 from unittest import mock
+from urllib.parse import quote
 
 from django.http import Http404
 from django.test import override_settings
@@ -488,11 +489,12 @@ class TestInstructorRecruitmentAddSignup(TestBase):
         # Arrange
         url_redirect = {
             "/asdasd": "/asdasd",
+            "/asdasd?status=o": "/asdasd?status=o",
             "https://google.com/": reverse("all_instructorrecruitment"),
             None: reverse("all_instructorrecruitment"),
         }
         for url, redirect in url_redirect.items():
-            request = RequestFactory().post("/", {"next": url} if url else {})
+            request = RequestFactory().post(f"/?next={quote(url)}" if url else "/")
             pk = 120000
             view = InstructorRecruitmentAddSignup(kwargs={"pk": pk})
             with mock.patch("recruitment.views.InstructorRecruitment"):
@@ -661,45 +663,24 @@ class TestInstructorRecruitmentSignupChangeState(FakeRedisTestCaseMixin, TestBas
         # Assert
         mock_signup.objects.get.assert_called_once_with(pk=pk)
 
-    def test_get_success_url__safe_next_provided(self) -> None:
+    def test_get_success_url(self) -> None:
         # Arrange
-        safe_next = "/asdasd"
-        request = RequestFactory().post("/", {"next": safe_next})
-        pk = 120000
-        view = InstructorRecruitmentSignupChangeState(kwargs={"pk": pk})
-        with mock.patch("recruitment.views.InstructorRecruitmentSignup"):
-            view.post(request)
-        # Act
-        result = view.get_success_url()
-        # Assert
-        self.assertEqual(result, safe_next)
-
-    def test_get_success_url__unsafe_next_provided(self) -> None:
-        # Arrange
-        unsafe_next = "https://google.com/"
-        default_success_url = reverse("all_instructorrecruitment")
-        request = RequestFactory().post("/", {"next": unsafe_next})
-        pk = 120000
-        view = InstructorRecruitmentSignupChangeState(kwargs={"pk": pk})
-        with mock.patch("recruitment.views.InstructorRecruitmentSignup"):
-            view.post(request)
-        # Act
-        result = view.get_success_url()
-        # Assert
-        self.assertEqual(result, default_success_url)
-
-    def test_get_success_url__next_not_provided(self) -> None:
-        # Arrange
-        default_success_url = reverse("all_instructorrecruitment")
-        request = RequestFactory().post("/")
-        pk = 120000
-        view = InstructorRecruitmentSignupChangeState(kwargs={"pk": pk})
-        with mock.patch("recruitment.views.InstructorRecruitmentSignup"):
-            view.post(request)
-        # Act
-        result = view.get_success_url()
-        # Assert
-        self.assertEqual(result, default_success_url)
+        url_redirect = {
+            "/asdasd": "/asdasd",
+            "/asdasd?status=o": "/asdasd?status=o",
+            "https://google.com/": reverse("all_instructorrecruitment"),
+            None: reverse("all_instructorrecruitment"),
+        }
+        for url, redirect in url_redirect.items():
+            request = RequestFactory().post("/", {"next": url} if url else {})
+            pk = 120000
+            view = InstructorRecruitmentSignupChangeState(kwargs={"pk": pk})
+            with mock.patch("recruitment.views.InstructorRecruitmentSignup"):
+                view.post(request)
+            # Act
+            result = view.get_success_url()
+            # Assert
+            self.assertEqual(result, redirect)
 
     def test_form_invalid__redirects_to_success_url(self) -> None:
         # Arrange
@@ -1015,6 +996,7 @@ class TestInstructorRecruitmentChangeState(FakeRedisTestCaseMixin, TestBase):
         # Arrange
         url_redirect = {
             "/asdasd": "/asdasd",
+            "/asdasd?status=o": "/asdasd?status=o",
             "https://google.com/": reverse("all_instructorrecruitment"),
             None: reverse("all_instructorrecruitment"),
         }

--- a/amy/recruitment/views.py
+++ b/amy/recruitment/views.py
@@ -1,5 +1,6 @@
 from datetime import date
 import logging
+from urllib.parse import unquote
 
 from django.conf import settings
 from django.contrib import messages
@@ -321,7 +322,9 @@ class InstructorRecruitmentAddSignup(
         return InstructorRecruitment.objects.get(pk=self.kwargs["pk"])
 
     def get_success_url(self) -> str:
-        next_url = self.request.POST.get("next", None)
+        next_url = self.request.GET.get("next", None)
+        if next_url:
+            next_url = unquote(next_url)
         default_url = reverse("all_instructorrecruitment")
         return safe_next_or_default_url(next_url, default_url)
 

--- a/amy/templates/includes/instructorrecruitment.html
+++ b/amy/templates/includes/instructorrecruitment.html
@@ -67,7 +67,7 @@
         <form action="{% url 'instructorrecruitmentsignup_changestate' signup.pk %}" onsubmit='return confirm("Do you want to CONFIRM this application?")' method="POST" class="d-inline-block my-1 mr-1">
           {% csrf_token %}
           <input type="hidden" name="action" value="confirm">
-          <input type="hidden" name="next" value="{{ request.get_full_path|urlencode }}">
+          <input type="hidden" name="next" value="{{ request.get_full_path }}">
           {% if signup.state == "p" %}
           <button type="submit" class="btn btn-sm btn-success">Confirm</button>
           {% else %}
@@ -77,7 +77,7 @@
         <form action="{% url 'instructorrecruitmentsignup_changestate' signup.pk %}" onsubmit='return confirm("Do you want to DECLINE this application?")' method="POST" class="d-inline-block my-1 mr-1">
           {% csrf_token %}
           <input type="hidden" name="action" value="decline">
-          <input type="hidden" name="next" value="{{ request.get_full_path|urlencode }}">
+          <input type="hidden" name="next" value="{{ request.get_full_path }}">
           {% if signup.state == "p" %}
           <button type="submit" class="btn btn-sm btn-danger">Decline</button>
           {% else %}
@@ -97,7 +97,7 @@
 <p>
   <div class="btn-group" role="group" aria-label="Actions for instructor recruitment">
     {% if perms.recruitment.change_instructorrecruitment and perms.recruitment.view_instructorrecruitmentsignup %}
-    <a href="{% url 'instructorrecruitment_add_signup' object.pk %}?next={{ request.get_full_path|urlize }}" class="btn btn-success">New instructor application</a>
+    <a href="{% url 'instructorrecruitment_add_signup' object.pk %}?next={{ request.get_full_path|urlencode }}" class="btn btn-success">New instructor application</a>
     {% else %}
     <a href="#" class="btn btn-success disabled" role="button" aria-disabled="true">New instructor application</a>
     {% endif %}
@@ -110,7 +110,7 @@
       onsubmit='return confirm("Are you sure you want to close this recruitment?");'
     >
       {% csrf_token %}
-      <input type="hidden" name="next" value="{{ request.get_full_path|urlize }}">
+      <input type="hidden" name="next" value="{{ request.get_full_path }}">
       <input type="hidden" name="action" value="close">
       <button type="submit" class="btn btn-warning">Close signups</button>
     </form>
@@ -126,7 +126,7 @@
       onsubmit='return confirm("Are you sure you want to re-open this recruitment?");'
     >
       {% csrf_token %}
-      <input type="hidden" name="next" value="{{ request.get_full_path|urlize }}">
+      <input type="hidden" name="next" value="{{ request.get_full_path }}">
       <input type="hidden" name="action" value="reopen">
       <button type="submit" class="btn btn-info">Re-open signups</button>
     </form>


### PR DESCRIPTION
Unquote is required if `next` contains e.g. `?status=o`, otherwise user was redirected to non-existing URL.