### PR TITLE
fix 500 error after posting invalid community role

### DIFF
--- a/amy/communityroles/fields.py
+++ b/amy/communityroles/fields.py
@@ -63,7 +63,7 @@ class CustomKeysWidget(forms.TextInput):
             values = data.getlist(name)
         except AttributeError:
             values = data.get(name, [])
-        return list(zip(self.labels, values))
+        return json.dumps(list(zip(self.labels, values)))
 
     def value_omitted_from_data(
         self, data: QueryDict, files: MultiValueDict, name: str

--- a/amy/communityroles/tests/test_community_role_views.py
+++ b/amy/communityroles/tests/test_community_role_views.py
@@ -119,6 +119,26 @@ class TestCommunityRoleUpdateView(TestCommunityRoleMixin, TestBase):
         self.assertEqual(page.status_code, 302)  # should redirect to new object
         self.assertRedirects(page, redirect)
 
+    def test_invalid_form_data_returns_page_with_error(self):
+        """
+        Regression test for issue #2336.
+        """
+        # Arrange
+        url = reverse("communityrole_edit", args=[self.community_role.pk])
+        data = self.data.copy()
+        data.pop(
+            "communityrole-award"
+        )  # creates a validation error as link_to_award is True
+
+        # Act
+        page = self.client.post(url, data)
+
+        # Assert
+        self.assertIn(
+            "Award is required with community role Test Role",
+            page.content.decode("utf-8"),
+        )
+
 
 class TestCommunityRoleDeleteView(TestCommunityRoleMixin, TestBase):
     def setUp(self):


### PR DESCRIPTION
Fixes #2336 (hopefully for good this time). Details in that issue.

This is a production issue, so again a hotfix release would be needed if 4.1 isn't ready to go yet.