### PR TITLE
Cache settings are now configurable via envvars

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -3,6 +3,7 @@ Django settings for AMY project.
 """
 
 from pathlib import Path
+from typing import cast
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
@@ -251,14 +252,17 @@ AUTH_PASSWORD_VALIDATORS = [
 # -----------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/2.2/topics/cache/#database-caching
 CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "default_cache_table",
-    },
-    "select2": {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "select2_cache_table",
-    },
+    # For Redis use:
+    # redis://127.0.0.1:6379/0?client_class=django_redis.client.DefaultClient
+    # redis://127.0.0.1:6379/1?client_class=django_redis.client.DefaultClient
+    "default": env.cache_url(
+        "AMY_CACHE_DEFAULT",
+        cast(environ.NoValue, "dbcache://default_cache_table"),
+    ),
+    "select2": env.cache_url(
+        "AMY_CACHE_SELECT2",
+        cast(environ.NoValue, "dbcache://select2_cache_table"),
+    ),
 }
 
 # MIDDLEWARE


### PR DESCRIPTION
This fixes #2350.

Two new envvars can be used: `AMY_CACHE_DEFAULT` and `AMY_CACHE_SELECT2`. They should use URL format, for example `AMY_CACHE_DEFAULT=redis://127.0.0.1:6379/0?client_class=django_redis.client.DefaultClient` for Redis or `AMY_CACHE_SELECT2=dbcache://select2_cache_table` for DB-based.