### PR TITLE
Colors for different builds

### DIFF
--- a/amy/static/css/amy.css
+++ b/amy/static/css/amy.css
@@ -22,6 +22,27 @@ footer {
     font-size: 0.75rem;
 }
 
+.banner {
+    display: block;
+    text-align: center;
+    font-size: 1rem;
+    padding: 0.5em;
+}
+
+.banner-local {
+    color: #222;
+    background-color: #000000;
+    opacity: 0.8;
+    background: repeating-linear-gradient(-45deg, hsl(56, 100%, 50%), hsl(56, 100%, 50%) 30px, hsl(56, 80%, 50%) 30px, hsl(56, 80%, 50%) 60px);
+}
+
+.banner-testing {
+    color: #EEE;
+    background-color: #000000;
+    opacity: 0.9;
+    background: repeating-linear-gradient(-45deg, hsl(0, 100%, 50%), hsl(0, 100%, 50%) 30px, hsl(0, 80%, 50%) 30px, hsl(0, 80%, 50%) 60px);
+}
+
 .sidebar select {
     resize: vertical;
 }

--- a/amy/static/css/amy.css
+++ b/amy/static/css/amy.css
@@ -27,20 +27,25 @@ footer {
     text-align: center;
     font-size: 1rem;
     padding: 0.5em;
+    position: sticky;
+    top: 0;
+    left: 0;
+    height: 40px;
+    z-index: 1020; /* the same as Bootstrap's navbar */
 }
 
 .banner-local {
-    color: #222;
-    background-color: #000000;
-    opacity: 0.8;
-    background: repeating-linear-gradient(-45deg, hsl(56, 100%, 50%), hsl(56, 100%, 50%) 30px, hsl(56, 80%, 50%) 30px, hsl(56, 80%, 50%) 60px);
+    color: #000000;
+    background: linear-gradient(180deg, hsl(56, 100%, 50%), hsl(56, 80%, 50%));
 }
 
 .banner-testing {
-    color: #EEE;
-    background-color: #000000;
-    opacity: 0.9;
-    background: repeating-linear-gradient(-45deg, hsl(0, 100%, 50%), hsl(0, 100%, 50%) 30px, hsl(0, 80%, 50%) 30px, hsl(0, 80%, 50%) 60px);
+    color: #FFFFFF;
+    background: linear-gradient(180deg, hsl(0, 100%, 50%), hsl(0, 80%, 50%));
+}
+
+.navbar-banner-displacement {
+    top: 40px; /* height of .banner */
 }
 
 .sidebar select {

--- a/amy/templates/base.html
+++ b/amy/templates/base.html
@@ -32,6 +32,12 @@
   </head>
   <body>
 
+    {% if SITE_BANNER_STYLE == "local" %}
+    <section class="banner banner-local">This is a local version of AMY.</section>
+    {% elif SITE_BANNER_STYLE == "testing" %}
+    <section class="banner banner-testing">You are on the test version of AMY. Do not use real data. Data may not be persistent.</section>
+    {% endif %}
+
     {% block navbar %}{% endblock navbar %}
     <div class="container-fluid">
       {% block main %}

--- a/amy/templates/navigation.html
+++ b/amy/templates/navigation.html
@@ -1,6 +1,6 @@
 {% load navigation %}
 {% block navbar %}
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top shadow">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top shadow {% if SITE_BANNER_STYLE != 'production' %}navbar-banner-displacement{% endif %}">
       <a class="navbar-brand" href="{% url 'admin-dashboard' %}">AMY</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/amy/workshops/context_processors.py
+++ b/amy/workshops/context_processors.py
@@ -1,5 +1,5 @@
-from django.http import HttpRequest
 from django.conf import settings
+from django.http import HttpRequest
 
 from amy import __version__
 

--- a/amy/workshops/context_processors.py
+++ b/amy/workshops/context_processors.py
@@ -1,8 +1,14 @@
 from django.http import HttpRequest
+from django.conf import settings
 
 from amy import __version__
 
 
 def version(request: HttpRequest) -> dict:
     data = {"amy_version": __version__}
+    return data
+
+
+def site_banner(request: HttpRequest) -> dict:
+    data = {"SITE_BANNER_STYLE": settings.SITE_BANNER_STYLE}
     return data

--- a/config/settings.py
+++ b/config/settings.py
@@ -44,6 +44,7 @@ env = environ.Env(
         "https://workshop-reports.carpentries.org/?key={hash}&slug={slug}",
     ),
     AMY_INSTRUCTOR_RECRUITMENT_ENABLED=(bool, False),
+    AMY_SITE_BANNER=(str, "local"),  # should be "local", "testing", or "production"
 )
 
 # OS environment variables take precedence over variables from .env
@@ -362,6 +363,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 # AMY version
                 "workshops.context_processors.version",
+                "workshops.context_processors.site_banner",
                 # Consent enums
                 "consents.context_processors.terms",
                 # GitHub auth
@@ -610,3 +612,13 @@ REPORTS_LINK = env("AMY_REPORTS_LINK")
 # -----------------------------------------------------------------------------
 # Settings for Instructor Recruitment project
 INSTRUCTOR_RECRUITMENT_ENABLED = env("AMY_INSTRUCTOR_RECRUITMENT_ENABLED")
+
+# Site banner style
+# -----------------------------------------------------------------------------
+# This should show a special banner on all sites so that users are aware of
+# local/dev/test stage they are using.
+SITE_BANNER_STYLE = env("AMY_SITE_BANNER")
+if SITE_BANNER_STYLE not in ("local", "testing", "production"):
+    raise ImproperlyConfigured(
+        "SITE_BANNER_STYLE accepts only one of 'local', 'testing', 'production'."
+    )


### PR DESCRIPTION
This fixes #2322.

There will be 2 banners available: local and testing.

Local looks like this:
![obraz](https://user-images.githubusercontent.com/72821/222916107-fecb4527-f34f-48e2-bc02-037231326f00.png)

Testing looks like this:
![obraz](https://user-images.githubusercontent.com/72821/222916180-2276f91d-d4d9-4e85-9b65-a04671ab9329.png)

Every site will have this banner. It will stay on top, but will hide beneath the navigation bar:
![banner_hides_beneath](https://user-images.githubusercontent.com/72821/222916364-23b9dbca-bf9d-4032-84f5-6d4d2904dce9.gif)

