### PR TITLE
Correct links in changes_log view

### DIFF
--- a/amy/templates/workshops/changes_log.html
+++ b/amy/templates/workshops/changes_log.html
@@ -9,7 +9,13 @@
     {% for change in log %}
     <tr>
       <td>{{ change.date_created|date:'M j, P' }} </td>
-      <td>{% if change.user %}{{ change.user.personal }}{%else%}Unknown user{%endif%} changed <a href="{% url 'object_changes' change.pk %}">{{ change.version_set.all|first }}</a></td>
+      <td>
+        {% if change.user %}
+          {{ change.user.personal }}
+        {%else%}
+          Unknown user
+        {%endif%} 
+        changed <a href="{% url 'object_changes' change.version_set.first.pk %}">{{ change.version_set.all|first }}</a></td>
     </tr>
     {% endfor %}
     </table>

--- a/amy/templates/workshops/changes_log.html
+++ b/amy/templates/workshops/changes_log.html
@@ -15,7 +15,7 @@
         {%else%}
           Unknown user
         {%endif%} 
-        changed <a href="{% url 'object_changes' change.version_set.first.pk %}">{{ change.version_set.all|first }}</a></td>
+        changed <a href="{% url 'object_changes' change.version_set.first.pk %}">{{ change.version_set.first }}</a></td>
     </tr>
     {% endfor %}
     </table>

--- a/amy/workshops/tests/test_views.py
+++ b/amy/workshops/tests/test_views.py
@@ -1,0 +1,57 @@
+from django.urls import reverse
+from reversion.models import Revision
+from reversion.revisions import create_revision
+
+from workshops.models import Event, Role, Tag, Task
+from workshops.tests.base import TestBase
+
+
+class TestChangesLogView(TestBase):
+    """Tests the view of recent changes."""
+
+    def setUp(self):
+        super().setUp()
+        self._setUpUsersAndLogin()
+        self._setUpRoles()
+        self.tag1, _ = Tag.objects.get_or_create(pk=1)
+
+    def test_changes_log_links(self):
+        """Regression test for https://github.com/carpentries/amy/issues/2456.
+
+        This test isn't an effective regression test unless the PKs of the most recent
+        revisions and versions are different, as the view used to use revision.pk
+        when it should have used version.pk.
+        """
+
+        # Arrange
+        # set up an event
+        with create_revision():
+            self.event = Event.objects.create(host=self.org_alpha, slug="event")
+            self.event.tags.add(self.tag1)
+            self.event.save()
+
+        # Act
+        # create a revision that generates two new versions,
+        # to offset the pk counter between revisions and versions
+        with create_revision():
+            self.task = Task.objects.create(
+                person=self.blackwidow,
+                event=self.event,
+                role=Role.objects.get(name="helper"),
+            )
+
+        # get the change we just made
+        revision = Revision.objects.order_by("-date_created").first()
+        version = revision.version_set.first()
+
+        url = reverse("changes_log")
+        rv = self.client.get(url)
+
+        # Assert
+        # check this is a valid test
+        self.assertNotEqual(revision.pk, version.pk)
+        self.assertEqual(rv.status_code, 200)
+
+        # check that links point to the correct versions
+        expected = f'<a href="/workshops/version/{version.pk}/">{version}</a>'
+        self.assertContains(rv, expected, html=True)


### PR DESCRIPTION
Fixes #2456.

Though now I've done this, I realise that displaying just the first Version created as part of each Revision loses some helpful information (e.g. if a Task is created, this updates an Event and a Person; only the Event name is shown in the changes_log view). As we barely use this view, I'm not going to propose further changes at this time.