### PR TITLE
Add survey links to instructor profile

### DIFF
--- a/amy/templates/dashboard/instructor_dashboard.html
+++ b/amy/templates/dashboard/instructor_dashboard.html
@@ -103,6 +103,7 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
             <th>Dates</th>
             <th>Venue</th>
             <th>Your role</th>
+            <th>Survey results</th>
           </tr>
           {% for task in tasks %}
             <tr>
@@ -114,6 +115,13 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
               <td>{{ task.event.start|date:'Y-m-d' }} &mdash; {{ task.event.end|date:'Y-m-d' }}</td>
               <td>{{ task.event.venue|default:'—' }}</td>
               <td>{{ task.role }}</td>
+              <td>
+                {% if task.event.instructors_pre %}
+                <a href="{{ task.event.instructors_pre}}">Results for {{ task.event }}</a>
+                {% else %}
+                Not available
+                {% endif %}
+              </td>
             </tr>
           {% endfor %}
         </table>

--- a/amy/templates/dashboard/instructor_dashboard.html
+++ b/amy/templates/dashboard/instructor_dashboard.html
@@ -116,7 +116,7 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
               <td>{{ task.event.venue|default:'—' }}</td>
               <td>{{ task.role }}</td>
               <td>
-                {% if task.event.instructors_pre %}
+                {% if task.event.instructors_pre and task.role.name in 'host instructor supporting-instructor' %}
                 <a href="{{ task.event.instructors_pre}}">Results for {{ task.event }}</a>
                 {% else %}
                 Not available

--- a/amy/templates/workshops/person.html
+++ b/amy/templates/workshops/person.html
@@ -139,18 +139,11 @@
       {% with tasks=person.task_set.all %}
       {% if tasks %}
       <table class="table table-sm">
-        <tr><th>Role</th><th>Event</th><th>Survey results</th></tr>
+        <tr><th>Role</th><th>Event</th></tr>
         {% for task in tasks %}
         <tr>
           <td>{{ task.role }}</td>
           <td><a href="{{ task.event.get_absolute_url }}">{{ task.event }}</a></td>
-          <td>
-            {% if task.event.instructors_pre %}
-            <a href="{{ task.event.instructors_pre}}">Results for {{ task.event }}</span></a>
-            {% else %}
-            Not available
-            {% endif %}
-          </td>
         </tr>
         {% endfor %}
       </table>

--- a/amy/templates/workshops/person.html
+++ b/amy/templates/workshops/person.html
@@ -139,11 +139,18 @@
       {% with tasks=person.task_set.all %}
       {% if tasks %}
       <table class="table table-sm">
-        <tr><th>Role</th><th>Event</th></tr>
+        <tr><th>Role</th><th>Event</th><th>Survey results</th></tr>
         {% for task in tasks %}
         <tr>
           <td>{{ task.role }}</td>
           <td><a href="{{ task.event.get_absolute_url }}">{{ task.event }}</a></td>
+          <td>
+            {% if task.event.instructors_pre %}
+            <a href="{{ task.event.instructors_pre}}">Results for {{ task.event }}</span></a>
+            {% else %}
+            Not available
+            {% endif %}
+          </td>
         </tr>
         {% endfor %}
       </table>


### PR DESCRIPTION
Fixes #2016 .

I used the `instructor_pre` field, but we could also use the `reports_link` function to generate the URL on the fly. I chose the former as some events don't seem to have survey links at all (especially older ones) and some point to surveymonkey links. Any thoughts on this?

Side question though: how/when is `instructor_pre` actually set? I assumed it's automatic if we can generate the links automatically, but I can't find it in the code.