### PR TITLE
Reduce hardcoding of consent labels in UI

### DIFF
--- a/amy/consents/admin.py
+++ b/amy/consents/admin.py
@@ -110,7 +110,13 @@ class TermOptionInline(admin.TabularInline):
 
 
 class TermAdmin(ArchiveActionMixin, admin.ModelAdmin):
-    list_display = ("slug", "content", "required_type", "archived_at")
+    list_display = (
+        "slug",
+        "content",
+        "short_description",
+        "required_type",
+        "archived_at",
+    )
     inlines = [
         TermOptionInline,
     ]

--- a/amy/consents/migrations/0007_term_short_description.py
+++ b/amy/consents/migrations/0007_term_short_description.py
@@ -26,20 +26,15 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # add field and make it temporarily nullable
+        # add field
         migrations.AddField(
             model_name="term",
             name="short_description",
-            field=models.CharField(null=True, max_length=100),
+            field=models.CharField(default="", max_length=100),
+            preserve_default=False,
         ),
         # set descriptions for existing terms
         migrations.RunPython(
             set_term_descriptions, reverse_code=migrations.RunPython.noop
-        ),
-        # make field non-nullable
-        migrations.AlterField(
-            model_name="term",
-            name="short_description",
-            field=models.CharField(max_length=100),
         ),
     ]

--- a/amy/consents/migrations/0007_term_short_description.py
+++ b/amy/consents/migrations/0007_term_short_description.py
@@ -1,0 +1,45 @@
+# Written by @elichad 2023-03-15
+
+from django.db import migrations, models
+
+term_descriptions = {
+    "may-contact": "May contact",
+    "public-profile": "Consent to making profile public",
+    "may-publish-name": "Consent to include name when publishing lessons",
+    "privacy-policy": "Privacy policy agreement",
+}
+
+
+def set_term_descriptions(apps, schema_editor):
+    Term = apps.get_model("consents", "Term")
+    for term in Term.objects.all():
+        term.short_description = term_descriptions.get(
+            term.slug, term.slug.replace("-", " ").capitalize()
+        )
+        term.save(update_fields=["short_description"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("consents", "0006_auto_20210614_1234"),
+    ]
+
+    operations = [
+        # add field and make it temporarily nullable
+        migrations.AddField(
+            model_name="term",
+            name="short_description",
+            field=models.CharField(null=True, max_length=100),
+        ),
+        # set descriptions for existing terms
+        migrations.RunPython(
+            set_term_descriptions, reverse_code=migrations.RunPython.noop
+        ),
+        # make field non-nullable
+        migrations.AlterField(
+            model_name="term",
+            name="short_description",
+            field=models.CharField(max_length=100),
+        ),
+    ]

--- a/amy/consents/models.py
+++ b/amy/consents/models.py
@@ -12,7 +12,7 @@ from django.utils.functional import cached_property
 from autoemails.mixins import RQJobsMixin
 from consents.exceptions import TermOptionDoesNotBelongToTermException
 from workshops.mixins import CreatedUpdatedArchivedMixin
-from workshops.models import STR_MED, Person
+from workshops.models import STR_LONG, STR_MED, Person
 
 
 class TermQuerySet(QuerySet):
@@ -71,6 +71,7 @@ class Term(CreatedUpdatedArchivedMixin, RQJobsMixin, models.Model):
         max_length=STR_MED, choices=TERM_REQUIRE_TYPE, default=OPTIONAL_REQUIRE_TYPE
     )
     help_text = models.TextField(verbose_name="Help Text", blank=True)
+    short_description = models.CharField(max_length=STR_LONG)
     objects = TermManager.from_queryset(TermQuerySet)()
 
     @staticmethod

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -17,7 +17,7 @@ from django_comments.models import Comment
 from autoemails.utils import safe_next_or_default_url
 from communityroles.models import CommunityRole
 from consents.forms import TermBySlugsForm
-from consents.models import Consent, TermEnum
+from consents.models import Consent, Term, TermEnum
 from dashboard.filters import UpcomingTeachingOpportunitiesFilter
 from dashboard.forms import (
     AssignmentForm,
@@ -144,8 +144,17 @@ def instructor_dashboard(request):
         .select_related("term", "term_option")
     )
     consents_by_key = {consent.term.key: consent for consent in consents}
+    # get display content for all visible terms
+    consents_content = {
+        term.key: term.content for term in Term.objects.filter(slug__in=TERM_SLUGS)
+    }
 
-    context = {"title": "Your profile", "user": user, "consents": consents_by_key}
+    context = {
+        "title": "Your profile",
+        "user": user,
+        "consents": consents_by_key,
+        "consents_content": consents_content,
+    }
     return render(request, "dashboard/instructor_dashboard.html", context)
 
 

--- a/amy/templates/dashboard/instructor_dashboard.html
+++ b/amy/templates/dashboard/instructor_dashboard.html
@@ -37,15 +37,15 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
       </th><td>{{ user.secondary_email|default:"—" }}</td></tr>
     <tr><th>Gender:</th><td>{{ user.get_gender_display }}{{ user.gender_other }}</td></tr>
     <tr>
-      <th>Can we contact you?</th>
+      <th>{{ consents_content.may_contact }}</th>
       <td>{% if consents.may_contact %}{{ consents.may_contact.term_option }}{% else %}Unset{% endif %}</td>
     </tr>
     <tr>
-      <th>Do you consent to publish your profile<br>on The Carpentries website?</th>
+      <th>{{ consents_content.public_profile }}</th>
       <td>{% if consents.public_profile %}{{ consents.public_profile.term_option }}{% else %}Unset{% endif %}</td>
     </tr>
     <tr>
-      <th>Do you consent to have your name or identity<br>associated with lesson publications?</th>
+      <th>{{ consents_content.may_publish_name }}</th>
       <td>{% if consents.may_publish_name %}{{ consents.may_publish_name.term_option }}{% else %}Unset{% endif %}</td>
     </tr>
     <tr><th>Country:</th><td>{% if user.country %}{% include "includes/country_flag.html" with country=user.country %}{% else %}—{% endif %}</td></tr>

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -274,15 +274,10 @@ class PersonDetails(OnlyForAdminsMixin, AMYDetailView):
             .active()
             .select_related("term", "term_option")
         )
-        consent_by_term_slug = {consent.term.slug: consent for consent in consents}
-        context["consents"] = {
-            "May contact": consent_by_term_slug[TermEnum.MAY_CONTACT],
-            "Consent to publish profile": consent_by_term_slug[TermEnum.PUBLIC_PROFILE],
-            "Consent to include name when publishing lessons": consent_by_term_slug[
-                TermEnum.MAY_PUBLISH_NAME
-            ],
-            "Privacy policy agreement": consent_by_term_slug[TermEnum.PRIVACY_POLICY],
+        consent_by_description = {
+            consent.term.short_description: consent for consent in consents
         }
+        context["consents"] = consent_by_description
         if not self.object.is_active:
             messages.info(self.request, f"{title} is not active.")
         return context

--- a/docs/amy_database_structure.md
+++ b/docs/amy_database_structure.md
@@ -234,6 +234,7 @@ When `Terms` are archived (`archived_at` timestamp is set), that `Term`'s `TermO
 * `content` content of the term. This text shown to users when they consent.
 * `required_type` determines whether or not a term is considered required for the user or not. If required it will be shown to the user when they log in to consent to.
 * `help_text` additional text shown to the user in order to give more context on the term.
+* `short_description` a short description of the consent, shown in the admin view of a profile
 
 ### TermOption
 

--- a/docs/users_guide/admin_index.md
+++ b/docs/users_guide/admin_index.md
@@ -131,8 +131,8 @@ This will take you to a screen where you can verify each record, correct any err
 AMY asks all users to consent or agree to the following:
 
 * **I have read and agree to the data privacy policy of The Carpentries.**
-* **May contact**
-* **Consent to making profile public**
+* **Can we contact you for volunteering opportunities, surveys, feedback, etc.?**
+* **Do you consent to publish your profile on The Carpentries website?**
 * **Do you consent to have your name or identity associated with lesson publications?**
 
 By default, all consents have null values (i.e., neither yes nor no). After a Person's record has been created, the individual can log in to AMY and edit their own consents. Admin users may also make these edits on behalf of the user, but this should be used only in rare circumstances. Consents are edited in a separate tab in the Person view. 

--- a/docs/users_guide/community_index.md
+++ b/docs/users_guide/community_index.md
@@ -33,7 +33,7 @@ The Carpentries can maintain the following information about individuals in our 
 * Consents (*Note consents can be changed by the individual at any time*)
     * Do you consent to have your name or identity associated with lesson publications?
     * Can we contact you for volunteering opportunities, surveys, feedback, etc.?
-    * Consent to making profile public
+    * Do you consent to publish your profile on The Carpentries website?
 
 
 ### Additional user information


### PR DESCRIPTION
Fixes #2302 .

Also propose updating the `content` field of the `public-profile` consent to "Do you consent to publish your profile
on The Carpentries website?" in the AMY Django admin interface.