### PR TITLE
Update instructor eligibility requirements with Get Involved step

### DIFF
--- a/amy/dashboard/tests/test_instructor_dashboard.py
+++ b/amy/dashboard/tests/test_instructor_dashboard.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.urls import reverse
 
+from trainings.models import Involvement
 from workshops.models import Award, Person, TrainingProgress, TrainingRequirement
 from workshops.tests.base import TestBase
 
@@ -57,19 +58,30 @@ class TestInstructorStatus(TestBase):
         self.assertNotContains(rv, "Congratulations, you're certified")
 
     def test_eligible_but_not_awarded(self):
-        """Test what is dispslayed when a trainee is eligible to be certified
-        as an SWC/DC Instructor, but doesn't have appropriate badge awarded
+        """Test what is displayed when a trainee is eligible to be certified
+        as an Instructor, but doesn't have appropriate badge awarded
         yet."""
         requirements = [
             "Training",
-            "Lesson Contribution",
+            "Get Involved",
             "Welcome Session",
             "Demo",
         ]
         for requirement in requirements:
+            if requirement == "Get Involved":
+                involvement = Involvement.objects.get(name="GitHub Contribution")
+                date = datetime.today()
+                url = "https://example.com"
+            else:
+                involvement = None
+                date = None
+                url = None
             TrainingProgress.objects.create(
                 trainee=self.admin,
                 requirement=TrainingRequirement.objects.get(name=requirement),
+                involvement_type=involvement,
+                date=date,
+                url=url,
             )
 
         admin = Person.objects.annotate_with_instructor_eligibility().get(

--- a/amy/templates/includes/training_progresses_inline.html
+++ b/amy/templates/includes/training_progresses_inline.html
@@ -11,12 +11,6 @@
   </a>
   &nbsp;
 {% endfor %}
-{% if person.training_tasks %}
 <a href="{% url 'trainingprogress_add' %}?trainee={{ person.id|urlencode }}&amp;next={{ request.get_full_path|urlencode }}"
    class="badge badge-secondary"
    data-toggle="popover" data-content="Click to add new progress" data-trigger="hover">+</a>
-{% else %}
-<a class="badge badge-secondary disabled"
-   data-toggle="popover"
-   data-content="It's not possible to add training progress to a trainee without any training task." data-trigger="hover">+</a>
-{% endif %}

--- a/amy/trainings/forms.py
+++ b/amy/trainings/forms.py
@@ -1,6 +1,5 @@
 from crispy_forms.layout import Layout
 from django import forms
-from django.core.exceptions import ValidationError
 from django.forms import CharField, RadioSelect, TextInput
 
 from trainings.models import Involvement
@@ -79,28 +78,6 @@ class TrainingProgressForm(forms.ModelForm):
     class Media:
         js = ("trainingprogress_form.js",)
 
-    def clean(self):
-        cleaned_data = super().clean()
-
-        trainee = cleaned_data.get("trainee")
-
-        # check if trainee has at least one training task
-        training_tasks = trainee.get_training_tasks()
-
-        if not training_tasks:
-            raise ValidationError(
-                "It's not possible to add training progress "
-                "to a trainee without any training task."
-            )
-
-        errors = dict()
-
-        # TODO: validation based on url_required in Involvement, etc
-
-        # raise errors if any present
-        if errors:
-            raise ValidationError(errors)
-
 
 class BulkAddTrainingProgressForm(forms.ModelForm):
     event = forms.ModelChoiceField(
@@ -148,19 +125,3 @@ class BulkAddTrainingProgressForm(forms.ModelForm):
             "state": RadioSelect,
             "notes": TextInput,
         }
-
-    def clean(self):
-        cleaned_data = super().clean()
-
-        trainees = cleaned_data.get("trainees", [])
-
-        # check if all trainees have at least one training task
-        for trainee in trainees:
-            training_tasks = trainee.get_training_tasks()
-
-            if not training_tasks:
-                raise ValidationError(
-                    "It's not possible to add training "
-                    "progress to a trainee without any "
-                    "training task."
-                )

--- a/amy/trainings/tests/test_trainees.py
+++ b/amy/trainings/tests/test_trainees.py
@@ -4,6 +4,7 @@ from functools import partial
 from django.urls import reverse
 
 from trainings.filters import filter_trainees_by_instructor_status
+from trainings.models import Involvement
 from trainings.views import all_trainees_queryset
 from workshops.models import (
     Award,
@@ -94,12 +95,15 @@ class TestFilterTraineesByInstructorStatus(TestBase):
         self.demo, _ = TrainingRequirement.objects.get_or_create(
             name="Demo", defaults={"url_required": True}
         )
-        self.lesson_contribution, _ = TrainingRequirement.objects.get_or_create(
-            name="Lesson Contribution", defaults={}
+        self.get_involved, _ = TrainingRequirement.objects.get_or_create(
+            name="Get Involved", defaults={}
         )
 
         self.welcome = TrainingRequirement.objects.get(name="Welcome Session")
         self.training = TrainingRequirement.objects.get(name="Training")
+        self.involvement, _ = Involvement.objects.get_or_create(
+            name="Test Involvement", defaults={}
+        )
 
     def _setUpInstructors(self):
         # prepare data
@@ -160,7 +164,9 @@ class TestFilterTraineesByInstructorStatus(TestBase):
                 ),
                 TrainingProgress(
                     trainee=self.trainee1,
-                    requirement=self.lesson_contribution,
+                    requirement=self.get_involved,
+                    involvement_type=self.involvement,
+                    date=date(2023, 6, 1),
                     state="p",
                 ),
                 TrainingProgress(
@@ -191,7 +197,9 @@ class TestFilterTraineesByInstructorStatus(TestBase):
                 ),
                 TrainingProgress(
                     trainee=self.trainee2,
-                    requirement=self.lesson_contribution,
+                    requirement=self.get_involved,
+                    involvement_type=self.involvement,
+                    date=date(2023, 6, 1),
                     state="p",
                 ),
                 TrainingProgress(
@@ -226,7 +234,9 @@ class TestFilterTraineesByInstructorStatus(TestBase):
                 ),
                 TrainingProgress(
                     trainee=self.trainee3,
-                    requirement=self.lesson_contribution,
+                    requirement=self.get_involved,
+                    involvement_type=self.involvement,
+                    date=date(2023, 6, 1),
                     state="p",
                 ),
                 TrainingProgress(
@@ -295,7 +305,7 @@ class TestFilterTraineesByInstructorStatus(TestBase):
                 is_instructor=0,
                 passed_training=1,
                 passed_welcome=1,
-                passed_lesson_contribution=1,
+                passed_get_involved=1,
                 passed_demo=1,
                 instructor_eligible=1,
             ),
@@ -305,7 +315,7 @@ class TestFilterTraineesByInstructorStatus(TestBase):
                 is_instructor=4,
                 passed_training=1,
                 passed_welcome=1,
-                passed_lesson_contribution=1,
+                passed_get_involved=1,
                 passed_demo=1,
                 instructor_eligible=1,
             ),
@@ -315,7 +325,7 @@ class TestFilterTraineesByInstructorStatus(TestBase):
                 is_instructor=0,
                 passed_training=1,
                 passed_welcome=0,
-                passed_lesson_contribution=1,
+                passed_get_involved=1,
                 passed_demo=1,
                 instructor_eligible=0,
             ),

--- a/amy/trainings/tests/test_training_progress.py
+++ b/amy/trainings/tests/test_training_progress.py
@@ -263,29 +263,15 @@ class TestTrainingProgressValidation(TestBase):
         with self.assertValidationErrors(["notes"]):
             failed_progress_no_notes.full_clean()
 
-    def test_form_invalid_if_trainee_has_no_training_task(self):
+    def test_form_valid_if_trainee_has_no_training_task(self):
+        """Regression test for https://github.com/carpentries/amy/issues/2440"""
         data = {
             "requirement": self.requirement.pk,
             "state": "p",
             "trainee": self.ironman.pk,
         }
         form = TrainingProgressForm(data)
-        self.assertEqual(form.is_valid(), False)
-        self.assertIn(
-            "not possible to add training progress", form.non_field_errors()[0]
-        )
-
-    def test_form_with_failed_status_requires_notes(self):
-        data = {
-            "requirement": self.requirement.pk,
-            "state": "p",
-            "trainee": self.ironman.pk,
-        }
-        form = TrainingProgressForm(data)
-        self.assertEqual(form.is_valid(), False)
-        self.assertIn(
-            "not possible to add training progress", form.non_field_errors()[0]
-        )
+        self.assertEqual(form.is_valid(), True)
 
 
 class TestProgressLabelTemplateTag(TestBase):

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -658,11 +658,9 @@ class PersonManager(BaseUserManager):
                 )
             )
 
-        LESSON_CONTRIBUTION_NAMES = ["Lesson Contribution"]
-
         return self.annotate(
             passed_training=passed("Training"),
-            passed_lesson_contribution=passed_either(*LESSON_CONTRIBUTION_NAMES),
+            passed_get_involved=passed("Get Involved"),
             passed_welcome=passed("Welcome Session"),
             passed_demo=passed("Demo"),
         ).annotate(
@@ -673,7 +671,7 @@ class PersonManager(BaseUserManager):
             instructor_eligible=(
                 F("passed_training")
                 * F("passed_welcome")
-                * F("passed_lesson_contribution")
+                * F("passed_get_involved")
                 * F("passed_demo")
             )
         )
@@ -970,7 +968,7 @@ class Person(
         """
         fields = [
             ("passed_training", "Training"),
-            ("passed_lesson_contribution", "Lesson Contribution"),
+            ("passed_get_involved", "Get Involved"),
             ("passed_welcome", "Welcome Session"),
             ("passed_demo", "Demo"),
         ]

--- a/amy/workshops/tests/test_person.py
+++ b/amy/workshops/tests/test_person.py
@@ -14,6 +14,7 @@ import webtest
 from webtest.forms import Upload
 
 from consents.models import Consent, Term, TermEnum
+from trainings.models import Involvement
 from workshops.filters import filter_taught_workshops
 from workshops.forms import PersonForm, PersonsMergeForm
 from workshops.mixins import GenderMixin
@@ -1292,12 +1293,15 @@ class TestGetMissingInstructorRequirements(TestBase):
     def setUp(self):
         self.person = Person.objects.create(username="person")
         self.training = TrainingRequirement.objects.get(name="Training")
-        self.lesson_contribution, _ = TrainingRequirement.objects.get_or_create(
-            name="Lesson Contribution", defaults={"url_required": True}
+        self.get_involved, _ = TrainingRequirement.objects.get_or_create(
+            name="Get Involved", defaults={"involvement_required": True}
         )
         self.welcome = TrainingRequirement.objects.get(name="Welcome Session")
         self.demo, _ = TrainingRequirement.objects.get_or_create(
             name="Demo", defaults={}
+        )
+        self.involvement, _ = Involvement.objects.get_or_create(
+            name="Test Involvement", defaults={}
         )
 
     def test_all_requirements_satisfied(self):
@@ -1305,7 +1309,11 @@ class TestGetMissingInstructorRequirements(TestBase):
             trainee=self.person, state="p", requirement=self.training
         )
         TrainingProgress.objects.create(
-            trainee=self.person, state="p", requirement=self.lesson_contribution
+            trainee=self.person,
+            state="p",
+            requirement=self.get_involved,
+            involvement_type=self.involvement,
+            date=date(2023, 5, 1),
         )
         TrainingProgress.objects.create(
             trainee=self.person, state="p", requirement=self.welcome
@@ -1320,12 +1328,20 @@ class TestGetMissingInstructorRequirements(TestBase):
         self.assertEqual(person.get_missing_instructor_requirements(), [])
 
     def test_some_requirements_are_fulfilled(self):
-        # Lesson Contribution was accepted, the second time.
+        # Get Involved was accepted, the second time.
         TrainingProgress.objects.create(
-            trainee=self.person, state="f", requirement=self.lesson_contribution
+            trainee=self.person,
+            state="f",
+            requirement=self.get_involved,
+            involvement_type=self.involvement,
+            date=date(2023, 5, 1),
         )
         TrainingProgress.objects.create(
-            trainee=self.person, state="p", requirement=self.lesson_contribution
+            trainee=self.person,
+            state="p",
+            requirement=self.get_involved,
+            involvement_type=self.involvement,
+            date=date(2023, 6, 1),
         )
         # Not passed progress should be ignored.
         TrainingProgress.objects.create(
@@ -1349,7 +1365,7 @@ class TestGetMissingInstructorRequirements(TestBase):
         )
         self.assertEqual(
             person.get_missing_instructor_requirements(),
-            ["Training", "Lesson Contribution", "Welcome Session", "Demo"],
+            ["Training", "Get Involved", "Welcome Session", "Demo"],
         )
 
 


### PR DESCRIPTION
In the interest of time, I'm raising this not against `feature/instructor-checkout-changes` but instead against the branch used in https://github.com/carpentries/amy/pull/2431 for review. Will not merge until https://github.com/carpentries/amy/pull/2431 is merged.

Fixes #2440.

This PR will:
- use 'Get Involved' rather than 'Lesson Contribution' when checking instructor badge eligibility and in all relevant tests (screenshot 1)
- allow TrainingProgress to be created for trainees without a training task (screenshot 2)
- fix the `test_eligible_but_not_awarded` test in `amy/dashboard/tests/test_instructor_dashboard.py` which was broken by #2431 
- break a different test `test_lesson_contribution_passed` in `amy/dashboard/tests/test_instructor_dashboard.py` which will be fixed as part of #2411

![Screenshot showing two trainees eligible for instructor badge](https://github.com/carpentries/amy/assets/20683271/e09f1ab8-0b3b-4b30-aae5-4248a68d353e)
![Screenshot of trainee with passed Welcome Session and no training task](https://github.com/carpentries/amy/assets/20683271/26b115d0-dfd1-4aae-a16c-8218d19913c0)


