### PR TITLE
bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: flake8
         exclude: (migrations/|urls\.py)
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]


### PR DESCRIPTION
Fixes #2347.
Reference: https://github.com/PyCQA/isort/issues/2077