### PR TITLE
Update bulk training progress form to work with Get Involved step

### DIFF
--- a/amy/trainings/forms.py
+++ b/amy/trainings/forms.py
@@ -118,6 +118,13 @@ class BulkAddTrainingProgressForm(forms.ModelForm):
         required=True,
     )
 
+    involvement_type = forms.ModelChoiceField(
+        label="Type of involvement",
+        required=False,
+        queryset=Involvement.objects.default_order().filter(archived_at__isnull=True),
+        widget=RadioSelect(),
+    )
+
     helper = BootstrapHelper(
         additional_form_class="training-progress",
         submit_label="Add",
@@ -129,8 +136,10 @@ class BulkAddTrainingProgressForm(forms.ModelForm):
         # the template where this form is used
         "requirement",
         "state",
+        "involvement_type",
         "event",
         "url",
+        "date",
         "notes",
     )
 
@@ -140,14 +149,19 @@ class BulkAddTrainingProgressForm(forms.ModelForm):
             # no 'trainees'
             "requirement",
             "state",
+            "involvement_type",
             "event",
             "url",
+            "date",
             "notes",
         ]
         widgets = {
             "state": RadioSelect,
             "notes": TextInput,
         }
+
+    class Media:
+        js = ("trainingprogress_form.js",)
 
     def clean(self):
         cleaned_data = super().clean()

--- a/amy/trainings/tests/test_trainees.py
+++ b/amy/trainings/tests/test_trainees.py
@@ -4,6 +4,7 @@ from functools import partial
 from django.urls import reverse
 
 from trainings.filters import filter_trainees_by_instructor_status
+from trainings.models import Involvement
 from trainings.views import all_trainees_queryset
 from workshops.models import (
     Award,
@@ -27,10 +28,14 @@ class TestTraineesView(TestBase):
         self._setUpRoles()
 
         self.training = TrainingRequirement.objects.get(name="Training")
-        self.lesson_contribution, _ = TrainingRequirement.objects.get_or_create(
-            name="Lesson Contribution", defaults={"url_required": True}
+        self.get_involved, _ = TrainingRequirement.objects.get_or_create(
+            name="Get Involved", defaults={"involvement_required": True}
         )
         self.welcome = TrainingRequirement.objects.get(name="Welcome Session")
+        self.demo = TrainingRequirement.objects.get(name="Demo")
+        self.involvement, _ = Involvement.objects.get_or_create(
+            name="GitHub Contribution", defaults={"url_required": True}
+        )
 
         self.ttt_event = Event.objects.create(
             start=datetime(2018, 7, 14),
@@ -39,11 +44,23 @@ class TestTraineesView(TestBase):
         )
         self.ttt_event.tags.add(Tag.objects.get(name="TTT"))
 
+        # add some training tasks
+        self.ironman.task_set.create(
+            event=self.ttt_event,
+            role=Role.objects.get(name="learner"),
+        )
+        self.spiderman.task_set.create(
+            event=self.ttt_event,
+            role=Role.objects.get(name="learner"),
+        )
+
     def test_view_loads(self):
         rv = self.client.get(reverse("all_trainees"))
         self.assertEqual(rv.status_code, 200)
 
-    def test_bulk_add_progress(self):
+    def test_bulk_add_progress__welcome(self):
+        # Arrange
+        # create a pre-existing progress to ensure bulk adding doesn't interfere
         TrainingProgress.objects.create(
             trainee=self.spiderman, requirement=self.welcome, state="n"
         )
@@ -54,22 +71,15 @@ class TestTraineesView(TestBase):
             "submit": "",
         }
 
-        # all trainees need to have a training task to assign a training
-        # progress to them
-        self.ironman.task_set.create(
-            event=self.ttt_event,
-            role=Role.objects.get(name="learner"),
-        )
-        self.spiderman.task_set.create(
-            event=self.ttt_event,
-            role=Role.objects.get(name="learner"),
-        )
-
+        # Act
         rv = self.client.post(reverse("all_trainees"), data, follow=True)
 
+        # Assert
+        self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.resolver_match.view_name, "all_trainees")
         msg = "Successfully changed progress of all selected trainees."
         self.assertContains(rv, msg)
+
         got = set(
             TrainingProgress.objects.values_list("trainee", "requirement", "state")
         )
@@ -77,6 +87,111 @@ class TestTraineesView(TestBase):
             (self.spiderman.pk, self.welcome.pk, "n"),
             (self.spiderman.pk, self.welcome.pk, "a"),
             (self.ironman.pk, self.welcome.pk, "a"),
+        }
+        self.assertEqual(got, expected)
+
+    def test_bulk_add_progress__training(self):
+        # Arrange
+        # create a pre-existing progress to ensure bulk adding doesn't interfere
+        TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.training, state="n"
+        )
+        data = {
+            "trainees": [self.spiderman.pk, self.ironman.pk],
+            "requirement": self.training.pk,
+            "state": "a",
+            "event": self.ttt_event.pk,
+            "submit": "",
+        }
+
+        # Act
+        rv = self.client.post(reverse("all_trainees"), data, follow=True)
+
+        # Assert
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.resolver_match.view_name, "all_trainees")
+        msg = "Successfully changed progress of all selected trainees."
+        self.assertContains(rv, msg)
+
+        got = set(
+            TrainingProgress.objects.values_list("trainee", "requirement", "state")
+        )
+        expected = {
+            (self.spiderman.pk, self.training.pk, "n"),
+            (self.spiderman.pk, self.training.pk, "a"),
+            (self.ironman.pk, self.training.pk, "a"),
+        }
+        self.assertEqual(got, expected)
+
+    def test_bulk_add_progress__demo(self):
+        # Arrange
+        # create a pre-existing progress to ensure bulk adding doesn't interfere
+        TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.demo, state="n"
+        )
+        data = {
+            "trainees": [self.spiderman.pk, self.ironman.pk],
+            "requirement": self.demo.pk,
+            "state": "a",
+            "submit": "",
+        }
+
+        # Act
+        rv = self.client.post(reverse("all_trainees"), data, follow=True)
+
+        # Assert
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.resolver_match.view_name, "all_trainees")
+        msg = "Successfully changed progress of all selected trainees."
+        self.assertContains(rv, msg)
+
+        got = set(
+            TrainingProgress.objects.values_list("trainee", "requirement", "state")
+        )
+        expected = {
+            (self.spiderman.pk, self.demo.pk, "n"),
+            (self.spiderman.pk, self.demo.pk, "a"),
+            (self.ironman.pk, self.demo.pk, "a"),
+        }
+        self.assertEqual(got, expected)
+
+    def test_bulk_add_progress__get_involved(self):
+        # Arrange
+        # create a pre-existing progress to ensure bulk adding doesn't interfere
+        TrainingProgress.objects.create(
+            trainee=self.spiderman,
+            requirement=self.get_involved,
+            state="n",
+            involvement_type=self.involvement,
+            url="https://example.org",
+            date=date(2022, 5, 3),
+        )
+        data = {
+            "trainees": [self.spiderman.pk, self.ironman.pk],
+            "requirement": self.get_involved.pk,
+            "state": "a",
+            "involvement_type": self.involvement.pk,
+            "url": "https://example.org",
+            "date": "2023-6-21",
+            "submit": "",
+        }
+
+        # Act
+        rv = self.client.post(reverse("all_trainees"), data, follow=True)
+
+        # Assert
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.resolver_match.view_name, "all_trainees")
+        msg = "Successfully changed progress of all selected trainees."
+        self.assertContains(rv, msg)
+
+        got = set(
+            TrainingProgress.objects.values_list("trainee", "requirement", "state")
+        )
+        expected = {
+            (self.spiderman.pk, self.get_involved.pk, "n"),
+            (self.spiderman.pk, self.get_involved.pk, "a"),
+            (self.ironman.pk, self.get_involved.pk, "a"),
         }
         self.assertEqual(got, expected)
 


### PR DESCRIPTION
In the interest of time, I'm raising this not against feature/instructor-checkout-changes but instead against the branch used in https://github.com/carpentries/amy/pull/2431 for review. Will not merge until https://github.com/carpentries/amy/pull/2431 is merged.

Fixes #2445.

This PR will:
- add fields needed for the Get Involved step to the bulk training progress form
- make the bulk form use the same JS as the individual training progress form to dynamically display fields based on options
- expand tests of the bulk form to test adding different requirements

![Screenshot showing the bottom of the all trainees page. One trainee is selected and the bulk add progress form displays the fields associated with the Get Involved requirement](https://github.com/carpentries/amy/assets/20683271/e341936d-36bb-4e92-9838-2d79ea59913c)
