### PR TITLE
Add tests for training progress template tags

### DIFF
--- a/amy/trainings/tests/test_template_tags.py
+++ b/amy/trainings/tests/test_template_tags.py
@@ -1,0 +1,127 @@
+from datetime import date
+
+from django.test import TestCase
+
+from trainings.models import Involvement
+from workshops.models import Person, TrainingProgress, TrainingRequirement
+from workshops.templatetags.training_progress import (
+    progress_description,
+    progress_label,
+)
+
+
+class TestProgressDescriptionTemplateTag(TestCase):
+    def setUp(self):
+        self.person = Person.objects.create(
+            personal="Test", family="User", email="test@user.com"
+        )
+
+    def test_progress_description__basic(self):
+        welcome, _ = TrainingRequirement.objects.get_or_create(name="Welcome Session")
+        progress = TrainingProgress.objects.create(
+            trainee=self.person, requirement=welcome, state="p"
+        )
+        created = progress.created_at
+        # Act
+        expected = (
+            f'Passed Welcome Session<br/>on {created.strftime("%A %d %B %Y at %H:%M")}.'
+        )
+        got = progress_description(progress)
+        # Assert
+        self.assertHTMLEqual(expected, got)
+
+    def test_progress_description__notes(self):
+        welcome, _ = TrainingRequirement.objects.get_or_create(name="Welcome Session")
+        progress = TrainingProgress.objects.create(
+            trainee=self.person,
+            requirement=welcome,
+            state="f",
+            notes="Notes from admin",
+        )
+        created = progress.created_at
+        # Act
+        expected = (
+            "Failed Welcome Session<br/>"
+            f'on {created.strftime("%A %d %B %Y at %H:%M")}.<br/>'
+            "Notes: Notes from admin"
+        )
+        got = progress_description(progress)
+        # Assert
+        self.assertHTMLEqual(expected, got)
+
+    def test_progress_description__get_involved(self):
+        get_involved, _ = TrainingRequirement.objects.get_or_create(
+            name="Get Involved", defaults={"involvement_required": True}
+        )
+        github_contribution, _ = Involvement.objects.get_or_create(
+            name="GitHub Contribution",
+            defaults={"display_name": "GitHub Contribution", "url_required": True},
+        )
+        day = date(2023, 7, 11)
+        progress = TrainingProgress.objects.create(
+            trainee=self.person,
+            requirement=get_involved,
+            involvement_type=github_contribution,
+            date=day,
+            state="p",
+        )
+        # Act
+        expected = (
+            "Passed Get Involved<br/>"
+            "GitHub Contribution<br/>"
+            f'on {day.strftime("%A %d %B %Y")}.'
+        )
+        got = progress_description(progress)
+        # Assert
+        self.assertHTMLEqual(expected, got)
+
+    def test_progress_description__get_involved__other(self):
+        get_involved, _ = TrainingRequirement.objects.get_or_create(
+            name="Get Involved", defaults={"involvement_required": True}
+        )
+        involvement_other, _ = Involvement.objects.get_or_create(
+            name="Other", defaults={"display_name": "Other", "notes_required": True}
+        )
+        day = date(2023, 7, 11)
+        progress = TrainingProgress.objects.create(
+            trainee=self.person,
+            requirement=get_involved,
+            involvement_type=involvement_other,
+            trainee_notes="Notes from trainee",
+            date=day,
+            state="p",
+        )
+        # Act
+        expected = (
+            "Passed Get Involved<br/>"
+            "Other: Notes from trainee<br/>"
+            f'on {day.strftime("%A %d %B %Y")}.'
+        )
+        got = progress_description(progress)
+        # Assert
+        self.assertHTMLEqual(expected, got)
+
+
+class TestProgressLabelTemplateTag(TestCase):
+    def test_progress_labels(self):
+        self.person = Person.objects.create(
+            personal="Test", family="User", email="test@user.com"
+        )
+        welcome, _ = TrainingRequirement.objects.get_or_create(name="Welcome Session")
+
+        expected = {
+            "p": "badge badge-success",
+            "f": "badge badge-danger",
+            "a": "badge badge-info",
+            "n": "badge badge-warning",
+        }
+
+        for state in expected.keys():
+            progress = TrainingProgress.objects.create(
+                trainee=self.person,
+                requirement=welcome,
+                state=state,
+                notes="Notes from admin",
+            )
+            got = progress_label(progress)
+            self.assertEqual(expected[state], got)

--- a/amy/workshops/tests/test_person.py
+++ b/amy/workshops/tests/test_person.py
@@ -740,9 +740,7 @@ class TestPersonMerging(TestBase):
 
         # create training requirement
         self.training = TrainingRequirement.objects.get(name="Training")
-        self.lesson_contribution, _ = TrainingRequirement.objects.get_or_create(
-            name="Lesson Contribution", defaults={"url_required": True}
-        )
+        self.demo, _ = TrainingRequirement.objects.get_or_create(name="Demo")
 
         # create first person
         self.person_a = Person.objects.create(
@@ -866,7 +864,7 @@ class TestPersonMerging(TestBase):
         self.person_b.domains.set([KnowledgeDomain.objects.last()])
         self.person_b.languages.set([Language.objects.last()])
         self.person_b.trainingprogress_set.create(requirement=self.training)
-        self.person_b.trainingprogress_set.create(requirement=self.lesson_contribution)
+        self.person_b.trainingprogress_set.create(requirement=self.demo)
 
         # comments made by this person
         self.cb_1 = Comment.objects.create(


### PR DESCRIPTION
Fixes #2452 .

Also cleans up a leftover reference to Lesson Contribution in a separate test.