### PR TITLE
Display timestamps of instructor signups on instructor recruitment page

### DIFF
--- a/amy/templates/includes/instructorrecruitment.html
+++ b/amy/templates/includes/instructorrecruitment.html
@@ -8,6 +8,8 @@
       <th>Notes from Instructor</th>
       <th>Notes from admin</th>
       <th>Date conflicts</th>
+      <th>Submission date</th>
+      <th>Last change</th>
       <th>
         State
         <i
@@ -58,6 +60,8 @@
           {% endif %}
         {% endfor %}
       </td>
+      <td>{{ signup.created_at|date:'Y-m-d' }}</td>
+      <td>{{ signup.last_updated_at|date:'Y-m-d'|default:"&mdash;" }}</td>
       <td>
         <span class="{% state_label signup %}">
           {{ signup.get_state_display }}

--- a/amy/templates/includes/instructorrecruitment.html
+++ b/amy/templates/includes/instructorrecruitment.html
@@ -28,16 +28,14 @@
     <tr>
       <td><a href="{{ signup.person.get_absolute_url }}">{{ signup.person }}</a></td>
       <td>
-        <span title="Helper: {{ signup.num_helper }}; Supporting Instructor: {{ signup.num_supporting }}; Instructor: {{ signup.num_instructor }}">
-          <span title="{{ signup.num_helper }} Helper Roles">
-            {{ signup.num_helper }} H;
-          </span>
-          <span title="{{ signup.num_supporting }} Supporting Instructor Roles">
-            {{ signup.num_supporting }} SI;
-          </span>
-          <span title="{{ signup.num_instructor }} Instructor Roles">
-            {{ signup.num_instructor }} I
-          </span>
+        <span title="{{ signup.num_helper }} Helper Roles">
+          {{ signup.num_helper }} H;
+        </span>
+        <span title="{{ signup.num_supporting }} Supporting Instructor Roles">
+          {{ signup.num_supporting }} SI;
+        </span>
+        <span title="{{ signup.num_instructor }} Instructor Roles">
+          {{ signup.num_instructor }} I
         </span>
       </td>
       <td>{% include "includes/country_flag.html" with country=signup.person.country %}</td>


### PR DESCRIPTION
Adds "Submission date" and "Last change" columns. Fixes #2259 

![Screenshot showing new "Submission date" and "Last change" columns](https://user-images.githubusercontent.com/20683271/215156946-54d70817-dfaf-4148-ac68-72e319c36c55.png)

Also removes a duplicate tooltip in the same table that is never displayed, from what I can tell.



