### PR TITLE
Fix internal errors from filters

### DIFF
--- a/amy/fiscal/filters.py
+++ b/amy/fiscal/filters.py
@@ -48,7 +48,7 @@ def filter_training_seats_only(queryset, name, seats):
         return queryset
 
 
-def filter_nonpositive_remaining_seats(queryset, name, seats):
+def filter_negative_remaining_seats(queryset, name, seats):
     """Limit Memberships to only entries with negative remaining seats."""
     if seats:
         return queryset.filter(instructor_training_seats_remaining__lt=0)
@@ -81,9 +81,9 @@ class MembershipFilter(AMYFilterSet):
         widget=widgets.CheckboxInput,
     )
 
-    nonpositive_remaining_seats_only = django_filters.BooleanFilter(
+    negative_remaining_seats_only = django_filters.BooleanFilter(
         label="Only show memberships with less than zero remaining seats",
-        method=filter_nonpositive_remaining_seats,
+        method=filter_negative_remaining_seats,
         widget=widgets.CheckboxInput,
     )
 
@@ -125,9 +125,9 @@ class MembershipTrainingsFilter(AMYFilterSet):
         widget=widgets.CheckboxInput,
     )
 
-    nonpositive_remaining_seats_only = django_filters.BooleanFilter(
+    negative_remaining_seats_only = django_filters.BooleanFilter(
         label="Only show memberships with less than zero remaining seats",
-        method=filter_nonpositive_remaining_seats,
+        method=filter_negative_remaining_seats,
         widget=widgets.CheckboxInput,
     )
 

--- a/amy/fiscal/filters.py
+++ b/amy/fiscal/filters.py
@@ -65,7 +65,7 @@ def filter_nonpositive_remaining_seats(queryset, name, seats):
 
 class MembershipFilter(AMYFilterSet):
     organization_name = django_filters.CharFilter(
-        label="Organisation name",
+        label="Organization name",
         field_name="organizations__fullname",
         lookup_expr="icontains",
     )

--- a/amy/fiscal/filters.py
+++ b/amy/fiscal/filters.py
@@ -1,7 +1,6 @@
 from datetime import date
 
 from django.forms import widgets
-from django.db.models import Q
 import django_filters
 
 from workshops.fields import Select2MultipleWidget, Select2Widget
@@ -121,13 +120,13 @@ class MembershipTrainingsFilter(AMYFilterSet):
     )
 
     training_seats_only = django_filters.BooleanFilter(
-        label="Only show memberships with more than zero allowed training seats (public or in-house)",
+        label="Only show memberships with more than zero allowed training seats",
         method=filter_training_seats_only,
         widget=widgets.CheckboxInput,
     )
 
     nonpositive_remaining_seats_only = django_filters.BooleanFilter(
-        label="Only show memberships with less than zero remaining seats (public or in-house)",
+        label="Only show memberships with less than zero remaining seats",
         method=filter_nonpositive_remaining_seats,
         widget=widgets.CheckboxInput,
     )
@@ -137,12 +136,9 @@ class MembershipTrainingsFilter(AMYFilterSet):
             "name",
             "agreement_start",
             "agreement_end",
-            "instructor_training_seats_public_total",
-            "instructor_training_seats_public_utilized",
-            "instructor_training_seats_public_remaining",
-            "instructor_training_seats_inhouse_total",
-            "instructor_training_seats_inhouse_utilized",
-            "instructor_training_seats_inhouse_remaining",
+            "instructor_training_seats_total",
+            "instructor_training_seats_utilized",
+            "instructor_training_seats_remaining",
         ),
     )
 

--- a/amy/fiscal/filters.py
+++ b/amy/fiscal/filters.py
@@ -44,10 +44,7 @@ def filter_active_memberships_only(queryset, name, active):
 def filter_training_seats_only(queryset, name, seats):
     """Limit Memberships to only entries with some training seats allowed."""
     if seats:
-        return queryset.filter(
-            Q(instructor_training_seats_public_total__gt=0)
-            | Q(instructor_training_seats_inhouse_total__gt=0)
-        )
+        return queryset.filter(instructor_training_seats_total__gt=0)
     else:
         return queryset
 
@@ -55,10 +52,7 @@ def filter_training_seats_only(queryset, name, seats):
 def filter_nonpositive_remaining_seats(queryset, name, seats):
     """Limit Memberships to only entries with negative remaining seats."""
     if seats:
-        return queryset.filter(
-            Q(instructor_training_seats_public_remaining__lt=0)
-            | Q(instructor_training_seats_inhouse_remaining__lt=0)
-        )
+        return queryset.filter(instructor_training_seats_remaining__lt=0)
     else:
         return queryset
 

--- a/amy/fiscal/tests/test_filters.py
+++ b/amy/fiscal/tests/test_filters.py
@@ -4,9 +4,9 @@ from django.db.models import Count, F, Q
 from django.db.models.functions import Coalesce
 from django.test import TestCase
 
-from fiscal.models import Membership
 from fiscal.filters import MembershipFilter, MembershipTrainingsFilter
-from workshops.models import Organization, Member, MemberRole, Role, Person, Task, Event
+from fiscal.models import Membership
+from workshops.models import Event, Member, MemberRole, Organization, Person, Role, Task
 
 
 class TestMembershipFilter(TestCase):

--- a/amy/fiscal/tests/test_filters.py
+++ b/amy/fiscal/tests/test_filters.py
@@ -1,0 +1,73 @@
+from datetime import date
+from unittest.mock import ANY, MagicMock, call
+
+from django.core.exceptions import ValidationError
+from django.db.models import F
+from django.test import TestCase
+
+from fiscal.models import Membership
+from fiscal.filters import MembershipFilter, MembershipTrainingsFilter
+from workshops.models import Organization, Member, MemberRole
+
+
+class TestMembershipFilter(TestCase):
+    def setUp(self):
+        self.model = Membership
+
+    def test_fields(self):
+        # Arrange
+        data = {}
+        # Act
+        filterset = MembershipFilter(data)
+        # Assert
+        self.assertEqual(
+            set(filterset.filters.keys()),
+            {
+                "organization_name",
+                "consortium",
+                "public_status",
+                "variant",
+                "contribution_type",
+                "active_only",
+                "training_seats_only",
+                "nonpositive_remaining_seats_only",
+                "order_by",
+            },
+        )
+
+    def test_filter_active_only(self):
+        # Arrange
+        qs_mock = MagicMock()
+        filterset = MembershipFilter({})
+        name = "active_only"
+        # Act
+        filterset.filters[name].filter(qs_mock, True)
+        # Assert
+        today = date.today()
+        qs_mock.filter.assert_called_once_with(
+            agreement_start__lte=today, agreement_end__gte=today
+        )
+        qs_mock.exclude.assert_not_called()
+
+    def test_filter_organization_name(self):
+        # Arrange
+        filterset = MembershipFilter({})
+        name = "organization_name"
+        value = "Test"
+        organization = Organization.objects.create(fullname=value, domain="example.org")
+        membership = Membership.objects.create(
+            name=value,
+            variant="Bronze",
+            agreement_start=date.today(),
+            agreement_end=date.today(),
+            contribution_type="Financial",
+        )
+        role = MemberRole.objects.first()
+        member = Member.objects.create(
+            membership=membership, organization=organization, role=role
+        )
+        qs = Membership.objects.all()
+        # Act
+        result = filterset.filters[name].filter(qs, value)
+        # Assert
+        self.assertQuerysetEqual(result, qs)

--- a/amy/fiscal/tests/test_filters.py
+++ b/amy/fiscal/tests/test_filters.py
@@ -218,7 +218,9 @@ class TestMembershipFilter(TestCase):
     def test_filter_order_by(self):
         # Arrange
         filter_name = "order_by"
+        fields = self.filterset.filters[filter_name].param_map
         results = {}
+        # default ordering is ascending
         expected_results = {
             "agreement_start": [self.membership2, self.membership],
             "agreement_end": [self.membership2, self.membership],
@@ -226,14 +228,17 @@ class TestMembershipFilter(TestCase):
         }
 
         # Act
-        for value in expected_results.keys():
-            results[value] = self.filterset.filters[filter_name].filter(
-                self.qs, [value]
+        for field in fields.keys():
+            results[field] = self.filterset.filters[filter_name].filter(
+                self.qs, [field]
             )
 
         # Assert
-        for value in results.keys():
-            self.assertQuerysetEqual(results[value], expected_results[value])
+        # we don't have any unexpected fields
+        self.assertListEqual(list(fields.keys()), list(expected_results.keys()))
+        # each field was filtered correctly
+        for field in fields.keys():
+            self.assertQuerysetEqual(results[field], expected_results[field])
 
 
 class TestMembershipTrainingsFilter(TestCase):
@@ -423,6 +428,7 @@ class TestMembershipTrainingsFilter(TestCase):
     def test_filter_order_by(self):
         # Arrange
         filter_name = "order_by"
+        fields = self.filterset.filters[filter_name].param_map
         results = {}
         # default ordering is ascending
         expected_results = {
@@ -435,11 +441,14 @@ class TestMembershipTrainingsFilter(TestCase):
         }
 
         # Act
-        for value in expected_results.keys():
-            results[value] = self.filterset.filters[filter_name].filter(
-                self.qs, [value]
+        for field in fields.keys():
+            results[field] = self.filterset.filters[filter_name].filter(
+                self.qs, [field]
             )
 
         # Assert
-        for value in results.keys():
-            self.assertQuerysetEqual(results[value], expected_results[value])
+        # we don't have any unexpected fields
+        self.assertListEqual(list(fields.keys()), list(expected_results.keys()))
+        # each field was filtered correctly
+        for field in fields.keys():
+            self.assertQuerysetEqual(results[field], expected_results[field])

--- a/amy/fiscal/tests/test_filters.py
+++ b/amy/fiscal/tests/test_filters.py
@@ -1,20 +1,21 @@
 from datetime import date
-from unittest.mock import ANY, MagicMock, call
 
-from django.core.exceptions import ValidationError
-from django.db.models import F
+from django.db.models import Count, F, Q
+from django.db.models.functions import Coalesce
 from django.test import TestCase
 
 from fiscal.models import Membership
 from fiscal.filters import MembershipFilter, MembershipTrainingsFilter
-from workshops.models import Organization, Member, MemberRole
+from workshops.models import Organization, Member, MemberRole, Role, Person, Task, Event
 
 
 class TestMembershipFilter(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.model = Membership
-        # create a test membership with one organization
+        member_role = MemberRole.objects.first()
+
+        # create a test membership that should be selected in filters
         cls.organization = Organization.objects.create(
             fullname="Test Organization", domain="example.org"
         )
@@ -24,26 +25,112 @@ class TestMembershipFilter(TestCase):
             agreement_start=date.today(),
             agreement_end=date.today(),
             contribution_type="Financial",
+            public_instructor_training_seats=1,
         )
-        role = MemberRole.objects.first()
         cls.member = Member.objects.create(
-            membership=cls.membership, organization=cls.organization, role=role
+            membership=cls.membership, organization=cls.organization, role=member_role
         )
+        # create a test membership that sphould be filtered out
+        cls.organization2 = Organization.objects.create(
+            fullname="To Be Filtered Out", domain="example2.org"
+        )
+        cls.membership2 = Membership.objects.create(
+            name="To Be Filtered Out",
+            variant="Silver",
+            agreement_start=date(2015, 1, 1),
+            agreement_end=date(2016, 1, 1),
+            contribution_type="Person-days",
+            public_instructor_training_seats=0,
+        )
+        cls.member2 = Member.objects.create(
+            membership=cls.membership2, organization=cls.organization2, role=member_role
+        )
+        cls.qs = Membership.objects.all().annotate(
+            instructor_training_seats_total=(
+                # Public
+                F("public_instructor_training_seats")
+                + F("additional_public_instructor_training_seats")
+                # Coalesce returns first non-NULL value
+                + Coalesce("public_instructor_training_seats_rolled_from_previous", 0)
+                # Inhouse
+                + F("inhouse_instructor_training_seats")
+                + F("additional_inhouse_instructor_training_seats")
+                + Coalesce("inhouse_instructor_training_seats_rolled_from_previous", 0)
+            ),
+            instructor_training_seats_remaining=(
+                # Public
+                F("public_instructor_training_seats")
+                + F("additional_public_instructor_training_seats")
+                # Coalesce returns first non-NULL value
+                + Coalesce("public_instructor_training_seats_rolled_from_previous", 0)
+                - Count(
+                    "task", filter=Q(task__role__name="learner", task__seat_public=True)
+                )
+                - Coalesce("public_instructor_training_seats_rolled_over", 0)
+                # Inhouse
+                + F("inhouse_instructor_training_seats")
+                + F("additional_inhouse_instructor_training_seats")
+                + Coalesce("inhouse_instructor_training_seats_rolled_from_previous", 0)
+                - Count(
+                    "task",
+                    filter=Q(task__role__name="learner", task__seat_public=False),
+                )
+                - Coalesce("inhouse_instructor_training_seats_rolled_over", 0)
+            ),
+        )
+
+        # create 2 used seats on test membership
+        # will make remaining seats negative
+        cls.event = Event.objects.create(
+            host=cls.organization,
+            sponsor=cls.organization,
+            membership=cls.membership,
+            slug="2023-02-16-ttt-test",
+        )
+        cls.person = Person.objects.create(personal="Test", username="test")
+        cls.person2 = Person.objects.create(personal="Test2", username="test2")
+        cls.role = Role.objects.create(name="learner", verbose_name="Learner")
+        cls.task = Task.objects.create(
+            event=cls.event,
+            person=cls.person,
+            role=cls.role,
+            seat_membership=cls.membership,
+            seat_public=True,
+        )
+        cls.task2 = Task.objects.create(
+            event=cls.event,
+            person=cls.person2,
+            role=cls.role,
+            seat_membership=cls.membership,
+            seat_public=True,
+        )
+
+        # get filterset
+        cls.filterset = MembershipFilter({})
 
     @classmethod
     def tearDownClass(cls) -> None:
+        # clean up used seats
+        cls.task.delete()
+        cls.task2.delete()
+        cls.event.delete()
+        cls.person.delete()
+        cls.person2.delete()
+        cls.role.delete()
+
+        # clean up memberships
         cls.member.delete()
         cls.membership.delete()
         cls.organization.delete()
+        cls.member2.delete()
+        cls.membership2.delete()
+        cls.organization2.delete()
 
     def test_fields(self):
-        # Arrange
-        data = {}
-        # Act
-        filterset = MembershipFilter(data)
+        # Arrange & Act stages happen in setUpClass()
         # Assert
         self.assertEqual(
-            set(filterset.filters.keys()),
+            set(self.filterset.filters.keys()),
             {
                 "organization_name",
                 "consortium",
@@ -59,26 +146,265 @@ class TestMembershipFilter(TestCase):
 
     def test_filter_active_only(self):
         # Arrange
-        qs_mock = MagicMock()
-        filterset = MembershipFilter({})
         name = "active_only"
+        value = True
+
         # Act
-        filterset.filters[name].filter(qs_mock, True)
-        today = date.today()
+        result = self.filterset.filters[name].filter(self.qs, value)
+
         # Assert
-        qs_mock.filter.assert_called_once_with(
-            agreement_start__lte=today, agreement_end__gte=today
-        )
-        qs_mock.exclude.assert_not_called()
+        self.assertTrue(self.membership in result)
+        self.assertFalse(self.membership2 in result)
 
     def test_filter_organization_name(self):
         # Arrange
-        filterset = MembershipFilter({})
         filter_name = "organization_name"
         value = "Test Organization"
-        qs = Membership.objects.all()
 
         # Act
-        result = filterset.filters[filter_name].filter(qs, value)
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
         # Assert
         self.assertQuerysetEqual(result, [self.membership])
+
+    def test_filter_variant(self):
+        # Arrange
+        filter_name = "variant"
+        value = "Bronze"
+
+        # Act
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
+        # Assert
+        self.assertTrue(self.membership in result)
+        self.assertFalse(self.membership2 in result)
+
+    def test_filter_contribution_type(self):
+        # Arrange
+        filter_name = "contribution_type"
+        value = "Financial"
+
+        # Act
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
+        # Assert
+        self.assertTrue(self.membership in result)
+        self.assertFalse(self.membership2 in result)
+
+    def test_filter_training_seats_only(self):
+        # Arrange
+        filter_name = "training_seats_only"
+        value = True
+
+        # Act
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
+        # Assert
+        self.assertTrue(self.membership in result)
+        self.assertFalse(self.membership2 in result)
+
+    def test_filter_nonpositive_remaining_seats_only(self):
+        # Arrange
+        filter_name = "nonpositive_remaining_seats_only"
+        value = True
+
+        # Act
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
+        # Assert
+        self.assertTrue(self.membership in result)
+        self.assertFalse(self.membership2 in result)
+
+    def test_filter_order_by(self):
+        # Arrange
+        filter_name = "nonpositive_remaining_seats_only"
+        value = True
+
+        # Act
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
+        # Assert
+        self.assertTrue(self.membership in result)
+        self.assertFalse(self.membership2 in result)
+
+
+class TestMembershipTrainingsFilter(TestCase):
+    """
+    Duplicate of TestMembershipFilter with some fields removed.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.model = Membership
+        member_role = MemberRole.objects.first()
+
+        # create a test membership that should be selected in filters
+        cls.organization = Organization.objects.create(
+            fullname="Test Organization", domain="example.org"
+        )
+        cls.membership = Membership.objects.create(
+            name="Test Membership",
+            variant="Bronze",
+            agreement_start=date.today(),
+            agreement_end=date.today(),
+            contribution_type="Financial",
+            public_instructor_training_seats=1,
+        )
+        cls.member = Member.objects.create(
+            membership=cls.membership, organization=cls.organization, role=member_role
+        )
+        # create a test membership that sphould be filtered out
+        cls.organization2 = Organization.objects.create(
+            fullname="To Be Filtered Out", domain="example2.org"
+        )
+        cls.membership2 = Membership.objects.create(
+            name="To Be Filtered Out",
+            variant="Silver",
+            agreement_start=date(2015, 1, 1),
+            agreement_end=date(2016, 1, 1),
+            contribution_type="Person-days",
+            public_instructor_training_seats=0,
+        )
+        cls.member2 = Member.objects.create(
+            membership=cls.membership2, organization=cls.organization2, role=member_role
+        )
+        cls.qs = Membership.objects.all().annotate(
+            instructor_training_seats_total=(
+                # Public
+                F("public_instructor_training_seats")
+                + F("additional_public_instructor_training_seats")
+                # Coalesce returns first non-NULL value
+                + Coalesce("public_instructor_training_seats_rolled_from_previous", 0)
+                # Inhouse
+                + F("inhouse_instructor_training_seats")
+                + F("additional_inhouse_instructor_training_seats")
+                + Coalesce("inhouse_instructor_training_seats_rolled_from_previous", 0)
+            ),
+            instructor_training_seats_remaining=(
+                # Public
+                F("public_instructor_training_seats")
+                + F("additional_public_instructor_training_seats")
+                # Coalesce returns first non-NULL value
+                + Coalesce("public_instructor_training_seats_rolled_from_previous", 0)
+                - Count(
+                    "task", filter=Q(task__role__name="learner", task__seat_public=True)
+                )
+                - Coalesce("public_instructor_training_seats_rolled_over", 0)
+                # Inhouse
+                + F("inhouse_instructor_training_seats")
+                + F("additional_inhouse_instructor_training_seats")
+                + Coalesce("inhouse_instructor_training_seats_rolled_from_previous", 0)
+                - Count(
+                    "task",
+                    filter=Q(task__role__name="learner", task__seat_public=False),
+                )
+                - Coalesce("inhouse_instructor_training_seats_rolled_over", 0)
+            ),
+        )
+
+        # create 2 used seats on test membership
+        # will make remaining seats negative
+        cls.event = Event.objects.create(
+            host=cls.organization,
+            sponsor=cls.organization,
+            membership=cls.membership,
+            slug="2023-02-16-ttt-test",
+        )
+        cls.person = Person.objects.create(personal="Test", username="test")
+        cls.person2 = Person.objects.create(personal="Test2", username="test2")
+        cls.role = Role.objects.create(name="learner", verbose_name="Learner")
+        cls.task = Task.objects.create(
+            event=cls.event,
+            person=cls.person,
+            role=cls.role,
+            seat_membership=cls.membership,
+            seat_public=True,
+        )
+        cls.task2 = Task.objects.create(
+            event=cls.event,
+            person=cls.person2,
+            role=cls.role,
+            seat_membership=cls.membership,
+            seat_public=True,
+        )
+
+        cls.filterset = MembershipTrainingsFilter({})
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # clean up used seats
+        cls.task.delete()
+        cls.task2.delete()
+        cls.event.delete()
+        cls.person.delete()
+        cls.person2.delete()
+        cls.role.delete()
+
+        # clean up memberships
+        cls.member.delete()
+        cls.membership.delete()
+        cls.organization.delete()
+        cls.member2.delete()
+        cls.membership2.delete()
+        cls.organization2.delete()
+
+    def test_fields(self):
+        # Arrange & Act stages happen in setUpClass()
+        # Assert
+        self.assertEqual(
+            set(self.filterset.filters.keys()),
+            {
+                "organization_name",
+                "active_only",
+                "training_seats_only",
+                "nonpositive_remaining_seats_only",
+                "order_by",
+            },
+        )
+
+    def test_filter_active_only(self):
+        # Arrange
+        name = "active_only"
+        value = True
+
+        # Act
+        result = self.filterset.filters[name].filter(self.qs, value)
+
+        # Assert
+        self.assertTrue(self.membership in result)
+        self.assertFalse(self.membership2 in result)
+
+    def test_filter_organization_name(self):
+        # Arrange
+        filter_name = "organization_name"
+        value = "Test Organization"
+
+        # Act
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
+        # Assert
+        self.assertQuerysetEqual(result, [self.membership])
+
+    def test_filter_training_seats_only(self):
+        # Arrange
+        filter_name = "training_seats_only"
+        value = True
+
+        # Act
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
+        # Assert
+        self.assertTrue(self.membership in result)
+        self.assertFalse(self.membership2 in result)
+
+    def test_filter_nonpositive_remaining_seats_only(self):
+        # Arrange
+        filter_name = "nonpositive_remaining_seats_only"
+        value = True
+
+        # Act
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
+        # Assert
+        self.assertTrue(self.membership in result)
+        self.assertFalse(self.membership2 in result)

--- a/amy/fiscal/tests/test_filters.py
+++ b/amy/fiscal/tests/test_filters.py
@@ -139,7 +139,7 @@ class TestMembershipFilter(TestCase):
                 "contribution_type",
                 "active_only",
                 "training_seats_only",
-                "nonpositive_remaining_seats_only",
+                "negative_remaining_seats_only",
                 "order_by",
             },
         )
@@ -203,9 +203,9 @@ class TestMembershipFilter(TestCase):
         self.assertTrue(self.membership in result)
         self.assertFalse(self.membership2 in result)
 
-    def test_filter_nonpositive_remaining_seats_only(self):
+    def test_filter_negative_remaining_seats_only(self):
         # Arrange
-        filter_name = "nonpositive_remaining_seats_only"
+        filter_name = "negative_remaining_seats_only"
         value = True
 
         # Act
@@ -373,7 +373,7 @@ class TestMembershipTrainingsFilter(TestCase):
                 "organization_name",
                 "active_only",
                 "training_seats_only",
-                "nonpositive_remaining_seats_only",
+                "negative_remaining_seats_only",
                 "order_by",
             },
         )
@@ -413,9 +413,9 @@ class TestMembershipTrainingsFilter(TestCase):
         self.assertTrue(self.membership in result)
         self.assertFalse(self.membership2 in result)
 
-    def test_filter_nonpositive_remaining_seats_only(self):
+    def test_filter_negative_remaining_seats_only(self):
         # Arrange
-        filter_name = "nonpositive_remaining_seats_only"
+        filter_name = "negative_remaining_seats_only"
         value = True
 
         # Act

--- a/amy/fiscal/views.py
+++ b/amy/fiscal/views.py
@@ -3,8 +3,8 @@ from typing import Any, Dict
 
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.db.models import Count, F, Prefetch, Q
-from django.db.models.functions import Coalesce, Now
+from django.db.models import Prefetch
+from django.db.models.functions import Now
 from django.forms import modelformset_factory
 from django.urls import reverse, reverse_lazy
 from django.views.generic import FormView
@@ -130,39 +130,7 @@ class AllMemberships(OnlyForAdminsMixin, AMYListView):
     template_name = "fiscal/all_memberships.html"
     filter_class = MembershipFilter
     queryset = (
-        Membership.objects.annotate(
-            instructor_training_seats_total=(
-                # Public
-                F("public_instructor_training_seats")
-                + F("additional_public_instructor_training_seats")
-                # Coalesce returns first non-NULL value
-                + Coalesce("public_instructor_training_seats_rolled_from_previous", 0)
-                # Inhouse
-                + F("inhouse_instructor_training_seats")
-                + F("additional_inhouse_instructor_training_seats")
-                + Coalesce("inhouse_instructor_training_seats_rolled_from_previous", 0)
-            ),
-            instructor_training_seats_remaining=(
-                # Public
-                F("public_instructor_training_seats")
-                + F("additional_public_instructor_training_seats")
-                # Coalesce returns first non-NULL value
-                + Coalesce("public_instructor_training_seats_rolled_from_previous", 0)
-                - Count(
-                    "task", filter=Q(task__role__name="learner", task__seat_public=True)
-                )
-                - Coalesce("public_instructor_training_seats_rolled_over", 0)
-                # Inhouse
-                + F("inhouse_instructor_training_seats")
-                + F("additional_inhouse_instructor_training_seats")
-                + Coalesce("inhouse_instructor_training_seats_rolled_from_previous", 0)
-                - Count(
-                    "task",
-                    filter=Q(task__role__name="learner", task__seat_public=False),
-                )
-                - Coalesce("inhouse_instructor_training_seats_rolled_over", 0)
-            ),
-        )
+        Membership.objects.annotate_with_seat_usage()
         .prefetch_related("organizations")
         .order_by("id")
     )

--- a/amy/reports/views.py
+++ b/amy/reports/views.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from django.contrib import messages
 from django.db.models import Case, Count, F, IntegerField, Prefetch, Q, Value, When
-from django.db.models.functions import Coalesce
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils import timezone
@@ -26,41 +25,8 @@ from workshops.utils.pagination import get_pagination_items
 @admin_required
 def membership_trainings_stats(request):
     """Display basic statistics for memberships and instructor trainings."""
-    data = Membership.objects.prefetch_related("organizations", "task_set").annotate(
-        instructor_training_seats_total=(
-            # Public
-            F("public_instructor_training_seats")
-            + F("additional_public_instructor_training_seats")
-            # Coalesce returns first non-NULL value
-            + Coalesce("public_instructor_training_seats_rolled_from_previous", 0)
-            # Inhouse
-            + F("inhouse_instructor_training_seats")
-            + F("additional_inhouse_instructor_training_seats")
-            # Coalesce returns first non-NULL value
-            + Coalesce("inhouse_instructor_training_seats_rolled_from_previous", 0)
-        ),
-        instructor_training_seats_utilized=(
-            Count("task", filter=Q(task__role__name="learner"))
-        ),
-        instructor_training_seats_remaining=(
-            # Public
-            F("public_instructor_training_seats")
-            + F("additional_public_instructor_training_seats")
-            + Coalesce("public_instructor_training_seats_rolled_from_previous", 0)
-            - Count(
-                "task", filter=Q(task__role__name="learner", task__seat_public=True)
-            )
-            - Coalesce("public_instructor_training_seats_rolled_over", 0)
-            # Inhouse
-            + F("inhouse_instructor_training_seats")
-            + F("additional_inhouse_instructor_training_seats")
-            + Coalesce("inhouse_instructor_training_seats_rolled_from_previous", 0)
-            - Count(
-                "task",
-                filter=Q(task__role__name="learner", task__seat_public=False),
-            )
-            - Coalesce("inhouse_instructor_training_seats_rolled_over", 0)
-        ),
+    data = Membership.objects.annotate_with_seat_usage().prefetch_related(
+        "organizations", "task_set"
     )
 
     filter_ = MembershipTrainingsFilter(request.GET, data)

--- a/amy/templates/fiscal/all_memberships.html
+++ b/amy/templates/fiscal/all_memberships.html
@@ -17,7 +17,7 @@
         <th>Variant</th>
         <th>Dates</th>
         <th>Contribution</th>
-        <th>Remaining public instructor training seats</th>
+        <th>Remaining instructor training seats</th>
         <th class="additional-links"></th>
       </tr>
       {% for membership in all_memberships %}
@@ -40,7 +40,9 @@
           </td>
           <td>{{ membership.agreement_start|date:"Y-m-d" }} &mdash; {{ membership.agreement_end|date:"Y-m-d" }}</td>
           <td>{{ membership.get_contribution_type_display }}</td>
-          <td {% if membership.instructor_training_seats_remaining <= 0 and membership.instructor_training_seats_total > 0 or membership.instructor_training_seats_remaining < 0 and membership.instructor_training_seats_total == 0 %}class="table-danger"{% endif %}>{{ membership.instructor_training_seats_remaining }}</td>
+          <td {% if membership.instructor_training_seats_remaining <= 0 and membership.instructor_training_seats_total > 0 or membership.instructor_training_seats_remaining < 0 and membership.instructor_training_seats_total == 0 %}class="table-danger"{% endif %}>
+            {{ membership.instructor_training_seats_remaining }}
+          </td>
           <td>
             <a href="{% url 'membership_details' membership.pk %}" title="View membership"><i class="fas fa-info-circle"></i></a>
             &nbsp;

--- a/amy/templates/reports/membership_trainings_stats.html
+++ b/amy/templates/reports/membership_trainings_stats.html
@@ -15,14 +15,10 @@
         <th rowspan="2">Variant</th>
         <th rowspan="2">Agreement</th>
         <th rowspan="2">Contribution</th>
-        <th colspan="3" class="text-center">Public instructor training seats</th>
-        <th colspan="3" class="text-center">In-house instructor training seats</th>
+        <th colspan="3" class="text-center">Instructor training seats (combined public and in-house)</th>
         <th rowspan="2" class="additional-links"></th>
       </tr>
       <tr>
-        <th>Total</th>
-        <th>Utilized</th>
-        <th>Remaining</th>
         <th>Total</th>
         <th>Utilized</th>
         <th>Remaining</th>
@@ -36,12 +32,9 @@
         <td>{{ result.get_variant_display }}</td>
         <td>{% human_daterange result.agreement_start result.agreement_end %}</td>
         <td>{{ result.get_contribution_type_display }}</td>
-        <td>{{ result.instructor_training_seats_public_total }}</td>
-        <td>{{ result.instructor_training_seats_public_utilized }}</td>
-        <td>{{ result.instructor_training_seats_public_remaining }}</td>
-        <td>{{ result.instructor_training_seats_inhouse_total }}</td>
-        <td>{{ result.instructor_training_seats_inhouse_utilized }}</td>
-        <td>{{ result.instructor_training_seats_inhouse_remaining }}</td>
+        <td>{{ result.instructor_training_seats_total }}</td>
+        <td>{{ result.instructor_training_seats_utilized }}</td>
+        <td>{{ result.instructor_training_seats_remaining }}</td>
         <td>
           <a href="{% url 'membership_details' result.pk %}" title="View membership"><i class="fas fa-info-circle"></i></a>
         </td>

--- a/amy/workshops/filters.py
+++ b/amy/workshops/filters.py
@@ -126,10 +126,10 @@ class NamesOrderingFilter(django_filters.OrderingFilter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.extra["choices"] += [
-            ("family", "Last name"),
-            ("-family", "Last name (descending)"),
-            ("personal", "First name"),
-            ("-personal", "First name (descending)"),
+            ("lastname", "Last name"),
+            ("-lastname", "Last name (descending)"),
+            ("firstname", "First name"),
+            ("-firstname", "First name (descending)"),
         ]
 
     def filter(self, qs, value):
@@ -139,13 +139,13 @@ class NamesOrderingFilter(django_filters.OrderingFilter):
             return ordering
 
         # `value` is a list
-        if any(v in ["family"] for v in value):
+        if any(v in ["lastname"] for v in value):
             return ordering.order_by("family", "middle", "personal")
-        elif any(v in ["-family"] for v in value):
+        elif any(v in ["-lastname"] for v in value):
             return ordering.order_by("-family", "-middle", "-personal")
-        elif any(v in ["personal"] for v in value):
+        elif any(v in ["firstname"] for v in value):
             return ordering.order_by("personal", "middle", "family")
-        elif any(v in ["-personal"] for v in value):
+        elif any(v in ["-firstname"] for v in value):
             return ordering.order_by("-personal", "-middle", "-family")
 
         return ordering

--- a/amy/workshops/filters.py
+++ b/amy/workshops/filters.py
@@ -126,10 +126,10 @@ class NamesOrderingFilter(django_filters.OrderingFilter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.extra["choices"] += [
-            ("lastname", "Last name"),
-            ("-lastname", "Last name (descending)"),
-            ("firstname", "First name"),
-            ("-firstname", "First name (descending)"),
+            ("family", "Last name"),
+            ("-family", "Last name (descending)"),
+            ("personal", "First name"),
+            ("-personal", "First name (descending)"),
         ]
 
     def filter(self, qs, value):
@@ -139,13 +139,13 @@ class NamesOrderingFilter(django_filters.OrderingFilter):
             return ordering
 
         # `value` is a list
-        if any(v in ["lastname"] for v in value):
+        if any(v in ["family"] for v in value):
             return ordering.order_by("family", "middle", "personal")
-        elif any(v in ["-lastname"] for v in value):
+        elif any(v in ["-family"] for v in value):
             return ordering.order_by("-family", "-middle", "-personal")
-        elif any(v in ["firstname"] for v in value):
+        elif any(v in ["personal"] for v in value):
             return ordering.order_by("personal", "middle", "family")
-        elif any(v in ["-firstname"] for v in value):
+        elif any(v in ["-personal"] for v in value):
             return ordering.order_by("-personal", "-middle", "-family")
 
         return ordering

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -499,6 +499,13 @@ class Membership(models.Model):
         c = self.inhouse_instructor_training_seats_rolled_over or 0
         return a - b - c
 
+    @property
+    def instructor_training_seats_total(self):
+        a = self.inhouse_instructor_training_seats_total
+        b = self.public_instructor_training_seats_total
+        return a + b
+
+
 
 # ------------------------------------------------------------
 

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -499,13 +499,6 @@ class Membership(models.Model):
         c = self.inhouse_instructor_training_seats_rolled_over or 0
         return a - b - c
 
-    @property
-    def instructor_training_seats_total(self):
-        a = self.inhouse_instructor_training_seats_total
-        b = self.public_instructor_training_seats_total
-        return a + b
-
-
 
 # ------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #2327 and introduces tests for membership filters.
Includes combining some columns in the membership training stats view as requested in that issue.