### PR TITLE
hotfix: check for null values when loading custom keys

### DIFF
--- a/amy/communityroles/fields.py
+++ b/amy/communityroles/fields.py
@@ -17,7 +17,10 @@ class CustomKeysWidget(forms.TextInput):
 
     def get_context(self, name: str, value: str, attrs: dict):
         value_deserialized = json.loads(value)
-        value_deserialized_dict = dict(value_deserialized)
+        if value_deserialized is not None:
+            value_deserialized_dict = dict(value_deserialized)
+        else:
+            value_deserialized_dict = {}
         default_values = dict([(label, "") for label in self.labels])
         context_value = default_values | value_deserialized_dict
 

--- a/amy/communityroles/fields.py
+++ b/amy/communityroles/fields.py
@@ -1,8 +1,11 @@
 import json
+import logging
 
 from django import forms
 from django.http import QueryDict
 from django.utils.datastructures import MultiValueDict
+
+logger = logging.getLogger("amy")
 
 
 class CustomKeysWidget(forms.TextInput):
@@ -17,9 +20,13 @@ class CustomKeysWidget(forms.TextInput):
 
     def get_context(self, name: str, value: str, attrs: dict):
         value_deserialized = json.loads(value)
-        if value_deserialized is not None:
+        try:
             value_deserialized_dict = dict(value_deserialized)
-        else:
+        except (ValueError, TypeError) as e:
+            logger.debug(
+                f"Failed to load custom key values {value_deserialized} to dict: {e}."
+            )
+            logger.debug("Proceeding without custom key values...")
             value_deserialized_dict = {}
         default_values = dict([(label, "") for label in self.labels])
         context_value = default_values | value_deserialized_dict

--- a/amy/communityroles/tests/test_fields.py
+++ b/amy/communityroles/tests/test_fields.py
@@ -1,6 +1,5 @@
-from django.core.exceptions import ValidationError
-
 import json
+
 from communityroles.fields import CustomKeysWidget
 from workshops.tests.base import TestBase
 

--- a/amy/communityroles/tests/test_fields.py
+++ b/amy/communityroles/tests/test_fields.py
@@ -9,29 +9,60 @@ class TestCustomKeysField(TestBase):
         self.widget = CustomKeysWidget()
 
     def test_custom_keys_apply_labels(self):
-        self.widget.apply_labels(["Test"])
-        self.assertEqual(self.widget.labels, ["Test"])
+        # Arrange
+        custom_keys = ["Test", "Second test"]
+
+        # Act
+        self.widget.apply_labels(custom_keys)
+
+        # Assert
+        self.assertEqual(self.widget.labels, custom_keys)
 
     def test_custom_keys_create_subwidgets(self):
+        # Arrange
         custom_keys = ["Test", "Second test"]
         values = {"Test": "test value", "Second test": "second test value"}
         self.widget.apply_labels(custom_keys)
-        self.assertEqual(self.widget.labels, custom_keys)
 
+        # Act
         context = self.widget.get_context(
             name="communityroles-custom_keys", value=json.dumps(values), attrs={}
         )
-
         subwidgets = context["widget"]["subwidgets"]
         subwidget_labels = [w["label"] for w in subwidgets]
         subwidget_values = [w["value"] for w in subwidgets]
+
+        # Assert
         self.assertListEqual(subwidget_labels, custom_keys)
         self.assertListEqual(subwidget_values, list(values.values()))
 
-    def test_custom_keys_none(self):
-        self.widget.apply_labels([])
+    def test_custom_keys_value_null(self):
+        # Arrange
+        custom_keys = ["Test"]
+        self.widget.apply_labels(custom_keys)
+
+        # Act
         context = self.widget.get_context(
             name="communityroles-custom_keys", value="null", attrs={}
         )
+        subwidget = context["widget"]["subwidgets"][0]
 
-        self.assertEqual(context["widget"]["subwidgets"], [])
+        # Assert
+        self.assertEqual(subwidget["value"], None)
+
+    def test_custom_keys_value_invalid(self):
+        # Arrange
+        custom_keys = ["Test"]
+        # set a value which cannot be parsed as dict - should be ignored
+        values = ["Test value"]
+        self.widget.apply_labels(custom_keys)
+
+        # Act
+        context = self.widget.get_context(
+            name="communityroles-custom_keys", value=json.dumps(values), attrs={}
+        )
+        subwidget = context["widget"]["subwidgets"][0]
+
+        # Assert
+        # subwidget should use the default label as a fallback
+        self.assertEqual(subwidget["value"], None)

--- a/amy/communityroles/tests/test_fields.py
+++ b/amy/communityroles/tests/test_fields.py
@@ -1,0 +1,38 @@
+from django.core.exceptions import ValidationError
+
+import json
+from communityroles.fields import CustomKeysWidget
+from workshops.tests.base import TestBase
+
+
+class TestCustomKeysField(TestBase):
+    def setUp(self):
+        self.widget = CustomKeysWidget()
+
+    def test_custom_keys_apply_labels(self):
+        self.widget.apply_labels(["Test"])
+        self.assertEqual(self.widget.labels, ["Test"])
+
+    def test_custom_keys_create_subwidgets(self):
+        custom_keys = ["Test", "Second test"]
+        values = {"Test": "test value", "Second test": "second test value"}
+        self.widget.apply_labels(custom_keys)
+        self.assertEqual(self.widget.labels, custom_keys)
+
+        context = self.widget.get_context(
+            name="communityroles-custom_keys", value=json.dumps(values), attrs={}
+        )
+
+        subwidgets = context["widget"]["subwidgets"]
+        subwidget_labels = [w["label"] for w in subwidgets]
+        subwidget_values = [w["value"] for w in subwidgets]
+        self.assertListEqual(subwidget_labels, custom_keys)
+        self.assertListEqual(subwidget_values, list(values.values()))
+
+    def test_custom_keys_none(self):
+        self.widget.apply_labels([])
+        context = self.widget.get_context(
+            name="communityroles-custom_keys", value="null", attrs={}
+        )
+
+        self.assertEqual(context["widget"]["subwidgets"], [])


### PR DESCRIPTION
Fixes #2336 .

I wrote some tests, but do we actually use custom keys at all?