### PR TITLE
Update trainee progress view

### DIFF
--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -154,7 +154,7 @@ class GetInvolvedForm(forms.ModelForm):
     date = forms.DateField(
         label="Date of activity",
         help_text="If the activity took place over multiple days, please enter the "
-        "first day.",
+        "first day. Format: YYYY-MM-DD",
         required=False,
     )
     url = forms.URLField(
@@ -166,7 +166,7 @@ class GetInvolvedForm(forms.ModelForm):
     trainee_notes = forms.CharField(
         label="Additional information",
         help_text="If you attended a community meeting, please tell us which meeting "
-        'you attended. If you selected "Other" for the type of involvement, please '
+        'you attended. If you selected "Other" for the activity, please '
         "provide details here.",
         required=False,
     )

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -181,19 +181,6 @@ class GetInvolvedForm(forms.ModelForm):
             "trainee_notes",
         ]
 
-    def add_error(self, field: str, error: ValidationError | str):
-        """Overrides add_error to ignore any errors that are intended to appear
-        on the admin-only "notes" field."""
-
-        # Intercept and simplify the involvement_type error
-        msg = "This field is required."
-        if field == "involvement_type":
-            error.error_list = [msg]
-        elif hasattr(error, "error_dict") and "involvement_type" in error.error_dict:
-            error.error_dict["involvement_type"] = [msg]
-
-        return super().add_error(field, error)
-
 
 class SearchForm(forms.Form):
     """Represent general searching form."""

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -184,10 +184,6 @@ class GetInvolvedForm(forms.ModelForm):
     def add_error(self, field: str, error: ValidationError | str):
         """Overrides add_error to ignore any errors that are intended to appear
         on the admin-only "notes" field."""
-        if field == "notes":
-            return
-        elif hasattr(error, "error_dict") and "notes" in error.error_dict:
-            error.error_dict.pop("notes")
 
         # Intercept and simplify the involvement_type error
         msg = "This field is required."

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -181,6 +181,21 @@ class GetInvolvedForm(forms.ModelForm):
             "trainee_notes",
         ]
 
+    def clean_trainee_notes(self):
+        """Raise an error if the trainee has not provided notes where required.
+
+        All other fields are cleaned in the TrainingProgress model itself.
+        This field is different as it should only show an error on this specific form.
+        """
+        involvement_type = self.cleaned_data["involvement_type"]
+        trainee_notes = self.cleaned_data["trainee_notes"]
+        if involvement_type.notes_required and not trainee_notes:
+            raise ValidationError(
+                f'This field is required for activity "{involvement_type}".'
+            )
+
+        return trainee_notes
+
 
 class SearchForm(forms.Form):
     """Represent general searching form."""

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -147,15 +147,15 @@ class GetInvolvedForm(forms.ModelForm):
         label="Activity",
         help_text="If your activity is not included in this list, please select "
         '"Other" and provide details under "Additional information" below.',
-        required=True,
+        required=False,
         queryset=Involvement.objects.default_order().filter(archived_at__isnull=True),
         widget=forms.RadioSelect(),
     )
     date = forms.DateField(
         label="Date of activity",
         help_text="If the activity took place over multiple days, please enter the "
-        "final day.",
-        required=True,
+        "first day.",
+        required=False,
     )
     url = forms.URLField(
         label="URL",
@@ -188,6 +188,13 @@ class GetInvolvedForm(forms.ModelForm):
             return
         elif hasattr(error, "error_dict") and "notes" in error.error_dict:
             error.error_dict.pop("notes")
+
+        # Intercept and simplify the involvement_type error
+        msg = "This field is required."
+        if field == "involvement_type":
+            error.error_list = [msg]
+        elif hasattr(error, "error_dict") and "involvement_type" in error.error_dict:
+            error.error_dict["involvement_type"] = [msg]
 
         return super().add_error(field, error)
 

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -144,22 +144,22 @@ class AutoUpdateProfileForm(forms.ModelForm):
 
 class GetInvolvedForm(forms.ModelForm):
     involvement_type = forms.ModelChoiceField(
-        label="Type of involvement",
-        help_text="If your involvement is not included in this list, please select "
+        label="Activity",
+        help_text="If your activity is not included in this list, please select "
         '"Other" and provide details under "Additional information" below.',
         required=True,
         queryset=Involvement.objects.default_order().filter(archived_at__isnull=True),
         widget=forms.RadioSelect(),
     )
     date = forms.DateField(
-        label="Date of involvement",
-        help_text="If the involvement took place over multiple days, please enter the "
+        label="Date of activity",
+        help_text="If the activity took place over multiple days, please enter the "
         "final day.",
         required=True,
     )
     url = forms.URLField(
         label="URL",
-        help_text="A link to the involvement, if there is one. For example, a "
+        help_text="A link to the activity, if there is one. For example, a "
         "workshop website or GitHub contribution.",
         required=False,
     )
@@ -176,8 +176,8 @@ class GetInvolvedForm(forms.ModelForm):
         model = TrainingProgress
         fields = [
             "involvement_type",
-            "url",
             "date",
+            "url",
             "trainee_notes",
         ]
 

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -134,7 +134,7 @@ class AutoUpdateProfileForm(forms.ModelForm):
             raise ValidationError(errors)
 
 
-class LessonContributionForm(forms.Form):
+class GetInvolvedForm(forms.Form):  # TODO: make this good
     url = forms.URLField(label="URL")
     helper = BootstrapHelper(add_cancel_button=False)
 

--- a/amy/dashboard/tests/test_instructor_dashboard.py
+++ b/amy/dashboard/tests/test_instructor_dashboard.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from django.urls import reverse
 
@@ -143,7 +143,7 @@ class TestGetInvolvedStatus(TestBase):
 
     def test_lesson_contribution_not_submitted(self):
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, "Get Involved not submitted")
+        self.assertContains(rv, "Get Involved step not submitted")
 
     def test_lesson_contribution_waiting_to_be_evaluated(self):
         TrainingProgress.objects.create(
@@ -173,7 +173,7 @@ class TestGetInvolvedStatus(TestBase):
             "url": "http://example.com",
             "requirement": self.get_involved.pk,
             "involvement_type": self.github_contribution.pk,
-            "date": datetime.today(),
+            "date": "2023-06-21",
         }
         rv = self.client.post(self.progress_url, data, follow=True)
         self.assertEqual(rv.status_code, 200)
@@ -191,7 +191,7 @@ class TestGetInvolvedStatus(TestBase):
                 "http://example.com",
                 self.get_involved.pk,
                 self.github_contribution.pk,
-                datetime.today(),
+                date(2023, 6, 21),
             )
         ]
         self.assertEqual(got, expected)

--- a/amy/dashboard/tests/test_instructor_dashboard.py
+++ b/amy/dashboard/tests/test_instructor_dashboard.py
@@ -208,16 +208,16 @@ class TestGetInvolvedStatus(TestBase):
             "date": "2023-06-21",
         }
         rv = self.client.post(self.progress_url, data, follow=True)
-        # if "notes" field error is not filtered out, a server error will occur
+        # if "notes" field error is not excluded, a server error will occur
         # as there is no "notes" field on the form
-        # so a status code 200 means it has been removed correctly
+        # so a status code 200 means it has been excluded correctly
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.resolver_match.view_name, "training-progress")
         # check that "trainee_notes" field error is displayed
         # special treatment needed due to quotation marks
         self.assertContains(
             rv,
-            'In the case of Get Involved - "Other", this field is required.',
+            'This field is required for activity "Other".',
             html=True,
         )
         # no TrainingProgress should have been created

--- a/amy/dashboard/tests/test_instructor_dashboard.py
+++ b/amy/dashboard/tests/test_instructor_dashboard.py
@@ -141,11 +141,11 @@ class TestGetInvolvedStatus(TestBase):
         )
         self.progress_url = reverse("training-progress")
 
-    def test_lesson_contribution_not_submitted(self):
+    def test_get_involved_not_submitted(self):
         rv = self.client.get(self.progress_url)
         self.assertContains(rv, "Get Involved step not submitted")
 
-    def test_lesson_contribution_waiting_to_be_evaluated(self):
+    def test_get_involved_waiting_to_be_evaluated(self):
         TrainingProgress.objects.create(
             trainee=self.admin,
             requirement=self.get_involved,
@@ -157,7 +157,7 @@ class TestGetInvolvedStatus(TestBase):
         rv = self.client.get(self.progress_url)
         self.assertContains(rv, "Get Involved step evaluation pending")
 
-    def test_lesson_contribution_passed(self):
+    def test_get_involved_passed(self):
         TrainingProgress.objects.create(
             trainee=self.admin,
             requirement=self.get_involved,

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -22,7 +22,7 @@ from dashboard.filters import UpcomingTeachingOpportunitiesFilter
 from dashboard.forms import (
     AssignmentForm,
     AutoUpdateProfileForm,
-    LessonContributionForm,
+    GetInvolvedForm,
     SearchForm,
     SignupForRecruitmentForm,
 )
@@ -208,7 +208,7 @@ def autoupdate_profile(request):
 
 @login_required
 def training_progress(request):
-    lesson_contribution_form = LessonContributionForm()
+    get_involved_form = GetInvolvedForm()
 
     # Add information about instructor training progress to request.user.
     request.user = (
@@ -224,32 +224,34 @@ def training_progress(request):
     )
 
     progresses = request.user.trainingprogress_set
-    last_lesson_contribution = (
-        progresses.filter(requirement__name="Lesson Contribution")
+    last_get_involved = (
+        progresses.filter(requirement__name="Get Involved")
         .order_by("-created_at")
         .first()
     )
 
     if request.method == "POST":
-        lesson_contribution_form = LessonContributionForm(data=request.POST)
-        if lesson_contribution_form.is_valid():
+        get_involved_form = GetInvolvedForm(data=request.POST)
+        if get_involved_form.is_valid():
             TrainingProgress.objects.create(
                 trainee=request.user,
                 state="n",  # not evaluated yet
-                requirement=TrainingRequirement.objects.get(name="Lesson Contribution"),
-                url=lesson_contribution_form.cleaned_data["url"],
+                requirement=TrainingRequirement.objects.get(name="Get Involved"),
+                involvement_type=get_involved_form.cleaned_data["involvement_type"],
+                url=get_involved_form.cleaned_data["url"],
+                date=get_involved_form.cleaned_data["date"],
+                trainee_notes=get_involved_form.cleaned_data["trainee_notes"],
             )
             messages.success(
-                request, "Your Lesson Contribution submission will be evaluated soon."
+                request, "Your Get Involved submission will be evaluated soon."
             )
             return redirect(reverse("training-progress"))
 
     context = {
         "title": "Your training progress",
-        "lesson_contribution_form": lesson_contribution_form,
-        "lesson_contribution_in_evaluation": (
-            last_lesson_contribution is not None
-            and last_lesson_contribution.state == "n"
+        "get_involved_form": get_involved_form,
+        "get_involved_in_evaluation": (
+            last_get_involved is not None and last_get_involved.state == "n"
         ),
     }
     return render(request, "dashboard/training_progress.html", context)

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -231,17 +231,17 @@ def training_progress(request):
     )
 
     if request.method == "POST":
-        get_involved_form = GetInvolvedForm(data=request.POST)
+        base_training_progress = TrainingProgress(
+            trainee=request.user,
+            state="n",  # not evaluated yet
+            requirement=TrainingRequirement.objects.get(name="Get Involved"),
+        )
+        get_involved_form = GetInvolvedForm(
+            data=request.POST, instance=base_training_progress
+        )
         if get_involved_form.is_valid():
-            TrainingProgress.objects.create(
-                trainee=request.user,
-                state="n",  # not evaluated yet
-                requirement=TrainingRequirement.objects.get(name="Get Involved"),
-                involvement_type=get_involved_form.cleaned_data["involvement_type"],
-                url=get_involved_form.cleaned_data["url"],
-                date=get_involved_form.cleaned_data["date"],
-                trainee_notes=get_involved_form.cleaned_data["trainee_notes"],
-            )
+            get_involved_form.save()
+
             messages.success(
                 request, "Your Get Involved submission will be evaluated soon."
             )

--- a/amy/scripts/seed_involvements.py
+++ b/amy/scripts/seed_involvements.py
@@ -23,7 +23,7 @@ InvolvementDef = TypedDict(
 
 INVOLVEMENTS: list[InvolvementDef] = [
     {
-        "display_name": "Served as an Instructor or a Helper at a Carpentries workshop",
+        "display_name": "Served as an Instructor or a helper at a Carpentries workshop",
         "name": "Workshop Instructor/Helper",
         "url_required": True,
         "date_required": True,

--- a/amy/scripts/seed_involvements.py
+++ b/amy/scripts/seed_involvements.py
@@ -23,14 +23,14 @@ InvolvementDef = TypedDict(
 
 INVOLVEMENTS: list[InvolvementDef] = [
     {
-        "display_name": "Served as an Instructor or a helper at a Carpentries workshop",
+        "display_name": "Served as an Instructor or a Helper at a Carpentries workshop",
         "name": "Workshop Instructor/Helper",
         "url_required": True,
         "date_required": True,
         "notes_required": False,
     },
     {
-        "display_name": "Attended an Instructor Meeting, regional meetup, or other community meeting",  # noqa
+        "display_name": "Attended an Instructor meeting, regional meetup, or other community meeting",  # noqa
         "name": "Community Meeting",
         "url_required": False,
         "date_required": True,

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -8,7 +8,7 @@
 {% block content %}
 
 {% if swc_form.errors or dc_form.errors %}
-  <div class="alert alert-danger" role="alert">Fix errors in your Lesson Contribution submission.</div>
+  <div class="alert alert-danger" role="alert">Fix errors in your Get Involved submission.</div>
 {% endif %}
 
 <div>
@@ -39,14 +39,14 @@
       </td>
     </tr>
     <tr>
-      <th rowspan="2">2. Lesson Contribution</th>
+      <th rowspan="2">2. Get Involved</th>
       <td>
-        {% if user.passed_lesson_contribution %}
-        <p class="text-success">Lesson Contribution accepted.</p>
-        {% elif lesson_contribution_in_evaluation %}
-        <p>Lesson Contribution evaluation pending.<br>Please wait while we evaluate your contribution.</p>
+        {% if user.passed_get_involved %}
+        <p class="text-success">Get Involved accepted.</p>
+        {% elif get_involved_in_evaluation %}
+        <p>Get Involved evaluation pending.<br>Please wait while we evaluate your contribution.</p>
         {% else %}
-        <p>Lesson Contribution not submitted.</p>
+        <p>Get Involved not submitted.</p>
         {% endif %}
       </td>
     </tr>
@@ -54,7 +54,7 @@
       <td>
         <p>
           Submit link to your contribution on Github. Your contribution will be reviewed within 7-10 days.<br>
-          If you do not use GitHub, you may submit your lesson contribution via
+          If you do not use GitHub, you may submit your Get Involved via
           <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMBOj5Rdh8Mgk0ebRbeRyHhGHKbItdft6avWuEzmeg8CgWbA/viewform">this form</a>.
           A Carpentries Core Team member will create an issue based on the relevant repository, and will
           send you a link so that you may view any responses. In either case, you can track your progress
@@ -77,7 +77,7 @@
           <li><a href="https://github.com/carpentrieslab">The Carpentries Lab</a></li>
           <li><a href="https://github.com/carpentries-incubator">carpentries-incubator</a></li>
          </ul>
-        {% crispy lesson_contribution_form %}
+        {% crispy get_involved_form %}
       </td>
     </tr>
     <tr>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -72,7 +72,7 @@
           <p class="text-success">Welcome Session passed.</p>
         {% else %}
           <p>Welcome Session not passed yet.</p>
-          <p>Register for a Welcome Session on <a href="https://pad.carpentries.org/welcome-sessions-2023">this Etherpad</a>.</p>
+          <p>Register for a Welcome Session on <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">this Etherpad</a>.</p>
         {% endif %}
       </td>
     </tr>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -72,7 +72,7 @@
           <p class="text-success">Welcome Session passed.</p>
         {% else %}
           <p>Welcome Session not passed yet.</p>
-          <p>Register for a Welcome Session on <a href="https://pad.carpentries.org/community-discussions">this Etherpad</a>. Register for only one session even if you want to become an Instructor for more than one Carpentry lesson program.</p>
+          <p>Register for a Welcome Session on <a href="https://pad.carpentries.org/welcome-sessions-2023">this Etherpad</a>.</p>
         {% endif %}
       </td>
     </tr>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -74,7 +74,7 @@
           <li><a href="https://github.com/carpentryconnect">CarpentryConnect</a></li>
           <li><a href="https://github.com/carpentries-workshops">carpentries-workshops</a></li>
           <li><a href="https://github.com/data-lessons">data-lessons</a></li>
-          <li><a href="https://github.com/carpentrieslab">The Carpentries Lab</a></li>
+          <li><a href="https://github.com/carpentries-lab">The Carpentries Lab</a></li>
           <li><a href="https://github.com/carpentries-incubator">carpentries-incubator</a></li>
          </ul>
         {% crispy get_involved_form %}

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -42,26 +42,26 @@
       <th rowspan="2">2. Get Involved</th>
       <td>
         {% if user.passed_get_involved %}
-        <p class="text-success">Get Involved accepted.</p>
+        <p class="text-success">Get Involved submission accepted.</p>
         {% elif get_involved_in_evaluation %}
-        <p>Get Involved evaluation pending.<br>Please wait while we evaluate your contribution.</p>
+        <p>Get Involved step evaluation pending.<br>Please wait while we evaluate your contribution.</p>
         {% else %}
-        <p>Get Involved not submitted.</p>
+        <p>Get Involved step not submitted.</p>
         {% endif %}
       </td>
     </tr>
     <tr>
       <td>
         <p>
-          Submit link to your contribution on Github. Your contribution will be reviewed within 7-10 days.<br>
-          If you do not use GitHub, you may submit your Get Involved via
+          Provide details of your involvement. Your contribution will be reviewed within 7-10 days.<br>
+          If you do not use GitHub, you may submit your Get Involved step via
           <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMBOj5Rdh8Mgk0ebRbeRyHhGHKbItdft6avWuEzmeg8CgWbA/viewform">this form</a>.
           A Carpentries Core Team member will create an issue based on the relevant repository, and will
           send you a link so that you may view any responses. In either case, you can track your progress
           by returning to this page.
         </p>
         <p>
-          Please be sure your contribution is to a repo in one of these organisations:
+          If submitting a GitHub contribution, please be sure your contribution is to a repo in one of these organisations:
         </p>
         <ul>
           <li><a href="https://github.com/carpentries">The Carpentries</a></li>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-{% if swc_form.errors or dc_form.errors %}
+{% if get_involved_form.errors %}
   <div class="alert alert-danger" role="alert">Fix errors in your Get Involved submission.</div>
 {% endif %}
 

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -44,7 +44,7 @@
         {% if user.passed_get_involved %}
         <p class="text-success">Get Involved submission accepted.</p>
         {% elif get_involved_in_evaluation %}
-        <p>Get Involved step evaluation pending.<br>Please wait while we evaluate your contribution.</p>
+        <p>Get Involved step evaluation pending.<br>Please wait while we evaluate your submission.</p>
         {% else %}
         <p>Get Involved step not submitted.</p>
         {% endif %}
@@ -53,30 +53,15 @@
     <tr>
       <td>
         <p>
-          Provide details of your involvement. Your contribution will be reviewed within 7-10 days.<br>
-          If you do not use GitHub, you may submit your Get Involved step via
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMBOj5Rdh8Mgk0ebRbeRyHhGHKbItdft6avWuEzmeg8CgWbA/viewform">this form</a>.
-          A Carpentries Core Team member will create an issue based on the relevant repository, and will
-          send you a link so that you may view any responses. In either case, you can track your progress
-          by returning to this page.
+          Provide details of your Get Involved activity. Your submission will be reviewed within 7-10 days. 
+          You can track your progress by returning to this page.
         </p>
         <p>
-          If submitting a GitHub contribution, please be sure your contribution is to a repo in one of these organisations:
+          Only submit an activity that you have already completed.
         </p>
-        <ul>
-          <li><a href="https://github.com/carpentries">The Carpentries</a></li>
-          <li><a href="https://github.com/datacarpentry">Data Carpentry</a></li>
-          <li><a href="https://github.com/librarycarpentry">Library Carpentry</a></li>
-          <li><a href="https://github.com/swcarpentry">Software Carpentry</a></li>
-          <li><a href="https://github.com/carpentries-es">The Carpentries - Spanish Translations</a></li>
-          <li><a href="https://github.com/Reproducible-Science-Curriculum">Reproducible Science Curriculum</a></li>
-          <li><a href="https://github.com/carpentrycon">CarpentryCon</a></li>
-          <li><a href="https://github.com/carpentryconnect">CarpentryConnect</a></li>
-          <li><a href="https://github.com/carpentries-workshops">carpentries-workshops</a></li>
-          <li><a href="https://github.com/data-lessons">data-lessons</a></li>
-          <li><a href="https://github.com/carpentries-lab">The Carpentries Lab</a></li>
-          <li><a href="https://github.com/carpentries-incubator">carpentries-incubator</a></li>
-         </ul>
+        <p>
+          If submitting a GitHub contribution, please be sure your contribution is to a repository in one of the <a href="">GitHub organisations owned by The Carpentries</a>.
+        </p>
         {% crispy get_involved_form %}
       </td>
     </tr>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -60,7 +60,10 @@
           Only submit an activity that you have already completed.
         </p>
         <p>
-          If submitting a GitHub contribution, please be sure your contribution is to a repository in one of the <a href="">GitHub organisations owned by The Carpentries</a>.
+          If submitting a GitHub contribution, please be sure your contribution is to a repository in one of the 
+          <a href="https://docs.carpentries.org/topic_folders/communications/tools/github_organisations.html">
+            GitHub organisations owned by The Carpentries
+          </a>.
         </p>
         {% crispy get_involved_form %}
       </td>

--- a/amy/trainings/forms.py
+++ b/amy/trainings/forms.py
@@ -78,6 +78,17 @@ class TrainingProgressForm(forms.ModelForm):
     class Media:
         js = ("trainingprogress_form.js",)
 
+    def add_error(self, field: str, error: ValidationError | str):
+        """Overrides add_error to ignore any errors that are intended to appear
+        on the trainee-only "trainee_notes" field."""
+        if field == "trainee_notes":
+            return
+        else:
+            if hasattr(error, "error_dict") and "trainee_notes" in error.error_dict:
+                error.error_dict.pop("trainee_notes")
+
+        return super().add_error(field, error)
+
 
 class BulkAddTrainingProgressForm(forms.ModelForm):
     event = forms.ModelChoiceField(

--- a/amy/trainings/forms.py
+++ b/amy/trainings/forms.py
@@ -1,6 +1,5 @@
 from crispy_forms.layout import Layout
 from django import forms
-from django.core.exceptions import ValidationError
 from django.forms import CharField, RadioSelect, TextInput
 
 from trainings.models import Involvement
@@ -79,17 +78,6 @@ class TrainingProgressForm(forms.ModelForm):
     class Media:
         js = ("trainingprogress_form.js",)
 
-    def add_error(self, field: str, error: ValidationError | str):
-        """Overrides add_error to ignore any errors that are intended to appear
-        on the trainee-only "trainee_notes" field."""
-        if field == "trainee_notes":
-            return
-        else:
-            if hasattr(error, "error_dict") and "trainee_notes" in error.error_dict:
-                error.error_dict.pop("trainee_notes")
-
-        return super().add_error(field, error)
-
 
 class BulkAddTrainingProgressForm(forms.ModelForm):
     event = forms.ModelChoiceField(
@@ -151,14 +139,3 @@ class BulkAddTrainingProgressForm(forms.ModelForm):
 
     class Media:
         js = ("trainingprogress_form.js",)
-
-    def add_error(self, field: str, error: ValidationError | str):
-        """Overrides add_error to ignore any errors that are intended to appear
-        on the trainee-only "trainee_notes" field."""
-        if field == "trainee_notes":
-            return
-        else:
-            if hasattr(error, "error_dict") and "trainee_notes" in error.error_dict:
-                error.error_dict.pop("trainee_notes")
-
-        return super().add_error(field, error)

--- a/amy/trainings/forms.py
+++ b/amy/trainings/forms.py
@@ -25,7 +25,7 @@ class TrainingProgressForm(forms.ModelForm):
         required=True,
     )
     involvement_type = forms.ModelChoiceField(
-        label="Type of involvement",
+        label="Get Involved activity",
         required=False,
         queryset=Involvement.objects.default_order().filter(archived_at__isnull=True),
         widget=RadioSelect(),

--- a/amy/trainings/forms.py
+++ b/amy/trainings/forms.py
@@ -1,5 +1,6 @@
 from crispy_forms.layout import Layout
 from django import forms
+from django.core.exceptions import ValidationError
 from django.forms import CharField, RadioSelect, TextInput
 
 from trainings.models import Involvement
@@ -77,6 +78,16 @@ class TrainingProgressForm(forms.ModelForm):
 
     class Media:
         js = ("trainingprogress_form.js",)
+
+    def add_error(self, field: str, error: ValidationError | str):
+        """Overrides add_error to ignore any errors that are intended to appear
+        on the trainee-only "trainee_notes" field."""
+        if field == "trainee_notes":
+            return
+        elif hasattr(error, "error_dict") and "trainee_notes" in error.error_dict:
+            error.error_dict.pop("trainee_notes")
+
+        super().add_error(field, error)
 
 
 class BulkAddTrainingProgressForm(forms.ModelForm):

--- a/amy/trainings/forms.py
+++ b/amy/trainings/forms.py
@@ -1,5 +1,6 @@
 from crispy_forms.layout import Layout
 from django import forms
+from django.core.exceptions import ValidationError
 from django.forms import CharField, RadioSelect, TextInput
 
 from trainings.models import Involvement

--- a/amy/trainings/forms.py
+++ b/amy/trainings/forms.py
@@ -151,3 +151,14 @@ class BulkAddTrainingProgressForm(forms.ModelForm):
 
     class Media:
         js = ("trainingprogress_form.js",)
+
+    def add_error(self, field: str, error: ValidationError | str):
+        """Overrides add_error to ignore any errors that are intended to appear
+        on the trainee-only "trainee_notes" field."""
+        if field == "trainee_notes":
+            return
+        else:
+            if hasattr(error, "error_dict") and "trainee_notes" in error.error_dict:
+                error.error_dict.pop("trainee_notes")
+
+        return super().add_error(field, error)

--- a/amy/trainings/tests/test_training_progress.py
+++ b/amy/trainings/tests/test_training_progress.py
@@ -193,7 +193,7 @@ class TestTrainingProgressValidation(TestBase):
         )
         p1.full_clean()
         p2.full_clean()
-        with self.assertValidationErrors(["notes", "trainee_notes"]):
+        with self.assertValidationErrors(["notes"]):
             p3.full_clean()
 
     def test_notes_required_and_trainee_notes_provided(self):

--- a/amy/trainings/tests/test_training_progress.py
+++ b/amy/trainings/tests/test_training_progress.py
@@ -422,6 +422,13 @@ class TestCRUDViews(TestBase):
                 "date_required": True,
             },
         )
+        self.involvement_other, _ = Involvement.objects.get_or_create(
+            name="Other",
+            defaults={
+                "display_name": "Other",
+                "notes_required": True,
+            },
+        )
         self.progress = TrainingProgress.objects.create(
             requirement=self.requirement,
             state="p",
@@ -455,7 +462,7 @@ class TestCRUDViews(TestBase):
             c[0].instance.pk
             for c in rv.context["form"].fields["involvement_type"].choices
         ]
-        self.assertEqual(choices, [self.involvement.pk])
+        self.assertEqual(choices, [self.involvement.pk, self.involvement_other.pk])
 
     def test_create_view_works(self):
         data = {
@@ -475,6 +482,39 @@ class TestCRUDViews(TestBase):
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.resolver_match.view_name, "trainingprogress_edit")
         self.assertEqual(len(TrainingProgress.objects.all()), 2)
+
+    def test_create_view_submission_invalid_notes(self):
+        # Arrange
+        data = {
+            "requirement": self.get_involved.pk,
+            "state": "p",
+            "trainee": self.ironman.pk,
+            "involvement_type": self.involvement_other.pk,
+            "date": "2023-06-21",
+        }
+        progresses_before = len(TrainingProgress.objects.all())
+
+        # Act
+        rv = self.client.post(reverse("trainingprogress_add"), data, follow=True)
+
+        # Assert
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.resolver_match.view_name, "trainingprogress_add")
+        # check that "trainee_notes" field error is NOT displayed
+        self.assertNotContains(
+            rv,
+            'In the case of Get Involved - "Other", this field is required.',
+            html=True,
+        )
+        # check that "notes" field error is displayed
+        self.assertContains(
+            rv,
+            'In the case of Get Involved - "Other", this field is required '
+            "if there are no notes from the trainee.",
+            html=True,
+        )
+        # confirm that no TrainingProgress was created
+        self.assertEqual(len(TrainingProgress.objects.all()), progresses_before)
 
     def test_edit_view_loads(self):
         rv = self.client.get(reverse("trainingprogress_edit", args=[self.progress.pk]))

--- a/amy/trainings/tests/test_training_progress.py
+++ b/amy/trainings/tests/test_training_progress.py
@@ -503,13 +503,13 @@ class TestCRUDViews(TestBase):
         # check that "trainee_notes" field error is NOT displayed
         self.assertNotContains(
             rv,
-            'In the case of Get Involved - "Other", this field is required.',
+            'This field is required for activity "Other".',
             html=True,
         )
         # check that "notes" field error is displayed
         self.assertContains(
             rv,
-            'In the case of Get Involved - "Other", this field is required '
+            'This field is required for activity "Other" '
             "if there are no notes from the trainee.",
             html=True,
         )

--- a/amy/trainings/tests/test_training_progress.py
+++ b/amy/trainings/tests/test_training_progress.py
@@ -193,7 +193,7 @@ class TestTrainingProgressValidation(TestBase):
         )
         p1.full_clean()
         p2.full_clean()
-        with self.assertValidationErrors(["notes"]):
+        with self.assertValidationErrors(["notes", "trainee_notes"]):
             p3.full_clean()
 
     def test_notes_required_and_trainee_notes_provided(self):

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -2684,11 +2684,16 @@ class TrainingProgress(CreatedUpdatedMixin, models.Model):
                 and not self.trainee_notes
                 and not self.notes
             ):
-                msg = (
+                msg_trainee = (
+                    f'In the case of {self.requirement} - "{self.involvement_type}",'
+                    " this field is required."
+                )
+                msg_admin = (
                     f'In the case of {self.requirement} - "{self.involvement_type}",'
                     " this field is required if there are no notes from the trainee."
                 )
-                errors["notes"].append(ValidationError(msg))
+                errors["trainee_notes"].append(ValidationError(msg_trainee))
+                errors["notes"].append(ValidationError(msg_admin))
 
         # state check
         if self.state == "f" and not self.notes:

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -2615,8 +2615,8 @@ class TrainingProgress(CreatedUpdatedMixin, models.Model):
     def get_absolute_url(self):
         return reverse("trainingprogress_edit", args=[str(self.id)])
 
-    def clean(self):
-        super().clean()
+    def clean_fields(self, exclude=None):
+        super().clean_fields(exclude=exclude)
         errors = defaultdict(list)
 
         # URL check
@@ -2692,8 +2692,10 @@ class TrainingProgress(CreatedUpdatedMixin, models.Model):
                     f'In the case of {self.requirement} - "{self.involvement_type}",'
                     " this field is required if there are no notes from the trainee."
                 )
-                errors["trainee_notes"].append(ValidationError(msg_trainee))
-                errors["notes"].append(ValidationError(msg_admin))
+                if "trainee_notes" not in exclude:
+                    errors["trainee_notes"].append(ValidationError(msg_trainee))
+                if "notes" not in exclude:
+                    errors["notes"].append(ValidationError(msg_admin))
 
         # state check
         if self.state == "f" and not self.notes:

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -2707,20 +2707,6 @@ class TrainingProgress(CreatedUpdatedMixin, models.Model):
             msg = "Date must be in the past."
             return ValidationError(msg)
 
-    def clean_trainee_notes(
-        self,
-        requirement: TrainingRequirement,
-        involvement_type: Involvement | None = None,
-    ):
-        """Trainee notes can only be required by an Involvement."""
-        if requirement.involvement_required and involvement_type:
-            if (
-                involvement_type.notes_required
-                and not self.trainee_notes
-                and not self.notes
-            ):
-                return self.get_required_error(involvement_type)
-
     def clean_notes(
         self,
         requirement: TrainingRequirement,
@@ -2751,12 +2737,13 @@ class TrainingProgress(CreatedUpdatedMixin, models.Model):
         super().clean_fields(exclude=exclude)
         errors = defaultdict(list)
 
+        # note: trainee_notes field is cleaned in GetInvolvedForm instead
+        #       as it should not display errors in admin-facing forms
         validators = [
             ("url", self.clean_url),
             ("event", self.clean_event),
             ("involvement_type", self.clean_involvement_type),
             ("date", self.clean_date),
-            ("trainee_notes", self.clean_trainee_notes),
             ("notes", self.clean_notes),
         ]
 


### PR DESCRIPTION
Fix #2411 , fix #2451 .

This PR will:

- update "Lesson Contribution" to "Get Involved" throughout the instructor dashboard/training progress view and in associated tests
- update the lesson contribution form to match the new Get Involved format, including validation
- update instructions and links in the training progress view
- refactor the validation for TrainingProgress
- update error messages so that they should make sense in both the admin-facing TrainingProgressForm and the trainee-facing GetInvolvedForm
- fix the failing test on this branch - CI should now pass.

![Screenshot of the Get Involved step in the training progress view, showing the updated form with activity, date, URL, and trainee notes fields.](https://github.com/carpentries/amy/assets/20683271/ee9aee41-2a9e-4a2c-9364-4d8d1de23508)
![Screenshot of the same form, now with form errors for an invalid date and missing URL](https://github.com/carpentries/amy/assets/20683271/2ed20f0c-e92a-434b-a15a-4da896161e02)

