### PR TITLE
Set default filtering for training requests

### DIFF
--- a/amy/extrequests/filters.py
+++ b/amy/extrequests/filters.py
@@ -2,6 +2,7 @@ import re
 
 from django.db.models import Q
 from django.forms import widgets
+from django.http import QueryDict
 import django_filters
 
 from extrequests.models import SelfOrganisedSubmission, WorkshopInquiryRequest
@@ -22,6 +23,16 @@ from workshops.models import Curriculum, Person, TrainingRequest, WorkshopReques
 
 
 class TrainingRequestFilter(AMYFilterSet):
+    def __init__(self, data=None, *args, **kwargs):
+        # if no filters are set, use a default
+        # avoids handling the full list of training requests
+        # client-side unless the user deliberately chooses to
+        # see https://github.com/carpentries/amy/issues/2314
+        if not data:
+            data = QueryDict("state=no_d&matched=u")
+
+        super().__init__(data, *args, **kwargs)
+
     search = django_filters.CharFilter(
         label="Name or Email",
         method="filter_by_person",

--- a/amy/extrequests/filters.py
+++ b/amy/extrequests/filters.py
@@ -24,10 +24,10 @@ from workshops.models import Curriculum, Person, TrainingRequest, WorkshopReques
 
 class TrainingRequestFilter(AMYFilterSet):
     def __init__(self, data=None, *args, **kwargs):
-        # if no filters are set, use a default
-        # avoids handling the full list of training requests
-        # client-side unless the user deliberately chooses to
-        # see https://github.com/carpentries/amy/issues/2314
+        # If no filters are set, use some default settings.
+        # This avoids handling the full list of training requests
+        # client-side unless the user deliberately chooses to do so.
+        # See https://github.com/carpentries/amy/issues/2314
         if not data:
             data = QueryDict("state=no_d&matched=u")
 

--- a/amy/extrequests/tests/test_training_request.py
+++ b/amy/extrequests/tests/test_training_request.py
@@ -290,7 +290,32 @@ class TestTrainingRequestsListView(TestBase):
         self.second_training.tags.add(self.ttt)
 
     def test_view_loads(self):
+        """
+        View should default to settings:
+            state=no_d (Pending or accepted)
+            matched=u (Unmatched)
+        """
+        # Act
         rv = self.client.get(reverse("all_trainingrequests"))
+
+        # Assert
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(
+            set(rv.context["requests"]),
+            {self.second_req},
+        )
+
+    def test_view_loads_all_on_request(self):
+        """
+        Explicitly setting state and matched to null should return all requests.
+        """
+        # Arrange
+        query_string = "state=&matched="
+
+        # Act
+        rv = self.client.get(reverse("all_trainingrequests"), QUERY_STRING=query_string)
+
+        # Assert
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(
             set(rv.context["requests"]),


### PR DESCRIPTION
Fixes #2315.
Stopgap for #2314 - the filtered view still performs a bit slowly on the full AMY database ([link](https://amy.carpentries.org/requests/training_requests/?search=&group_name=&state=no_d&matched=u&affiliation=&location=&order_by=)), but it shouldn't be catastrophic any more.

This implementation only sets the defaults if the user has chosen not to filter at all - i.e. it is still possible to see all training requests by explicitly selecting the blank options for these fields in the filter UI (or setting the URL query string to `?state=&matched=`)
Note that setting defaults for requests that do include user-selected filter choices is [not recommended](https://django-filter.readthedocs.io/en/main/guide/tips.html?highlight=default#using-initial-values-as-defaults).