### PR TITLE
Feature/1993 display consents history

### DIFF
--- a/amy/static/css/amy.css
+++ b/amy/static/css/amy.css
@@ -76,6 +76,11 @@ table .table-row-distinctive {
     border-top: 4px solid #dee2e6 !important;
 }
 
+caption {
+    caption-side: top;
+    color: #000000;
+}
+
 .form-group small {
     font-size: 0.8rem;
 }

--- a/amy/templates/workshops/person_edit_form.html
+++ b/amy/templates/workshops/person_edit_form.html
@@ -119,6 +119,32 @@
       <p>No Terms.</p>
     {% endif %}
 
+    {% if consents %}
+    <table class="table table-striped">
+      <caption><h2>All consents</h2></caption>
+      <thead>
+        <tr>
+          <th>Term</th>
+          <th>Option</th>
+          <th>Date created</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for consent in consents %}
+        <tr>
+          <td>{{ consent.term.content }}</td>
+          <td>{{ consent.term_option }}</td>
+          <td>{{ consent.created_at }}</td>
+          <td>{% if consent.is_active %}Active{% else %}Archived at {{ consent.archived_at }}{% endif %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p>No consents set.</p>
+    {% endif %}
+
   </div>
   <div class="tab-pane" role="tabpanel" aria-labelledby="communityroles-tab" id="communityroles">
     {% if perms.communityroles.add_communityroles %}

--- a/amy/templates/workshops/person_edit_form.html
+++ b/amy/templates/workshops/person_edit_form.html
@@ -29,6 +29,7 @@
 
     {% if awards %}
     <table class="table table-striped">
+      <caption><h2>All awards</h2></caption>
       <thead>
         <tr>
           <th>Badge</th>
@@ -72,6 +73,7 @@
 
     {% if tasks %}
     <table class="table table-striped">
+      <caption><h2>All tasks</h2></caption>
       <tr>
         <th>Event</th>
         <th>URL</th>
@@ -155,6 +157,7 @@
 
     {% if community_roles %}
     <table class="table table-striped">
+      <caption><h2>All community roles</h2></caption>
       <tr>
         <th>Role</th>
         <th>Dates</th>

--- a/amy/templates/workshops/person_edit_form.html
+++ b/amy/templates/workshops/person_edit_form.html
@@ -133,10 +133,10 @@
       <tbody>
         {% for consent in consents %}
         <tr>
-          <td>{{ consent.term.content }}</td>
+          <td>{{ consent.term.short_description }}</td>
           <td>{{ consent.term_option }}</td>
           <td>{{ consent.created_at }}</td>
-          <td>{% if consent.is_active %}Active{% else %}Archived at {{ consent.archived_at }}{% endif %}</td>
+          <td>{% if consent.is_active %}Active{% else %}Archived {{ consent.archived_at }}{% endif %}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -621,6 +621,9 @@ class PersonUpdate(OnlyForAdminsMixin, UserPassesTestMixin, AMYUpdateView):
                 "tasks": self.object.task_set.select_related("role", "event").order_by(
                     "-event__slug"
                 ),
+                "consents": self.object.consent_set.select_related("term").order_by(
+                    "-archived_at"
+                ),
                 "consents_form": ActiveTermConsentsForm(
                     form_tag=False,
                     prefix="consents",


### PR DESCRIPTION
Fixes #1993 (not as envisioned, but in the most practical way).

Also adds captions for the tables in the person edit form, in line with [accessibility best practices](https://www.w3.org/WAI/tutorials/tables/caption-summary/).

![Screenshot of consents update form followed by table captioned 'All consents', which lists the term, option, creation date, and status for each consent](https://user-images.githubusercontent.com/20683271/229826411-6edfe5d5-45aa-4aa5-90e3-005ebdf9e4f1.png)
