### PR TITLE
Improvements to trainee progress view

### DIFF
--- a/amy/dashboard/tests/test_instructor_dashboard.py
+++ b/amy/dashboard/tests/test_instructor_dashboard.py
@@ -125,8 +125,8 @@ class TestInstructorTrainingStatus(TestBase):
 
         self.event = Event.objects.create(
             slug="event-ttt",
-            start=date(2023, 6, 24),
-            end=date(2023, 6, 25),
+            start=date(2023, 6, 4),
+            end=date(2023, 6, 5),
             host=self.org_alpha,
         )
         self.training = TrainingRequirement.objects.get(name="Training")
@@ -140,7 +140,7 @@ class TestInstructorTrainingStatus(TestBase):
         self.assertContains(
             rv,
             '<p>Training <span class="badge-success">passed</span> '
-            "as of June 25, 2023.</p>",
+            "as of June 5, 2023.</p>",
             html=True,
         )
 
@@ -152,7 +152,7 @@ class TestInstructorTrainingStatus(TestBase):
         self.assertContains(
             rv,
             '<p>Training <span class="badge-danger">failed</span> '
-            "as of June 25, 2023.</p>",
+            "as of June 5, 2023.</p>",
             html=True,
         )
 
@@ -164,7 +164,7 @@ class TestInstructorTrainingStatus(TestBase):
         self.assertContains(
             rv,
             '<p>Training <span class="badge-info">asked to repeat</span> '
-            "as of June 25, 2023.</p>",
+            "as of June 5, 2023.</p>",
             html=True,
         )
 

--- a/amy/dashboard/tests/test_instructor_dashboard.py
+++ b/amy/dashboard/tests/test_instructor_dashboard.py
@@ -245,11 +245,13 @@ class TestWelcomeSessionStatus(TestBase):
         self._setUpUsersAndLogin()
         self.welcome = TrainingRequirement.objects.get(name="Welcome Session")
         self.progress_url = reverse("training-progress")
+        self.SESSION_LINK_TEXT = "Register for a Welcome Session on"
 
     def test_session_passed(self):
         TrainingProgress.objects.create(trainee=self.admin, requirement=self.welcome)
         rv = self.client.get(self.progress_url)
-        self.assertContains(rv, "Welcome Session passed")
+        self.assertContains(rv, "Welcome Session completed")
+        self.assertNotContains(rv, self.SESSION_LINK_TEXT)
 
     def test_session_failed(self):
         TrainingProgress.objects.create(
@@ -257,10 +259,12 @@ class TestWelcomeSessionStatus(TestBase):
         )
         rv = self.client.get(self.progress_url)
         self.assertContains(rv, "Welcome Session failed")
+        self.assertNotContains(rv, self.SESSION_LINK_TEXT)
 
     def test_no_participation_in_a_session_yet(self):
         rv = self.client.get(self.progress_url)
         self.assertContains(rv, "Welcome Session not completed yet")
+        self.assertContains(rv, self.SESSION_LINK_TEXT)
 
 
 class TestDemoSessionStatus(TestBase):
@@ -281,13 +285,20 @@ class TestDemoSessionStatus(TestBase):
         self.assertContains(rv, "Demo passed")
         self.assertNotContains(rv, self.SESSION_LINK_TEXT)
 
+    def test_session_asked_to_repeat(self):
+        TrainingProgress.objects.create(
+            trainee=self.admin, requirement=self.demo, state="a"
+        )
+        rv = self.client.get(self.progress_url)
+        self.assertContains(rv, "Demo asked to repeat")
+        self.assertContains(rv, self.SESSION_LINK_TEXT)
+
     def test_session_failed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.demo, state="f"
         )
         rv = self.client.get(self.progress_url)
         self.assertContains(rv, "Demo failed")
-        self.assertContains(rv, self.SESSION_LINK_TEXT)
 
     def test_no_participation_in_a_session_yet(self):
         rv = self.client.get(self.progress_url)

--- a/amy/dashboard/tests/test_utils.py
+++ b/amy/dashboard/tests/test_utils.py
@@ -1,0 +1,98 @@
+from dashboard.utils import get_passed_or_last_progress
+from workshops.models import TrainingProgress, TrainingRequirement
+from workshops.tests.base import TestBase
+
+
+class TestGetLastOrPassedProgress(TestBase):
+    def setUp(self):
+        super().setUp()
+        self._setUpTags()
+
+        # set up some progresses
+        self.requirement, _ = TrainingRequirement.objects.get_or_create(name="Demo")
+
+    def test_no_progress(self):
+        """Should return None if no progress present."""
+        # Act
+        got_progress = get_passed_or_last_progress(
+            self.spiderman, self.requirement.name
+        )
+        # Assert
+        self.assertIsNone(got_progress)
+
+    def test_single_passed_progress(self):
+        """Only one progress, and it's passed"""
+        # Arrange
+        expected = TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.requirement, state="p"
+        )
+        # Act
+        got_progress = get_passed_or_last_progress(
+            self.spiderman, self.requirement.name
+        )
+        # Assert
+        self.assertEqual(expected, got_progress)
+
+    def test_single_nonpassed_progress(self):
+        """Only one progress, and it's not passed"""
+        # Arrange
+        expected = TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.requirement, state="f"
+        )
+        # Act
+        got_progress = get_passed_or_last_progress(
+            self.spiderman, self.requirement.name
+        )
+        # Assert
+        self.assertEqual(expected, got_progress)
+
+    def test_passed_progress_prioritised(self):
+        """Passed progress should be returned even if later progresses exist"""
+        # Arrange
+        TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.requirement, state="a"
+        )
+        expected = TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.requirement, state="p"
+        )
+        TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.requirement, state="f"
+        )
+        # Act
+        got_progress = get_passed_or_last_progress(
+            self.spiderman, self.requirement.name
+        )
+        # Assert
+        self.assertEqual(expected, got_progress)
+
+    def test_recent_progress_no_pass(self):
+        """The most recent progress should be returned if none are passed"""
+        # Arrange
+        TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.requirement, state="a"
+        )
+        expected = TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.requirement, state="a"
+        )
+        # Act
+        got_progress = get_passed_or_last_progress(
+            self.spiderman, self.requirement.name
+        )
+        # Assert
+        self.assertEqual(expected, got_progress)
+
+    def test_recent_passed_progress(self):
+        """The most recent passed progress should be returned if multiple are passed"""
+        # Arrange
+        TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.requirement, state="p"
+        )
+        expected = TrainingProgress.objects.create(
+            trainee=self.spiderman, requirement=self.requirement, state="p"
+        )
+        # Act
+        got_progress = get_passed_or_last_progress(
+            self.spiderman, self.requirement.name
+        )
+        # Assert
+        self.assertEqual(expected, got_progress)

--- a/amy/dashboard/utils.py
+++ b/amy/dashboard/utils.py
@@ -1,0 +1,20 @@
+from workshops.models import Person, TrainingProgress
+
+
+def get_passed_or_last_progress(
+    trainee: Person, requirement: str
+) -> TrainingProgress | None:
+    """Returns a recent progress, prioritising progress with a passed state.
+
+    If there are one or more passed progresses, returns the most recent of those.
+    Otherwise, returns the most recent progress of any state.
+    If the trainee has no progresses for this requirement, returns None.
+    """
+    progresses = trainee.trainingprogress_set.filter(
+        requirement__name=requirement
+    ).order_by("-created_at")
+
+    try:
+        return progresses.filter(state="p")[0]
+    except IndexError:
+        return progresses.first()

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -26,6 +26,7 @@ from dashboard.forms import (
     SearchForm,
     SignupForRecruitmentForm,
 )
+from dashboard.utils import get_passed_or_last_progress
 from extrequests.base_views import AMYCreateAndFetchObjectView
 from fiscal.models import MembershipTask
 from recruitment.models import InstructorRecruitment, InstructorRecruitmentSignup
@@ -223,23 +224,10 @@ def training_progress(request):
         .get(pk=request.user.pk)
     )
 
-    progresses = request.user.trainingprogress_set
-    last_training = (
-        progresses.filter(requirement__name="Training").order_by("-created_at").first()
-    )
-    last_welcome = (
-        progresses.filter(requirement__name="Welcome Session")
-        .order_by("-created_at")
-        .first()
-    )
-    last_demo = (
-        progresses.filter(requirement__name="Demo").order_by("-created_at").first()
-    )
-    last_get_involved = (
-        progresses.filter(requirement__name="Get Involved")
-        .order_by("-created_at")
-        .first()
-    )
+    progress_training = get_passed_or_last_progress(request.user, "Training")
+    progress_get_involved = get_passed_or_last_progress(request.user, "Get Involved")
+    progress_welcome = get_passed_or_last_progress(request.user, "Welcome Session")
+    progress_demo = get_passed_or_last_progress(request.user, "Demo")
 
     if request.method == "POST":
         base_training_progress = TrainingProgress(
@@ -263,10 +251,10 @@ def training_progress(request):
     context = {
         "title": "Your training progress",
         "get_involved_form": get_involved_form,
-        "last_training": last_training,
-        "last_welcome": last_welcome,
-        "last_demo": last_demo,
-        "last_get_involved": last_get_involved,
+        "progress_training": progress_training,
+        "progress_get_involved": progress_get_involved,
+        "progress_welcome": progress_welcome,
+        "progress_demo": progress_demo,
     }
     return render(request, "dashboard/training_progress.html", context)
 

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -224,6 +224,17 @@ def training_progress(request):
     )
 
     progresses = request.user.trainingprogress_set
+    last_training = (
+        progresses.filter(requirement__name="Training").order_by("-created_at").first()
+    )
+    last_welcome = (
+        progresses.filter(requirement__name="Welcome Session")
+        .order_by("-created_at")
+        .first()
+    )
+    last_demo = (
+        progresses.filter(requirement__name="Demo").order_by("-created_at").first()
+    )
     last_get_involved = (
         progresses.filter(requirement__name="Get Involved")
         .order_by("-created_at")
@@ -252,9 +263,10 @@ def training_progress(request):
     context = {
         "title": "Your training progress",
         "get_involved_form": get_involved_form,
-        "get_involved_in_evaluation": (
-            last_get_involved is not None and last_get_involved.state == "n"
-        ),
+        "last_training": last_training,
+        "last_welcome": last_welcome,
+        "last_demo": last_demo,
+        "last_get_involved": last_get_involved,
     }
     return render(request, "dashboard/training_progress.html", context)
 

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -243,7 +243,9 @@ def training_progress(request):
             get_involved_form.save()
 
             messages.success(
-                request, "Your Get Involved submission will be evaluated soon."
+                request,
+                "Thank you. Your Get Involved submission will be reviewed within 7-10 "
+                "days.",
             )
             return redirect(reverse("training-progress"))
 

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -125,7 +125,7 @@
           {% now 'n' as current_month %}
           {% now 'Y' as current_year %}
           <p>Register for a Welcome Session on
-            {% if current_month|add:"0" >= 10 %}
+            {% if current_month|add:"0" >= 11 %}
             one of these Etherpads: <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year }}">Welcome Sessions {{ current_year }}</a>; <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year | add:'1' }}">Welcome Sessions {{ current_year | add:"1" }}</a>.
             {% else %}
             this Etherpad: <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year }}">Welcome Sessions {{ current_year }}</a>.

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -18,12 +18,7 @@
   
   {% if user.instructor_badges %}
   <div class="alert alert-success" role="alert">
-    <p>Congratulations, you're a certified:</p>
-    <ul>
-    {% for badge in user.instructor_badges %}
-      <li>{{ badge.title }}</li>
-    {% endfor %}
-    </ul>
+    <p>Congratulations, you're a certified Instructor!
   </div>
   {% elif user.instructor_eligible %}
   <div class="alert alert-info" role="alert">
@@ -32,12 +27,12 @@
     You will receive your certificate and more information by email in 1-2 weeks.
   </p>
   </div>
-  {% elif user.passed_training %}
+  {% elif user.passed_training or user.passed_get_involved or user.passed_welcome or user.passed_demo %}
   <div class="alert alert-info" role="alert">
     <p>
+      Please review your progress towards Instructor certification below. 
       {% if progress_training %}
         {% checkout_deadline progress_training.event.end as deadline %}
-        Please review your progress towards Instructor certification below. 
         Based on your training dates of {% human_daterange progress_training.event.start progress_training.event.end %}, the 90-day deadline to complete these 
         requirements is {{ deadline }}.
       {% endif %}

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -34,7 +34,7 @@
       {% if progress_training %}
         {% checkout_deadline progress_training.event.end as deadline %}
         Based on your training dates of {% human_daterange progress_training.event.start progress_training.event.end %}, the 90-day deadline to complete these 
-        requirements is {{ deadline }}.
+        requirements is <strong>{{ deadline }}</strong>.
       {% endif %}
     </p>
       If you would like an extension, please contact us at 

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -5,6 +5,7 @@
 
 {% load crispy_forms_tags %}
 {% load dates %}
+{% load training_progress %}
 
 {% block content %}
 
@@ -36,7 +37,7 @@
     <p>
       Please review your progress towards Instructor certification below. 
       Based on your training date of {{ last_training.start_date }}, the 90-day deadline to complete these 
-      requirements is {% get_checkout_deadline last_training.start_date %}.
+      requirements is {% checkout_deadline last_training.start_date %}.
     </p>
       If you would like an extension, please contact us at 
       <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org</a>
@@ -65,13 +66,10 @@
     <tr>
       <th>1. Training</th>
       <td>
-        {% if user.passed_training %}
-          <p class="text-success">Training passed
-            {% if last_training %}
-              as of {{ last_training.end_date | date:'j F Y' }}
-            {% endif %}
-            .
-          </p>
+        {% if last_training %}
+          {% progress_trainee_view last_training %}
+        {% elif user.passed_training %}
+          <p class="text-success">Training passed.</p>
         {% else %}
           <p>Training not completed yet.</p>
         {% endif %}
@@ -80,19 +78,13 @@
     <tr>
       <th rowspan="2">2. Get Involved</th>
       <td>
-        {% if user.passed_get_involved %}
-        <p class="text-success">Get Involved step passed
-          {% if last_get_involved %}
-              as of {{ last_get_involved.last_updated_at | date:'j F Y'}}
+        {% if last_get_involved %}
+          {% progress_trainee_view last_get_involved %}
+          {% if last_get_involved.state == "n" %}
+          <p>Please wait while we evaluate your submission.</p>
           {% endif %}
-          .
-        </p>
-        {% elif last_get_involved and last_get_involved.state == "n" %}
-        <p>Get Involved step evaluation pending
-          {% if last_get_involved %}
-              as of {{ last_get_involved.last_updated_at | date:'j F Y' }}
-          {% endif %}
-        .<br>Please wait while we evaluate your submission.</p>
+        {% elif user.passed_get_involved %}
+        <p class="text-success">Get Involved step passed.</p>
         {% else %}
         <p>Get Involved step not submitted.</p>
         {% endif %}
@@ -129,9 +121,10 @@
         {% else %}
           <p>Welcome Session not completed yet.</p>
           {% is_late_in_year as show_next_year %}
+          {% now 'Y' as current_year %}
           <p>Register for a Welcome Session on
             {% if show_next_year %}
-            one of these Etherpads: <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">Welcome Sessions {% now 'Y' %}</a>; <a href="https://pad.carpentries.org/welcome-sessions-{% next_year %}">Welcome Sessions {% next_year %}</a>.
+            one of these Etherpads: <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">Welcome Sessions {% now 'Y' %}</a>; <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year | add:'1' }}">Welcome Sessions {{ current_year | add:"1" }}</a>.
             {% else %}
             this Etherpad: <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">Welcome Sessions {% now 'Y' %}</a>.
             {% endif %}

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -4,6 +4,7 @@
 {% endblock %}
 
 {% load crispy_forms_tags %}
+{% load dates %}
 
 {% block content %}
 
@@ -12,8 +13,8 @@
 {% endif %}
 
 <div>
-  <h2>Your progress of becoming The Carpentries Instructor</h2>
-
+  <h2>Your progress toward becoming a Carpentries Instructor</h2>
+  
   {% if user.instructor_badges %}
   <div class="alert alert-success" role="alert">
     <p>Congratulations, you're a certified:</p>
@@ -23,9 +24,38 @@
     {% endfor %}
     </ul>
   </div>
+  {% elif user.passed_training and user.passed_demo and user.passed_welcome and user.passed_get_involved %}
+  <div class="alert alert-info" role="alert">
+  <p>
+    Congratulations. You have successfully completed all steps towards Instructor certification. 
+    You will receive your certificate and more information by email in 1-2 weeks.
+  </p>
+  </div>
+  {% elif user.passed_training %}
+  <div class="alert alert-info" role="alert">
+    <p>
+      Please review your progress towards Instructor certification below. 
+      As a reminder, because you completed training on [DATE], you have until [DATE + 90 days] 
+      to complete these requirements. Visit our 
+      <a href="https://carpentries.github.io/instructor-training/checkout">checkout page</a>
+      for more information. 
+    </p>
+      If you would like an extension on this deadline, please contact us at 
+      <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org.</a>
+    </p>
+    <p>
+      If you have recently completed a training or step towards checkout, 
+      please allow 7-10 days for this information to show up in your profile.
+    </p>
+  </div>
+  {% else %}
+  <div class="alert alert-info" role="alert">
+    <p>
+      If you have recently completed a training or step towards checkout, 
+      please allow 7-10 days for this information to show up in your profile.
+    </p>
+  </div>
   {% endif %}
-
-  <div class="alert alert-warning" role="alert">Due to the structure of our checkout tracking progress, all steps towards checkout may not be included here. If your instructor badge is correctly displayed, you are in good standing.</div>
 
   <table class="table table-striped">
     <tr>
@@ -34,7 +64,7 @@
         {% if user.passed_training %}
           <p class="text-success">Training passed.</p>
         {% else %}
-          <p>Training not passed yet.</p>
+          <p>Training not completed yet.</p>
         {% endif %}
       </td>
     </tr>
@@ -42,7 +72,7 @@
       <th rowspan="2">2. Get Involved</th>
       <td>
         {% if user.passed_get_involved %}
-        <p class="text-success">Get Involved submission accepted.</p>
+        <p class="text-success">Get Involved step passed.</p>
         {% elif get_involved_in_evaluation %}
         <p>Get Involved step evaluation pending.<br>Please wait while we evaluate your submission.</p>
         {% else %}
@@ -72,10 +102,18 @@
       <th>3. Welcome Session</th>
       <td>
         {% if user.passed_welcome %}
-          <p class="text-success">Welcome Session passed.</p>
+          <p class="text-success">Welcome Session completed.</p>
         {% else %}
-          <p>Welcome Session not passed yet.</p>
-          <p>Register for a Welcome Session on <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">this Etherpad</a>.</p>
+          <p>Welcome Session not completed yet.</p>
+          {% with is_late_in_year as show_next_year %}
+          <p>Register for a Welcome Session on
+            {% if show_next_year %}
+            one of these Etherpads: <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">Welcome Sessions {% now 'Y' %}</a>; <a href="https://pad.carpentries.org/welcome-sessions-{% next_year %}">Welcome Sessions {% next_year %}</a>.
+            {% else %}
+            this Etherpad: <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">Welcome Sessions {% now 'Y' %}</a>.
+            {% endif %}
+          </p>
+          {% endwith %}
         {% endif %}
       </td>
     </tr>
@@ -85,8 +123,8 @@
         {% if user.passed_demo %}
         <p class="text-success">Demo Session passed.</p>
         {% else %}
-        <p>Demo Session not completed.</p>
-        <p>You can register for a Demo Session on <a href="https://pad.carpentries.org/teaching-demos">this Etherpad</a>.</p>
+        <p>Demo Session not completed yet.</p>
+        <p>Register for a Demo Session on this Etherpad: <a href="https://pad.carpentries.org/teaching-demos">Teaching Demos</a>.</p>
         {% endif %}
       </td>
     </tr>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -111,7 +111,9 @@
     <tr>
       <th>3. Welcome Session</th>
       <td>
-        {% if user.passed_welcome %}
+        {% if last_welcome %}
+          {% progress_trainee_view last_welcome %}
+        {% elif user.passed_welcome %}
           <p class="text-success">Welcome Session completed 
             {% if last_welcome %}
               as of {{ last_welcome.last_updated_at | date:'j F Y' }}
@@ -135,7 +137,9 @@
     <tr>
       <th>4. Demo Session</th>
       <td>
-        {% if user.passed_demo %}
+        {% if last_demo %}
+          {% progress_trainee_view last_demo %}
+        {% elif user.passed_demo %}
         <p class="text-success">Demo Session passed
           {% if last_demo %}
             as of {{ last_demo.last_updated_at | date:'j F Y' }}

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -24,7 +24,7 @@
     {% endfor %}
     </ul>
   </div>
-  {% elif user.passed_training and user.passed_demo and user.passed_welcome and user.passed_get_involved %}
+  {% elif user.instructor_eligible %}
   <div class="alert alert-info" role="alert">
   <p>
     Congratulations. You have successfully completed all steps towards Instructor certification. 
@@ -35,17 +35,21 @@
   <div class="alert alert-info" role="alert">
     <p>
       Please review your progress towards Instructor certification below. 
-      As a reminder, because you completed training on [DATE], you have until [DATE + 90 days] 
-      to complete these requirements. Visit our 
-      <a href="https://carpentries.github.io/instructor-training/checkout">checkout page</a>
-      for more information. 
+      Based on your training date of {{ last_training.start_date }}, the 90-day deadline to complete these 
+      requirements is {% get_checkout_deadline last_training.start_date %}.
     </p>
-      If you would like an extension on this deadline, please contact us at 
-      <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org.</a>
+      If you would like an extension, please contact us at 
+      <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org</a>
+      and refer to your confirmation email for your updated deadline.
     </p>
     <p>
       If you have recently completed a training or step towards checkout, 
       please allow 7-10 days for this information to show up in your profile.
+    </p> 
+    <p>
+      Visit our 
+      <a href="https://carpentries.github.io/instructor-training/checkout">checkout page</a>
+      for more information. 
     </p>
   </div>
   {% else %}
@@ -62,7 +66,12 @@
       <th>1. Training</th>
       <td>
         {% if user.passed_training %}
-          <p class="text-success">Training passed.</p>
+          <p class="text-success">Training passed
+            {% if last_training %}
+              as of {{ last_training.end_date | date:'j F Y' }}
+            {% endif %}
+            .
+          </p>
         {% else %}
           <p>Training not completed yet.</p>
         {% endif %}
@@ -72,9 +81,18 @@
       <th rowspan="2">2. Get Involved</th>
       <td>
         {% if user.passed_get_involved %}
-        <p class="text-success">Get Involved step passed.</p>
-        {% elif get_involved_in_evaluation %}
-        <p>Get Involved step evaluation pending.<br>Please wait while we evaluate your submission.</p>
+        <p class="text-success">Get Involved step passed
+          {% if last_get_involved %}
+              as of {{ last_get_involved.last_updated_at | date:'j F Y'}}
+          {% endif %}
+          .
+        </p>
+        {% elif last_get_involved and last_get_involved.state == "n" %}
+        <p>Get Involved step evaluation pending
+          {% if last_get_involved %}
+              as of {{ last_get_involved.last_updated_at | date:'j F Y' }}
+          {% endif %}
+        .<br>Please wait while we evaluate your submission.</p>
         {% else %}
         <p>Get Involved step not submitted.</p>
         {% endif %}
@@ -102,10 +120,15 @@
       <th>3. Welcome Session</th>
       <td>
         {% if user.passed_welcome %}
-          <p class="text-success">Welcome Session completed.</p>
+          <p class="text-success">Welcome Session completed 
+            {% if last_welcome %}
+              as of {{ last_welcome.last_updated_at | date:'j F Y' }}
+            {% endif %}  
+            .
+          </p>
         {% else %}
           <p>Welcome Session not completed yet.</p>
-          {% with is_late_in_year as show_next_year %}
+          {% is_late_in_year as show_next_year %}
           <p>Register for a Welcome Session on
             {% if show_next_year %}
             one of these Etherpads: <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">Welcome Sessions {% now 'Y' %}</a>; <a href="https://pad.carpentries.org/welcome-sessions-{% next_year %}">Welcome Sessions {% next_year %}</a>.
@@ -113,7 +136,6 @@
             this Etherpad: <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">Welcome Sessions {% now 'Y' %}</a>.
             {% endif %}
           </p>
-          {% endwith %}
         {% endif %}
       </td>
     </tr>
@@ -121,7 +143,12 @@
       <th>4. Demo Session</th>
       <td>
         {% if user.passed_demo %}
-        <p class="text-success">Demo Session passed.</p>
+        <p class="text-success">Demo Session passed
+          {% if last_demo %}
+            as of {{ last_demo.last_updated_at | date:'j F Y' }}
+          {% endif %}
+          .
+        </p>
         {% else %}
         <p>Demo Session not completed yet.</p>
         <p>Register for a Demo Session on this Etherpad: <a href="https://pad.carpentries.org/teaching-demos">Teaching Demos</a>.</p>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -35,9 +35,9 @@
   {% elif user.passed_training %}
   <div class="alert alert-info" role="alert">
     <p>
-      {% checkout_deadline last_training.event.end as deadline %}
+      {% checkout_deadline progress_training.event.end as deadline %}
       Please review your progress towards Instructor certification below. 
-      Based on your training dates of {% human_daterange last_training.event.start last_training.event.end %}, the 90-day deadline to complete these 
+      Based on your training dates of {% human_daterange progress_training.event.start progress_training.event.end %}, the 90-day deadline to complete these 
       requirements is {{ deadline }}.
     </p>
       If you would like an extension, please contact us at 
@@ -67,8 +67,8 @@
     <tr>
       <th>1. Training</th>
       <td>
-        {% if last_training %}
-          {% progress_trainee_view last_training %}
+        {% if progress_training %}
+          {% progress_trainee_view progress_training %}
         {% elif user.passed_training %}
           <p class="text-success">Training passed.</p>
         {% else %}
@@ -79,9 +79,9 @@
     <tr>
       <th rowspan="2">2. Get Involved</th>
       <td>
-        {% if last_get_involved %}
-          {% progress_trainee_view last_get_involved %}
-          {% if last_get_involved.state == "n" %}
+        {% if progress_get_involved %}
+          {% progress_trainee_view progress_get_involved %}
+          {% if progress_get_involved.state == "n" %}
           <p>Please wait while we evaluate your submission.</p>
           {% endif %}
         {% elif user.passed_get_involved %}
@@ -112,8 +112,8 @@
     <tr>
       <th>3. Welcome Session</th>
       <td>
-        {% if last_welcome %}
-          {% progress_trainee_view last_welcome %}
+        {% if progress_welcome %}
+          {% progress_trainee_view progress_welcome %}
         {% elif user.passed_welcome %}
           <p class="text-success">Welcome Session completed.
           </p>
@@ -134,8 +134,8 @@
     <tr>
       <th>4. Demo Session</th>
       <td>
-        {% if last_demo %}
-          {% progress_trainee_view last_demo %}
+        {% if progress_demo %}
+          {% progress_trainee_view progress_demo %}
         {% elif user.passed_demo %}
         <p class="text-success">Demo Session passed.
         </p>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -36,7 +36,7 @@
   <div class="alert alert-info" role="alert">
     <p>
       Please review your progress towards Instructor certification below. 
-      Based on your training date of {{ last_training.start_date }}, the 90-day deadline to complete these 
+      Based on your training dates of {% human_daterange last_training.event.start last_training.event.end %}, the 90-day deadline to complete these 
       requirements is {% checkout_deadline last_training.start_date %}.
     </p>
       If you would like an extension, please contact us at 

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -35,10 +35,12 @@
   {% elif user.passed_training %}
   <div class="alert alert-info" role="alert">
     <p>
-      {% checkout_deadline progress_training.event.end as deadline %}
-      Please review your progress towards Instructor certification below. 
-      Based on your training dates of {% human_daterange progress_training.event.start progress_training.event.end %}, the 90-day deadline to complete these 
-      requirements is {{ deadline }}.
+      {% if progress_training %}
+        {% checkout_deadline progress_training.event.end as deadline %}
+        Please review your progress towards Instructor certification below. 
+        Based on your training dates of {% human_daterange progress_training.event.start progress_training.event.end %}, the 90-day deadline to complete these 
+        requirements is {{ deadline }}.
+      {% endif %}
     </p>
       If you would like an extension, please contact us at 
       <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org</a>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -37,6 +37,7 @@
         requirements is <strong>{{ deadline }}</strong>.
       {% endif %}
     </p>
+    <p>
       If you would like an extension, please contact us at 
       <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org</a>
       and refer to your confirmation email for your updated deadline.
@@ -65,7 +66,7 @@
       <th>1. Training</th>
       <td>
         {% if progress_training %}
-          {% progress_trainee_view progress_training %}
+          {% include 'includes/progress_trainee_view.html' with progress=progress_training %}
         {% elif user.passed_training %}
           <p class="text-success">Training passed.</p>
         {% else %}
@@ -77,7 +78,7 @@
       <th rowspan="2">2. Get Involved</th>
       <td>
         {% if progress_get_involved %}
-          {% progress_trainee_view progress_get_involved %}
+          {% include 'includes/progress_trainee_view.html' with progress=progress_get_involved %}
           {% if progress_get_involved.state == "n" %}
           <p>Please wait while we evaluate your submission.</p>
           {% endif %}
@@ -110,21 +111,13 @@
       <th>3. Welcome Session</th>
       <td>
         {% if progress_welcome %}
-          {% progress_trainee_view progress_welcome %}
+          {% include 'includes/progress_trainee_view.html' with progress=progress_welcome %}
         {% elif user.passed_welcome %}
           <p class="text-success">Welcome Session completed.
           </p>
         {% else %}
           <p>Welcome Session not completed yet.</p>
-          {% now 'n' as current_month %}
-          {% now 'Y' as current_year %}
-          <p>Register for a Welcome Session on
-            {% if current_month|add:"0" >= 11 %}
-            one of these Etherpads: <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year }}">Welcome Sessions {{ current_year }}</a>; <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year | add:'1' }}">Welcome Sessions {{ current_year | add:"1" }}</a>.
-            {% else %}
-            this Etherpad: <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year }}">Welcome Sessions {{ current_year }}</a>.
-            {% endif %}
-          </p>
+          {% welcome_instructions %}
         {% endif %}
       </td>
     </tr>
@@ -132,7 +125,7 @@
       <th>4. Demo Session</th>
       <td>
         {% if progress_demo %}
-          {% progress_trainee_view progress_demo %}
+          {% include 'includes/progress_trainee_view.html' with progress=progress_demo %}
           {% if progress_demo.state == "a" %}
             <p>Register for a Demo Session on this Etherpad: <a href="https://pad.carpentries.org/teaching-demos">Teaching Demos</a>.</p>
           {% endif %}

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -125,7 +125,7 @@
           {% now 'n' as current_month %}
           {% now 'Y' as current_year %}
           <p>Register for a Welcome Session on
-            {% if current_month|add:"0" >= 7 %}
+            {% if current_month|add:"0" >= 10 %}
             one of these Etherpads: <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year }}">Welcome Sessions {{ current_year }}</a>; <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year | add:'1' }}">Welcome Sessions {{ current_year | add:"1" }}</a>.
             {% else %}
             this Etherpad: <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year }}">Welcome Sessions {{ current_year }}</a>.

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -14,7 +14,7 @@
 {% endif %}
 
 <div>
-  <h2>Your progress toward becoming a Carpentries Instructor</h2>
+  <h2>Your progress towards becoming a Carpentries Instructor</h2>
   
   {% if user.instructor_badges %}
   <div class="alert alert-success" role="alert">
@@ -35,9 +35,10 @@
   {% elif user.passed_training %}
   <div class="alert alert-info" role="alert">
     <p>
+      {% checkout_deadline last_training.event.end as deadline %}
       Please review your progress towards Instructor certification below. 
       Based on your training dates of {% human_daterange last_training.event.start last_training.event.end %}, the 90-day deadline to complete these 
-      requirements is {% checkout_deadline last_training.start_date %}.
+      requirements is {{ deadline }}.
     </p>
       If you would like an extension, please contact us at 
       <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org</a>
@@ -114,11 +115,7 @@
         {% if last_welcome %}
           {% progress_trainee_view last_welcome %}
         {% elif user.passed_welcome %}
-          <p class="text-success">Welcome Session completed 
-            {% if last_welcome %}
-              as of {{ last_welcome.last_updated_at | date:'j F Y' }}
-            {% endif %}  
-            .
+          <p class="text-success">Welcome Session completed.
           </p>
         {% else %}
           <p>Welcome Session not completed yet.</p>
@@ -140,11 +137,7 @@
         {% if last_demo %}
           {% progress_trainee_view last_demo %}
         {% elif user.passed_demo %}
-        <p class="text-success">Demo Session passed
-          {% if last_demo %}
-            as of {{ last_demo.last_updated_at | date:'j F Y' }}
-          {% endif %}
-          .
+        <p class="text-success">Demo Session passed.
         </p>
         {% else %}
         <p>Demo Session not completed yet.</p>

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -122,13 +122,13 @@
           </p>
         {% else %}
           <p>Welcome Session not completed yet.</p>
-          {% is_late_in_year as show_next_year %}
+          {% now 'n' as current_month %}
           {% now 'Y' as current_year %}
           <p>Register for a Welcome Session on
-            {% if show_next_year %}
-            one of these Etherpads: <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">Welcome Sessions {% now 'Y' %}</a>; <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year | add:'1' }}">Welcome Sessions {{ current_year | add:"1" }}</a>.
+            {% if current_month|add:"0" >= 7 %}
+            one of these Etherpads: <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year }}">Welcome Sessions {{ current_year }}</a>; <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year | add:'1' }}">Welcome Sessions {{ current_year | add:"1" }}</a>.
             {% else %}
-            this Etherpad: <a href="https://pad.carpentries.org/welcome-sessions-{% now 'Y' %}">Welcome Sessions {% now 'Y' %}</a>.
+            this Etherpad: <a href="https://pad.carpentries.org/welcome-sessions-{{ current_year }}">Welcome Sessions {{ current_year }}</a>.
             {% endif %}
           </p>
         {% endif %}

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -138,6 +138,9 @@
       <td>
         {% if progress_demo %}
           {% progress_trainee_view progress_demo %}
+          {% if progress_demo.state == "a" %}
+            <p>Register for a Demo Session on this Etherpad: <a href="https://pad.carpentries.org/teaching-demos">Teaching Demos</a>.</p>
+          {% endif %}
         {% elif user.passed_demo %}
         <p class="text-success">Demo Session passed.
         </p>

--- a/amy/templates/includes/progress_trainee_view.html
+++ b/amy/templates/includes/progress_trainee_view.html
@@ -1,0 +1,16 @@
+{% load training_progress %}
+
+<p>
+    {{ progress.requirement.name }}
+    {% if progress.requirement.name == "Welcome Session" and progress.state == "p" %}
+        <span class = "badge-success">&nbsp;completed&nbsp;</span>    
+    {% else %}
+        <span class = "badge-{% progress_state_class progress.state %}">&nbsp;{{ progress.get_state_display | lower}}&nbsp;</span>
+    {% endif %}
+    as of 
+    {% if progress.requirement.name == "Training" %}
+        {{ progress.event.end }}.
+    {% else %}
+        {{ progress.last_updated_at.date }}.
+    {% endif %}
+</p>

--- a/amy/trainings/tests/test_template_tags.py
+++ b/amy/trainings/tests/test_template_tags.py
@@ -1,13 +1,16 @@
-from datetime import date
+from datetime import date, datetime
 
 from django.test import TestCase
 
 from trainings.models import Involvement
-from workshops.models import Person, TrainingProgress, TrainingRequirement
+from workshops.models import Event, Person, Tag, TrainingProgress, TrainingRequirement
 from workshops.templatetags.training_progress import (
+    checkout_deadline,
     progress_description,
     progress_label,
+    progress_trainee_view,
 )
+from workshops.tests.base import TestBase
 
 
 class TestProgressDescriptionTemplateTag(TestCase):
@@ -125,3 +128,171 @@ class TestProgressLabelTemplateTag(TestCase):
             )
             got = progress_label(progress)
             self.assertEqual(expected[state], got)
+
+
+class TestCheckoutDeadlineTemplateTag(TestCase):
+    def test_checkout_deadline(self):
+        # Arrange
+        start = date(2023, 7, 25)
+        # Act
+        got = checkout_deadline(start)
+        # Assert
+        expected = date(2023, 10, 23)
+        self.assertEqual(expected, got)
+
+
+class TestProgressTraineeViewTemplateTag(TestBase):
+    def test_progress_trainee_view__training(self):
+        # Arrange
+        self._setUpTags()
+        event = Event.objects.create(
+            slug="event-ttt",
+            start=date(2023, 6, 24),
+            end=date(2023, 6, 25),
+            host=self.org_alpha,
+        )
+        event.tags.add(Tag.objects.get(name="TTT"))
+        requirement, _ = TrainingRequirement.objects.get_or_create(name="Training")
+        progress = TrainingProgress.objects.create(
+            trainee=self.spiderman,
+            requirement=requirement,
+            state="p",  # passed
+            event=event,
+            url=None,
+        )
+
+        # Act
+        got = progress_trainee_view(progress)
+
+        # Assert
+        expected = '<p class="text-success"> Training passed as of June 25, 2023.</p>'
+        self.assertHTMLEqual(expected, got)
+
+    def test_progress_trainee_view__get_involved(self):
+        # Arrange
+        requirement, _ = TrainingRequirement.objects.get_or_create(
+            name="Get Involved", defaults={"involvement_required": True}
+        )
+        involvement, _ = Involvement.objects.get_or_create(
+            name="GitHub Contribution", defaults={"url_required": True}
+        )
+        progress = TrainingProgress.objects.create(
+            trainee=self.spiderman,
+            requirement=requirement,
+            involvement_type=involvement,
+            state="p",  # passed
+            event=None,
+            url="https://example.org",
+            date=date(2023, 6, 25),
+        )
+
+        # Act
+        got = progress_trainee_view(progress)
+
+        # Assert
+        expected = (
+            '<p class="text-success"> Get Involved passed as of '
+            f'{datetime.today().strftime("%B %d, %Y")}.</p>'
+        )
+        self.assertHTMLEqual(expected, got)
+
+    def test_progress_trainee_view__welcome(self):
+        # Arrange
+        requirement, _ = TrainingRequirement.objects.get_or_create(
+            name="Welcome Session"
+        )
+        progress = TrainingProgress.objects.create(
+            trainee=self.spiderman,
+            requirement=requirement,
+            state="p",  # passed
+        )
+
+        # Act
+        got = progress_trainee_view(progress)
+
+        # Assert
+        expected = (
+            '<p class="text-success"> Welcome Session passed as of '
+            f'{datetime.today().strftime("%B %d, %Y")}.</p>'
+        )
+        self.assertHTMLEqual(expected, got)
+
+    def test_progress_trainee_view__demo(self):
+        # Arrange
+        requirement, _ = TrainingRequirement.objects.get_or_create(name="Demo")
+        progress = TrainingProgress.objects.create(
+            trainee=self.spiderman,
+            requirement=requirement,
+            state="p",  # passed
+        )
+
+        # Act
+        got = progress_trainee_view(progress)
+
+        # Assert
+        expected = (
+            '<p class="text-success"> Demo passed as of '
+            f'{datetime.today().strftime("%B %d, %Y")}.</p>'
+        )
+        self.assertHTMLEqual(expected, got)
+
+    def test_progress_trainee_view__failed(self):
+        # Arrange
+        requirement, _ = TrainingRequirement.objects.get_or_create(name="Demo")
+        progress = TrainingProgress.objects.create(
+            trainee=self.spiderman,
+            requirement=requirement,
+            state="f",  # failed
+            notes="Reason for failure",
+        )
+
+        # Act
+        got = progress_trainee_view(progress)
+
+        # Assert
+        expected = (
+            '<p class="text-danger"> Demo failed as of '
+            f'{datetime.today().strftime("%B %d, %Y")}.</p>'
+            "<p>Administrator comments: Reason for failure</p>"
+        )
+        self.assertHTMLEqual(expected, got)
+
+    def test_progress_trainee_view__asked_to_repeat(self):
+        # Arrange
+        requirement, _ = TrainingRequirement.objects.get_or_create(name="Demo")
+        progress = TrainingProgress.objects.create(
+            trainee=self.spiderman,
+            requirement=requirement,
+            state="a",  # asked to repeat
+            notes="Reason for asking to repeat",
+        )
+
+        # Act
+        got = progress_trainee_view(progress)
+
+        # Assert
+        expected = (
+            '<p class="text-info"> Demo asked to repeat as of '
+            f'{datetime.today().strftime("%B %d, %Y")}.</p>'
+            "<p>Administrator comments: Reason for asking to repeat</p>"
+        )
+        self.assertHTMLEqual(expected, got)
+
+    def test_progress_trainee_view__not_evaluated_yet(self):
+        # Arrange
+        requirement, _ = TrainingRequirement.objects.get_or_create(name="Demo")
+        progress = TrainingProgress.objects.create(
+            trainee=self.spiderman,
+            requirement=requirement,
+            state="n",  # not evaluated yet
+        )
+
+        # Act
+        got = progress_trainee_view(progress)
+
+        # Assert
+        expected = (
+            '<p class="text-warning"> Demo not evaluated yet as of '
+            f'{datetime.today().strftime("%B %d, %Y")}.</p>'
+        )
+        self.assertHTMLEqual(expected, got)

--- a/amy/trainings/tests/test_template_tags.py
+++ b/amy/trainings/tests/test_template_tags.py
@@ -253,7 +253,7 @@ class TestProgressTraineeViewTemplateTag(TestBase):
         expected = (
             '<p class="text-danger"> Demo failed as of '
             f'{datetime.today().strftime("%B %d, %Y")}.</p>'
-            "<p>Administrator comments: Reason for failure</p>"
+            # "<p>Administrator comments: Reason for failure</p>"
         )
         self.assertHTMLEqual(expected, got)
 
@@ -274,7 +274,7 @@ class TestProgressTraineeViewTemplateTag(TestBase):
         expected = (
             '<p class="text-info"> Demo asked to repeat as of '
             f'{datetime.today().strftime("%B %d, %Y")}.</p>'
-            "<p>Administrator comments: Reason for asking to repeat</p>"
+            # "<p>Administrator comments: Reason for asking to repeat</p>"
         )
         self.assertHTMLEqual(expected, got)
 

--- a/amy/trainings/tests/test_template_tags.py
+++ b/amy/trainings/tests/test_template_tags.py
@@ -212,7 +212,7 @@ class TestProgressTraineeViewTemplateTag(TestBase):
 
         # Assert
         expected = (
-            '<p class="text-success"> Welcome Session passed as of '
+            '<p class="text-success"> Welcome Session completed as of '
             f'{datetime.today().strftime("%B %d, %Y")}.</p>'
         )
         self.assertHTMLEqual(expected, got)

--- a/amy/workshops/templatetags/dates.py
+++ b/amy/workshops/templatetags/dates.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django import template
 from django.utils.safestring import mark_safe
 from django.utils.timezone import now
@@ -20,17 +18,3 @@ def is_late_in_year():
     """return True if current month is October, November, or December"""
 
     return now().month >= 10
-
-
-@register.simple_tag
-def next_year():
-    """get the year after the current year"""
-
-    return now().year + 1
-
-
-@register.simple_tag
-def get_checkout_deadline(start_date):
-    """get the year after the current year"""
-
-    return start_date + timedelta(days=90)

--- a/amy/workshops/templatetags/dates.py
+++ b/amy/workshops/templatetags/dates.py
@@ -1,5 +1,6 @@
 from django import template
 from django.utils.safestring import mark_safe
+from django.utils.timezone import now
 
 from workshops.utils.dates import human_daterange as human_daterange_util
 
@@ -10,3 +11,17 @@ register = template.Library()
 def human_daterange(date_left, date_right):
     result = human_daterange_util(date_left, date_right)
     return mark_safe(result)
+
+
+@register.simple_tag
+def is_late_in_year():
+    """return True if current month is October, November, or December"""
+
+    return now().month >= 7
+
+
+@register.simple_tag
+def next_year():
+    """get the year after the current year"""
+
+    return now().year + 1

--- a/amy/workshops/templatetags/dates.py
+++ b/amy/workshops/templatetags/dates.py
@@ -1,6 +1,5 @@
 from django import template
 from django.utils.safestring import mark_safe
-from django.utils.timezone import now
 
 from workshops.utils.dates import human_daterange as human_daterange_util
 
@@ -11,10 +10,3 @@ register = template.Library()
 def human_daterange(date_left, date_right):
     result = human_daterange_util(date_left, date_right)
     return mark_safe(result)
-
-
-@register.simple_tag
-def is_late_in_year():
-    """return True if current month is October, November, or December"""
-
-    return now().month >= 10

--- a/amy/workshops/templatetags/dates.py
+++ b/amy/workshops/templatetags/dates.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django import template
 from django.utils.safestring import mark_safe
 from django.utils.timezone import now
@@ -17,7 +19,7 @@ def human_daterange(date_left, date_right):
 def is_late_in_year():
     """return True if current month is October, November, or December"""
 
-    return now().month >= 7
+    return now().month >= 10
 
 
 @register.simple_tag
@@ -25,3 +27,10 @@ def next_year():
     """get the year after the current year"""
 
     return now().year + 1
+
+
+@register.simple_tag
+def get_checkout_deadline(start_date):
+    """get the year after the current year"""
+
+    return start_date + timedelta(days=90)

--- a/amy/workshops/templatetags/training_progress.py
+++ b/amy/workshops/templatetags/training_progress.py
@@ -66,19 +66,30 @@ def checkout_deadline(start_date):
 
 
 @register.simple_tag
-def progress_trainee_view(progress):
+def progress_trainee_view(progress: TrainingProgress) -> str:
     assert isinstance(progress, TrainingProgress)
 
+    # state: follow our internal choices
+    # except for Welcome Session
+    # as 'passed' implies assessment, but you just have to show up
+    state_display = progress.get_state_display().lower()
+    if state_display == "passed" and progress.requirement.name == "Welcome Session":
+        state_display = "completed"
+
+    # date: show event dates for training, most recent update date otherwise
     date = progress.event.end if progress.event else progress.last_updated_at
+
+    # notes: show notes if state is failed or asked to repeat
     notes = (
         f"<p>Administrator comments: {progress.notes}</p>"
         if progress.state in ["f", "a"]
         else ""
     )
 
+    # put it all together
     text = (
         f'<p class="text-{progress_state_class(progress.state)}"> '
-        f"{progress.requirement.name} {progress.get_state_display().lower()} "
+        f"{progress.requirement.name} {state_display} "
         f'as of {date.strftime("%B %d, %Y")}.</p>{notes}'
     )
 

--- a/amy/workshops/templatetags/training_progress.py
+++ b/amy/workshops/templatetags/training_progress.py
@@ -23,9 +23,7 @@ def progress_state_class(state):
 def progress_label(progress):
     assert isinstance(progress, TrainingProgress)
 
-    additional_label = progress_state_class(progress.state)
-
-    fmt = "badge badge-{}".format(additional_label)
+    fmt = f"badge badge-{progress_state_class(progress.state)}"
     return mark_safe(fmt)
 
 
@@ -63,8 +61,7 @@ def progress_description(progress):
 
 @register.simple_tag
 def checkout_deadline(start_date):
-    """get the year after the current year"""
-
+    # we allow 90 days for checkout
     return start_date + timedelta(days=90)
 
 

--- a/amy/workshops/templatetags/training_progress.py
+++ b/amy/workshops/templatetags/training_progress.py
@@ -80,17 +80,19 @@ def progress_trainee_view(progress: TrainingProgress) -> str:
     date = progress.event.end if progress.event else progress.last_updated_at
 
     # notes: show notes if state is failed or asked to repeat
-    notes = (
-        f"<p>Administrator comments: {progress.notes}</p>"
-        if progress.state in ["f", "a"]
-        else ""
-    )
+    # TODO: implement a separate field for these notes
+    # notes = (
+    #     f"<p>Administrator comments: {progress.notes}</p>"
+    #     if progress.state in ["f", "a"]
+    #     else ""
+    # )
 
     # put it all together
     text = (
         f'<p class="text-{progress_state_class(progress.state)}"> '
         f"{progress.requirement.name} {state_display} "
-        f'as of {date.strftime("%B %d, %Y")}.</p>{notes}'
+        f'as of {date.strftime("%B %d, %Y")}.</p>'
+        # f'{notes}' # TODO
     )
 
     return mark_safe(text)

--- a/amy/workshops/templatetags/training_progress.py
+++ b/amy/workshops/templatetags/training_progress.py
@@ -82,7 +82,7 @@ def progress_trainee_view(progress):
     text = (
         f'<p class="text-{progress_state_class(progress.state)}"> '
         f"{progress.requirement.name} {progress.get_state_display().lower()} "
-        f'as of {date.strftime("%d %B %Y")}.</p>{notes}'
+        f'as of {date.strftime("%B %d, %Y")}.</p>{notes}'
     )
 
     return mark_safe(text)

--- a/amy/workshops/templatetags/training_progress.py
+++ b/amy/workshops/templatetags/training_progress.py
@@ -87,4 +87,5 @@ def welcome_instructions(date: datetime | None = None):
             f"Welcome Sessions { date.year }</a>."
         )
     text += "</p>"
-    return text
+
+    return mark_safe(text)

--- a/amy/workshops/templatetags/training_progress.py
+++ b/amy/workshops/templatetags/training_progress.py
@@ -73,12 +73,16 @@ def progress_trainee_view(progress):
     assert isinstance(progress, TrainingProgress)
 
     date = progress.event.end if progress.event else progress.last_updated_at
-    notes = f"<br/>Notes: {progress.notes}" if progress.state in ["f", "a"] else ""
+    notes = (
+        f"<p>Administrator comments: {progress.notes}</p>"
+        if progress.state in ["f", "a"]
+        else ""
+    )
 
     text = (
         f'<p class="text-{progress_state_class(progress.state)}"> '
         f"{progress.requirement.name} {progress.get_state_display().lower()} "
-        f'as of {date.strftime("%d %B %Y")}.{notes}</p>'
+        f'as of {date.strftime("%d %B %Y")}.</p>{notes}'
     )
 
     return mark_safe(text)


### PR DESCRIPTION
## Changes
This PR will:
- show colour-coded state & date of each step's progress. This shows one recent progress for each step, prioritising progress with a passed state. (fixes #2476, fixes #2477)
- update alerts at top of page (fixes #2475)

This PR will not:
- update the Get Involved part of the page to show/edit a submission - that will come in the next PR (and is previewed in #2472). I've deliberately omitted the submission form from the screenshots for this reason.
- ~fix the colour contrast issues that have arisen - @elichad will work on this separately before the 4.2 release~ figured out a way to improve contrast after all

Requesting code review from @pbanaszkiewicz as usual.

## Questions
For @klbarnes20 and @karenword I have some outstanding design questions. You only need to look through the screenshots below, not at the code (unless you want to).
1. we discussed the 'failed' state a bit in #2476 but I want to come back to this. In the current state of this PR, for a failed progress, the page will explicitly say 'failed' and will not display instructions for re-completing the step. Would you like this changed, and if so how?
2. I've assumed the 90-day checkout deadline is counted from the final day of the training event - is that correct?
3. I've rendered the 'Notes' field in cases where the state is 'asked to repeat' or 'failed.' This is so the trainee can see the reason for that status. However, since this field has not historically been shown to users, I can imagine that some older data would rather not be shown. We could potentially only show notes written after a specified date (e.g. the release date). What are your thoughts on this?

## Screenshots
No progress:
![Alert says to allow 7-10 days for recent checkout steps to show. Training not completed yet. Get Involved step not submitted yet.](https://github.com/carpentries/amy/assets/20683271/2159d995-c308-4cfd-a75f-6372bc18b4e9)
![Welcome Session not completed yet. Demo Session not completed yet. Both steps have instructions for Etherpad registration.](https://github.com/carpentries/amy/assets/20683271/b7740759-6e27-4809-9279-98e14a32f177)
After completing some steps with various status and submitting a Get Involved activity:
![Success message: submission will be reviewed in 7-10 days. Alert shows checkout deadline of June 14, 2023 and contact details for extensions. Training passed as of March 16, 2023. Get Involved not evaluated yet as of July 25, 2023.](https://github.com/carpentries/amy/assets/20683271/5e5dd1ea-75c7-4a38-a9bb-602fbbc0a243)
![Welcome session failed as of July 25, 2023. Administrator comments: Reason for failure. Demo asked to repeat as of July 25, 2023. Administrator comments: Reason for repeating. Instructions for Etherpad registration only appear for the Demo step.](https://github.com/carpentries/amy/assets/20683271/535cd88e-82a2-48ce-9831-44102654a45d)
After passing all steps:
![Alert says you have completed all steps towards Instructor certification and will receive more information in 1-2 weeks. Training passed as of March 16, 2023. Get Involved passed as of July 25, 2023.](https://github.com/carpentries/amy/assets/20683271/2630e557-a0ec-43b1-871b-a3f2929f51b5)
After instructor badge is awarded:
![Success alert says you're a certified Instructor!](https://github.com/carpentries/amy/assets/20683271/a99c1de6-e61e-4074-b602-a3975fdb6714)
