### PR TITLE
[Emails] Template context variables documentation links

### DIFF
--- a/amy/emails/actions.py
+++ b/amy/emails/actions.py
@@ -15,11 +15,17 @@ from emails.signals import (
     persons_merged_signal,
 )
 from emails.types import (
+    AdminSignsInstructorUpContext,
     AdminSignsInstructorUpKwargs,
+    InstructorBadgeAwardedContext,
     InstructorBadgeAwardedKwargs,
+    InstructorConfirmedContext,
     InstructorConfirmedKwargs,
+    InstructorDeclinedContext,
     InstructorDeclinedKwargs,
+    InstructorSignupContext,
     InstructorSignupKwargs,
+    PersonsMergedContext,
     PersonsMergedKwargs,
 )
 from emails.utils import (
@@ -47,7 +53,7 @@ def instructor_badge_awarded_receiver(
     scheduled_at = immediate_action()
     person = Person.objects.get(pk=person_id)
     award = Award.objects.get(pk=award_id)
-    context = {
+    context: InstructorBadgeAwardedContext = {
         "person": person,
         "award": award,
     }
@@ -83,7 +89,7 @@ def instructor_confirmed_for_workshop_receiver(
     instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
         pk=instructor_recruitment_signup_id
     )
-    context = {
+    context: InstructorConfirmedContext = {
         "person": person,
         "event": event,
         "instructor_recruitment_signup": instructor_recruitment_signup,
@@ -120,7 +126,7 @@ def instructor_declined_from_workshop_receiver(
     instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
         pk=instructor_recruitment_signup_id
     )
-    context = {
+    context: InstructorDeclinedContext = {
         "person": person,
         "event": event,
         "instructor_recruitment_signup": instructor_recruitment_signup,
@@ -157,7 +163,7 @@ def instructor_signs_up_for_workshop_receiver(
     instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
         pk=instructor_recruitment_signup_id
     )
-    context = {
+    context: InstructorSignupContext = {
         "person": person,
         "event": event,
         "instructor_recruitment_signup": instructor_recruitment_signup,
@@ -194,7 +200,7 @@ def admin_signs_instructor_up_for_workshop_receiver(
     instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
         pk=instructor_recruitment_signup_id
     )
-    context = {
+    context: AdminSignsInstructorUpContext = {
         "person": person,
         "event": event,
         "instructor_recruitment_signup": instructor_recruitment_signup,
@@ -223,7 +229,7 @@ def persons_merged_receiver(sender: Any, **kwargs: Unpack[PersonsMergedKwargs]) 
 
     scheduled_at = immediate_action()
     person = Person.objects.get(pk=selected_person_id)
-    context = {
+    context: PersonsMergedContext = {
         "person": person,
     }
     signal = persons_merged_signal.signal_name

--- a/amy/emails/controller.py
+++ b/amy/emails/controller.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any, Mapping
 
 from django.db.models import Model
 
@@ -15,7 +16,7 @@ class EmailController:
     @staticmethod
     def schedule_email(
         signal: str,
-        context: dict,
+        context: Mapping[str, Any],
         scheduled_at: datetime,
         to_header: list[str],
         generic_relation_obj: Model | None = None,
@@ -24,8 +25,8 @@ class EmailController:
         template = EmailTemplate.objects.filter(active=True).get(signal=signal)
         engine = EmailTemplate.get_engine()
 
-        subject = EmailTemplate.render_template(engine, template.subject, context)
-        body = EmailTemplate.render_template(engine, template.body, context)
+        subject = EmailTemplate.render_template(engine, template.subject, dict(context))
+        body = EmailTemplate.render_template(engine, template.body, dict(context))
 
         scheduled_email = ScheduledEmail.objects.create(
             state="scheduled",

--- a/amy/emails/forms.py
+++ b/amy/emails/forms.py
@@ -38,7 +38,16 @@ class EmailTemplateCreateForm(forms.ModelForm):
         self.fields["bcc_header"].help_text = array_email_field_help_text
 
 
-EmailTemplateUpdateForm = EmailTemplateCreateForm
+class EmailTemplateUpdateForm(EmailTemplateCreateForm):
+    signal = forms.CharField(
+        required=False,
+        disabled=True,
+        help_text=EmailTemplate._meta.get_field("signal").help_text,
+        widget=forms.Select(choices=SignalNameEnum.choices()),
+    )
+
+    class Meta(EmailTemplateCreateForm.Meta):
+        pass
 
 
 class ScheduledEmailUpdateForm(forms.ModelForm):

--- a/amy/emails/signals.py
+++ b/amy/emails/signals.py
@@ -63,3 +63,12 @@ persons_merged_signal = Signal(
     signal_name=SignalNameEnum.persons_merged,
     context_type=PersonsMergedContext,
 )
+
+ALL_SIGNALS = [
+    instructor_badge_awarded_signal,
+    instructor_confirmed_for_workshop_signal,
+    instructor_declined_from_workshop_signal,
+    instructor_signs_up_for_workshop_signal,
+    admin_signs_instructor_up_for_workshop_signal,
+    persons_merged_signal,
+]

--- a/amy/emails/signals.py
+++ b/amy/emails/signals.py
@@ -64,11 +64,4 @@ persons_merged_signal = Signal(
     context_type=PersonsMergedContext,
 )
 
-ALL_SIGNALS = [
-    instructor_badge_awarded_signal,
-    instructor_confirmed_for_workshop_signal,
-    instructor_declined_from_workshop_signal,
-    instructor_signs_up_for_workshop_signal,
-    admin_signs_instructor_up_for_workshop_signal,
-    persons_merged_signal,
-]
+ALL_SIGNALS = [item for item in locals().values() if isinstance(item, Signal)]

--- a/amy/emails/signals.py
+++ b/amy/emails/signals.py
@@ -1,6 +1,16 @@
 from enum import StrEnum
+from typing import Any, Mapping
 
 from django.dispatch import Signal as DjangoSignal
+
+from emails.types import (
+    AdminSignsInstructorUpContext,
+    InstructorBadgeAwardedContext,
+    InstructorConfirmedContext,
+    InstructorDeclinedContext,
+    InstructorSignupContext,
+    PersonsMergedContext,
+)
 
 
 class SignalNameEnum(StrEnum):
@@ -20,26 +30,36 @@ class SignalNameEnum(StrEnum):
 
 class Signal(DjangoSignal):
     signal_name: SignalNameEnum
+    context_type: type[Mapping[str, Any]]
 
     def __init__(self, *args, **kwargs):
         self.signal_name = kwargs.pop("signal_name")
+        self.context_type = kwargs.pop("context_type")
         super().__init__(*args, **kwargs)
 
 
 # Scheduled to run immediately after action (so roughly up to 1 hour later).
 instructor_badge_awarded_signal = Signal(
-    signal_name=SignalNameEnum.instructor_badge_awarded
+    signal_name=SignalNameEnum.instructor_badge_awarded,
+    context_type=InstructorBadgeAwardedContext,
 )
 instructor_confirmed_for_workshop_signal = Signal(
-    signal_name=SignalNameEnum.instructor_confirmed_for_workshop
+    signal_name=SignalNameEnum.instructor_confirmed_for_workshop,
+    context_type=InstructorConfirmedContext,
 )
 instructor_declined_from_workshop_signal = Signal(
-    signal_name=SignalNameEnum.instructor_declined_from_workshop
+    signal_name=SignalNameEnum.instructor_declined_from_workshop,
+    context_type=InstructorDeclinedContext,
 )
 instructor_signs_up_for_workshop_signal = Signal(
-    signal_name=SignalNameEnum.instructor_signs_up_for_workshop
+    signal_name=SignalNameEnum.instructor_signs_up_for_workshop,
+    context_type=InstructorSignupContext,
 )
 admin_signs_instructor_up_for_workshop_signal = Signal(
-    signal_name=SignalNameEnum.admin_signs_instructor_up_for_workshop
+    signal_name=SignalNameEnum.admin_signs_instructor_up_for_workshop,
+    context_type=AdminSignsInstructorUpContext,
 )
-persons_merged_signal = Signal(signal_name=SignalNameEnum.persons_merged)
+persons_merged_signal = Signal(
+    signal_name=SignalNameEnum.persons_merged,
+    context_type=PersonsMergedContext,
+)

--- a/amy/emails/templatetags/emails.py
+++ b/amy/emails/templatetags/emails.py
@@ -15,6 +15,10 @@ def is_email_module_enabled() -> bool:
 
 @register.filter
 def model_documentation_link(model: Model) -> str:
+    # This is a limited mapping of model to its documentation link. It should
+    # be expanded as needed.
+    # If our model documentation grows, we should consider including link to model
+    # documentation inside every model. Then this mapping would become obsolete.
     mapping = {
         "InstructorRecruitmentSignup": (
             "https://carpentries.github.io/amy/design/database_models/"

--- a/amy/emails/templatetags/emails.py
+++ b/amy/emails/templatetags/emails.py
@@ -1,5 +1,6 @@
 from django import template
 from django.conf import settings
+from django.db.models import Model
 
 register = template.Library()
 
@@ -10,3 +11,18 @@ def is_email_module_enabled() -> bool:
         return bool(settings.EMAIL_MODULE_ENABLED)
     except AttributeError:
         return False
+
+
+@register.filter
+def model_documentation_link(model: Model) -> str:
+    mapping = {
+        "InstructorRecruitmentSignup": (
+            "https://carpentries.github.io/amy/design/database_models/"
+            "#instructorrecruitmentsignup"
+        ),
+        "Event": "https://carpentries.github.io/amy/amy_database_structure/#events",
+        "Award": "https://carpentries.github.io/amy/design/database_models/#award",
+        "Person": "https://carpentries.github.io/amy/amy_database_structure/#persons",
+    }
+    model_name = model.__class__.__name__
+    return mapping.get(model_name, "")

--- a/amy/emails/tests/test_signals.py
+++ b/amy/emails/tests/test_signals.py
@@ -28,7 +28,7 @@ class TestSignal(TestCase):
     def test_signal_name(self) -> None:
         """Check if Signal contains an attribute `signal_name`."""
         # Arrange
-        signal = Signal(signal_name="test_signal_name")
+        signal = Signal(signal_name="test_signal_name", context_type=dict)
 
         # Act
         signal_name = signal.signal_name

--- a/amy/emails/tests/test_signals.py
+++ b/amy/emails/tests/test_signals.py
@@ -1,18 +1,14 @@
 from django.test import TestCase
 
 import emails.signals
-from emails.signals import Signal, SignalNameEnum
+from emails.signals import ALL_SIGNALS, Signal, SignalNameEnum
 
 
 class TestSignalName(TestCase):
     def test_choices(self) -> None:
         """Check if SignalName.choices() returns all defined signals."""
         # Arrange
-        signal_names = {
-            emails.signals.__dict__[signal].signal_name
-            for signal in emails.signals.__dict__
-            if signal.endswith("_signal")
-        }
+        signal_names = {item.signal_name for item in ALL_SIGNALS}
 
         # Act
         choices = SignalNameEnum.choices()

--- a/amy/emails/tests/test_template_tags.py
+++ b/amy/emails/tests/test_template_tags.py
@@ -16,6 +16,8 @@ class TestEmailsTemplateTags(TestCase):
 class TestModelDocumentationLink(TestCase):
     def test_model_documentation_link__valid_model(self) -> None:
         # Arrange
+        # Real models are replaced with their metaclass BaseModel, so the tests don't
+        # work with real models and instead mocks are used.
         model = MagicMock()
         model.__class__.__name__ = "Person"
 
@@ -30,6 +32,8 @@ class TestModelDocumentationLink(TestCase):
 
     def test_model_documentation_link__invalid_model(self) -> None:
         # Arrange
+        # Real models are replaced with their metaclass BaseModel, so the tests don't
+        # work with real models and instead mocks are used.
         model = MagicMock()
         # Badge is not in the mapping yet
         model.__class__.__name__ = "Badge"

--- a/amy/emails/tests/test_template_tags.py
+++ b/amy/emails/tests/test_template_tags.py
@@ -1,6 +1,8 @@
+from unittest.mock import MagicMock
+
 from django.test import TestCase
 
-from emails.templatetags.emails import is_email_module_enabled
+from emails.templatetags.emails import is_email_module_enabled, model_documentation_link
 
 
 class TestEmailsTemplateTags(TestCase):
@@ -9,3 +11,31 @@ class TestEmailsTemplateTags(TestCase):
             self.assertEqual(is_email_module_enabled(), False)
         with self.settings(EMAIL_MODULE_ENABLED=True):
             self.assertEqual(is_email_module_enabled(), True)
+
+
+class TestModelDocumentationLink(TestCase):
+    def test_model_documentation_link__valid_model(self) -> None:
+        # Arrange
+        model = MagicMock()
+        model.__class__.__name__ = "Person"
+
+        # Act
+        link = model_documentation_link(model)
+
+        # Assert
+        self.assertEqual(
+            link,
+            "https://carpentries.github.io/amy/amy_database_structure/#persons",
+        )
+
+    def test_model_documentation_link__invalid_model(self) -> None:
+        # Arrange
+        model = MagicMock()
+        # Badge is not in the mapping yet
+        model.__class__.__name__ = "Badge"
+
+        # Act
+        link = model_documentation_link(model)
+
+        # Assert
+        self.assertEqual(link, "")

--- a/amy/emails/tests/test_utils.py
+++ b/amy/emails/tests/test_utils.py
@@ -7,9 +7,11 @@ from django.utils import timezone
 import pytz
 
 from emails.models import ScheduledEmail
+from emails.signals import Signal
 from emails.utils import (
     check_feature_flag,
     feature_flag_enabled,
+    find_signal_by_name,
     immediate_action,
     messages_action_scheduled,
     messages_missing_template,
@@ -127,3 +129,36 @@ class TestPersonFromRequest(TestCase):
         result = person_from_request(request)
         # Assert
         self.assertEqual(result, user)
+
+
+class TestFindSignalByName(TestCase):
+    def test_find_signal_by_name__empty_signal_list(self) -> None:
+        # Arrange
+        all_signals = []
+
+        # Act
+        result = find_signal_by_name("test", all_signals)
+
+        # Assert
+        self.assertEqual(result, None)
+
+    def test_find_signal_by_name__signal_not_found(self) -> None:
+        # Arrange
+        all_signals = [Signal(signal_name="not_found", context_type=dict)]
+
+        # Act
+        result = find_signal_by_name("test", all_signals)
+
+        # Assert
+        self.assertEqual(result, None)
+
+    def test_find_signal_by_name__signal_found(self) -> None:
+        # Arrange
+        expected = Signal(signal_name="test", context_type=dict)
+        all_signals = [Signal(signal_name="not_found", context_type=dict), expected]
+
+        # Act
+        result = find_signal_by_name("test", all_signals)
+
+        # Assert
+        self.assertEqual(result, expected)

--- a/amy/emails/tests/test_views.py
+++ b/amy/emails/tests/test_views.py
@@ -10,6 +10,8 @@ from emails.models import (
     ScheduledEmailLog,
     ScheduledEmailStatus,
 )
+from emails.types import PersonsMergedContext
+from workshops.models import Person
 from workshops.tests.base import TestBase
 
 
@@ -53,7 +55,7 @@ class TestEmailTemplateDetails(TestBase):
         super()._setUpUsersAndLogin()
         template = EmailTemplate.objects.create(
             name="Test Email Template1",
-            signal="test_email_template1",
+            signal="persons_merged",
             from_header="workshops@carpentries.org",
             cc_header=["team@carpentries.org"],
             bcc_header=[],
@@ -71,6 +73,13 @@ class TestEmailTemplateDetails(TestBase):
         self.assertEqual(
             rv.context["rendered_body"],
             "<p>Hello, {{ name }}! Nice to meet <strong>you</strong>.</p>",
+        )
+        self.assertEqual(rv.context["body_context_type"], PersonsMergedContext)
+        self.assertEqual(
+            rv.context["body_context_annotations"],
+            {
+                "person": Person,
+            },
         )
 
 
@@ -242,7 +251,7 @@ class TestScheduledEmailDetails(TestBase):
         super()._setUpUsersAndLogin()
         template = EmailTemplate.objects.create(
             name="Test Email Template1",
-            signal="test_email_template1",
+            signal="persons_merged",
             from_header="workshops@carpentries.org",
             cc_header=["team@carpentries.org"],
             bcc_header=[],
@@ -286,6 +295,13 @@ class TestScheduledEmailDetails(TestBase):
         self.assertEqual(
             rv.context["rendered_body"],
             "<p>Hello, Harry! Nice to meet <strong>you</strong>.</p>",
+        )
+        self.assertEqual(rv.context["body_context_type"], PersonsMergedContext)
+        self.assertEqual(
+            rv.context["body_context_annotations"],
+            {
+                "person": Person,
+            },
         )
 
 

--- a/amy/emails/tests/test_views.py
+++ b/amy/emails/tests/test_views.py
@@ -118,6 +118,33 @@ class TestEmailTemplateCreate(TestBase):
 
 class TestEmailTemplateUpdateView(TestBase):
     @override_settings(EMAIL_MODULE_ENABLED=True)
+    def test_view_context(self) -> None:
+        # Arrange
+        super()._setUpUsersAndLogin()
+        template = EmailTemplate.objects.create(
+            name="Test Email Template1",
+            signal="persons_merged",
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ name }}",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+        url = reverse("emailtemplate_edit", kwargs={"pk": template.pk})
+
+        # Act
+        rv = self.client.get(url)
+
+        # Assert
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(
+            rv.context["body_context_annotations"],
+            {
+                "person": Person,
+            },
+        )
+
+    @override_settings(EMAIL_MODULE_ENABLED=True)
     def test_view(self) -> None:
         # Arrange
         super()._setUpUsersAndLogin()
@@ -306,6 +333,46 @@ class TestScheduledEmailDetails(TestBase):
 
 
 class TestScheduledEmailUpdate(TestBase):
+    @override_settings(EMAIL_MODULE_ENABLED=True)
+    def test_view_context(self) -> None:
+        # Arrange
+        super()._setUpUsersAndLogin()
+        template = EmailTemplate.objects.create(
+            name="Test Email Template1",
+            signal="persons_merged",
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ name }}",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+        engine = EmailTemplate.get_engine()
+        context = {"name": "Harry"}
+        scheduled_email = ScheduledEmail.objects.create(
+            scheduled_at=timezone.now() + timedelta(hours=1),
+            to_header=["peter@spiderman.net"],
+            from_header=template.from_header,
+            reply_to_header=template.reply_to_header,
+            cc_header=template.cc_header,
+            bcc_header=template.bcc_header,
+            subject=template.render_template(engine, template.subject, context),
+            body=template.render_template(engine, template.body, context),
+            template=template,
+        )
+        url = reverse("scheduledemail_edit", kwargs={"pk": scheduled_email.pk})
+
+        # Act
+        rv = self.client.get(url)
+
+        # Assert
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(
+            rv.context["body_context_annotations"],
+            {
+                "person": Person,
+            },
+        )
+
     @override_settings(EMAIL_MODULE_ENABLED=True)
     def test_view(self) -> None:
         # Arrange

--- a/amy/emails/tests/test_views.py
+++ b/amy/emails/tests/test_views.py
@@ -150,7 +150,7 @@ class TestEmailTemplateUpdateView(TestBase):
         template.refresh_from_db()
 
         self.assertEqual(template.name, "Greetings")
-        self.assertEqual(template.signal, "greetings")
+        self.assertEqual(template.signal, "test_email_template1")
         self.assertEqual(template.from_header, "noreply@carpentries.org")
         self.assertEqual(template.reply_to_header, "")
         self.assertEqual(template.cc_header, [])

--- a/amy/emails/tests/test_views.py
+++ b/amy/emails/tests/test_views.py
@@ -323,13 +323,6 @@ class TestScheduledEmailDetails(TestBase):
             rv.context["rendered_body"],
             "<p>Hello, Harry! Nice to meet <strong>you</strong>.</p>",
         )
-        self.assertEqual(rv.context["body_context_type"], PersonsMergedContext)
-        self.assertEqual(
-            rv.context["body_context_annotations"],
-            {
-                "person": Person,
-            },
-        )
 
 
 class TestScheduledEmailUpdate(TestBase):
@@ -366,12 +359,6 @@ class TestScheduledEmailUpdate(TestBase):
 
         # Assert
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(
-            rv.context["body_context_annotations"],
-            {
-                "person": Person,
-            },
-        )
 
     @override_settings(EMAIL_MODULE_ENABLED=True)
     def test_view(self) -> None:

--- a/amy/emails/types.py
+++ b/amy/emails/types.py
@@ -2,11 +2,19 @@ from typing import TypedDict
 
 from django.http import HttpRequest
 
+from recruitment.models import InstructorRecruitmentSignup
+from workshops.models import Award, Event, Person
+
 
 class InstructorBadgeAwardedKwargs(TypedDict):
     request: HttpRequest
     person_id: int
     award_id: int
+
+
+class InstructorBadgeAwardedContext(TypedDict):
+    person: Person
+    award: Award
 
 
 class InstructorConfirmedKwargs(TypedDict):
@@ -17,12 +25,24 @@ class InstructorConfirmedKwargs(TypedDict):
     instructor_recruitment_signup_id: int
 
 
+class InstructorConfirmedContext(TypedDict):
+    person: Person
+    event: Event
+    instructor_recruitment_signup: InstructorRecruitmentSignup
+
+
 class InstructorDeclinedKwargs(TypedDict):
     request: HttpRequest
     person_id: int
     event_id: int
     instructor_recruitment_id: int
     instructor_recruitment_signup_id: int
+
+
+class InstructorDeclinedContext(TypedDict):
+    person: Person
+    event: Event
+    instructor_recruitment_signup: InstructorRecruitmentSignup
 
 
 class InstructorSignupKwargs(TypedDict):
@@ -33,6 +53,12 @@ class InstructorSignupKwargs(TypedDict):
     instructor_recruitment_signup_id: int
 
 
+class InstructorSignupContext(TypedDict):
+    person: Person
+    event: Event
+    instructor_recruitment_signup: InstructorRecruitmentSignup
+
+
 class AdminSignsInstructorUpKwargs(TypedDict):
     request: HttpRequest
     person_id: int
@@ -41,8 +67,18 @@ class AdminSignsInstructorUpKwargs(TypedDict):
     instructor_recruitment_signup_id: int
 
 
+class AdminSignsInstructorUpContext(TypedDict):
+    person: Person
+    event: Event
+    instructor_recruitment_signup: InstructorRecruitmentSignup
+
+
 class PersonsMergedKwargs(TypedDict):
     request: HttpRequest
     person_a_id: int
     person_b_id: int
     selected_person_id: int
+
+
+class PersonsMergedContext(TypedDict):
+    person: Person

--- a/amy/emails/utils.py
+++ b/amy/emails/utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 import logging
-from typing import cast
+from typing import Iterable, cast
 
 from django.conf import settings
 from django.contrib import messages
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.utils.html import format_html
 
 from emails.models import ScheduledEmail
+from emails.signals import Signal
 from workshops.models import Person
 
 logger = logging.getLogger("amy")
@@ -75,3 +76,12 @@ def person_from_request(request: HttpRequest) -> Person | None:
         return None
 
     return cast(Person, request.user)
+
+
+def find_signal_by_name(
+    signal_name: str, all_signals: Iterable[Signal]
+) -> Signal | None:
+    return next(
+        (signal for signal in all_signals if signal.signal_name == signal_name),
+        None,
+    )

--- a/amy/emails/views.py
+++ b/amy/emails/views.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable
+from typing import Any
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
@@ -16,7 +16,7 @@ from emails.forms import (
 )
 from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailLog
 from emails.signals import ALL_SIGNALS, Signal
-from emails.utils import person_from_request
+from emails.utils import find_signal_by_name, person_from_request
 from workshops.base_views import (
     AMYCreateView,
     AMYDeleteView,
@@ -27,15 +27,6 @@ from workshops.base_views import (
     ConditionallyEnabledMixin,
 )
 from workshops.utils.access import OnlyForAdminsMixin
-
-
-def find_signal_by_name(
-    signal_name: str, all_signals: Iterable[Signal]
-) -> Signal | None:
-    return next(
-        (signal for signal in all_signals if signal.signal_name == signal_name),
-        None,
-    )
 
 
 class EmailModuleEnabledMixin(ConditionallyEnabledMixin):

--- a/amy/emails/views.py
+++ b/amy/emails/views.py
@@ -84,6 +84,14 @@ class EmailTemplateUpdate(OnlyForAdminsMixin, EmailModuleEnabledMixin, AMYUpdate
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = f'Email template "{self.object}"'
+
+        signal = find_signal_by_name(self.object.signal, ALL_SIGNALS)
+
+        context["body_context_type"] = None
+        context["body_context_annotations"] = {}
+        if signal:
+            context["body_context_type"] = signal.context_type
+            context["body_context_annotations"] = signal.context_type.__annotations__
         return context
 
 
@@ -146,6 +154,16 @@ class ScheduledEmailUpdate(OnlyForAdminsMixin, EmailModuleEnabledMixin, AMYUpdat
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = f'Scheduled email "{self.object.subject}"'
+
+        signal: Signal | None = None
+        if self.object.template:
+            signal = find_signal_by_name(self.object.template.signal, ALL_SIGNALS)
+
+        context["body_context_type"] = None
+        context["body_context_annotations"] = {}
+        if signal:
+            context["body_context_type"] = signal.context_type
+            context["body_context_annotations"] = signal.context_type.__annotations__
         return context
 
     def form_valid(self, form: ScheduledEmailUpdateForm) -> HttpResponse:

--- a/amy/emails/views.py
+++ b/amy/emails/views.py
@@ -15,7 +15,7 @@ from emails.forms import (
     ScheduledEmailUpdateForm,
 )
 from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailLog
-from emails.signals import ALL_SIGNALS, Signal
+from emails.signals import ALL_SIGNALS
 from emails.utils import find_signal_by_name, person_from_request
 from workshops.base_views import (
     AMYCreateView,
@@ -130,16 +130,6 @@ class ScheduledEmailDetails(OnlyForAdminsMixin, EmailModuleEnabledMixin, AMYDeta
             .order_by("-created_at")
         )
         context["rendered_body"] = markdownify(self.object.body)
-
-        signal: Signal | None = None
-        if self.object.template:
-            signal = find_signal_by_name(self.object.template.signal, ALL_SIGNALS)
-
-        context["body_context_type"] = None
-        context["body_context_annotations"] = {}
-        if signal:
-            context["body_context_type"] = signal.context_type
-            context["body_context_annotations"] = signal.context_type.__annotations__
         return context
 
 
@@ -154,16 +144,6 @@ class ScheduledEmailUpdate(OnlyForAdminsMixin, EmailModuleEnabledMixin, AMYUpdat
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = f'Scheduled email "{self.object.subject}"'
-
-        signal: Signal | None = None
-        if self.object.template:
-            signal = find_signal_by_name(self.object.template.signal, ALL_SIGNALS)
-
-        context["body_context_type"] = None
-        context["body_context_annotations"] = {}
-        if signal:
-            context["body_context_type"] = signal.context_type
-            context["body_context_annotations"] = signal.context_type.__annotations__
         return context
 
     def form_valid(self, form: ScheduledEmailUpdateForm) -> HttpResponse:

--- a/amy/templates/emails/email_template_create.html
+++ b/amy/templates/emails/email_template_create.html
@@ -6,4 +6,13 @@
 
 {% crispy form %}
 
+<div class="row">
+  <div class="col-12 col-lg-2">
+    <strong>Template variables</strong>
+  </div>
+  <div class="col-12 col-lg-10">
+    Visible after saving the template.
+  </div>
+</div>
+
 {% endblock %}

--- a/amy/templates/emails/email_template_create.html
+++ b/amy/templates/emails/email_template_create.html
@@ -8,7 +8,7 @@
 
 <div class="row">
   <div class="col-12 col-lg-2">
-    <strong>Template variables</strong>
+    <strong>Variables available in the email template body</strong>
   </div>
   <div class="col-12 col-lg-10">
     Visible after saving the template.

--- a/amy/templates/emails/email_template_detail.html
+++ b/amy/templates/emails/email_template_detail.html
@@ -1,4 +1,5 @@
 {% extends "base_nav.html" %}
+{% load emails %}
 
 {% block content %}
 
@@ -94,6 +95,16 @@
     <td>
       <strong>Rendered:</strong>
       {{ rendered_body|safe }}
+    </td>
+  </tr>
+  <tr>
+    <th>Template variables</th>
+    <td colspan="2">
+      <ul>
+      {% for key, value in body_context_annotations.items %}
+      <li><code>{{ key }}</code>: {{ value|model_documentation_link|urlize }}</li>
+      {% endfor %}
+      </ul>
     </td>
   </tr>
 </table>

--- a/amy/templates/emails/email_template_detail.html
+++ b/amy/templates/emails/email_template_detail.html
@@ -98,7 +98,7 @@
     </td>
   </tr>
   <tr>
-    <th>Template variables</th>
+    <th>Variables available in the email template body</th>
     <td colspan="2">
       <ul>
       {% for key, value in body_context_annotations.items %}

--- a/amy/templates/emails/email_template_edit.html
+++ b/amy/templates/emails/email_template_edit.html
@@ -9,7 +9,7 @@
 
 <div class="row">
   <div class="col-12 col-lg-2">
-    <strong>Template variables</strong>
+    <strong>Variables available in the email template body</strong>
   </div>
   <div class="col-12 col-lg-10">
     <ul>

--- a/amy/templates/emails/email_template_edit.html
+++ b/amy/templates/emails/email_template_edit.html
@@ -1,9 +1,23 @@
 {% extends "base_nav.html" %}
 
 {% load crispy_forms_tags %}
+{% load emails %}
 
 {% block content %}
 
 {% crispy form %}
+
+<div class="row">
+  <div class="col-12 col-lg-2">
+    <strong>Template variables</strong>
+  </div>
+  <div class="col-12 col-lg-10">
+    <ul>
+    {% for key, value in body_context_annotations.items %}
+    <li><code>{{ key }}</code>: {{ value|model_documentation_link|urlize }}</li>
+    {% endfor %}
+    </ul>
+  </div>
+</div>
 
 {% endblock %}

--- a/amy/templates/emails/scheduled_email_detail.html
+++ b/amy/templates/emails/scheduled_email_detail.html
@@ -117,18 +117,8 @@
     </td>
   </tr>
   <tr>
-    <th>Template:</th>
+    <th>Email template:</th>
     <td colspan="2"><a href="{{ scheduled_email.template.get_absolute_url }}">{{ scheduled_email.template }}</a></td>
-  </tr>
-  <tr>
-    <th>Template variables</th>
-    <td colspan="2">
-      <ul>
-      {% for key, value in body_context_annotations.items %}
-      <li><code>{{ key }}</code>: {{ value|model_documentation_link|urlize }}</li>
-      {% endfor %}
-      </ul>
-    </td>
   </tr>
   <tr>
     <th>Related object:</th>

--- a/amy/templates/emails/scheduled_email_detail.html
+++ b/amy/templates/emails/scheduled_email_detail.html
@@ -1,4 +1,5 @@
 {% extends "base_nav.html" %}
+{% load emails %}
 
 {% block title %}
 <h1>
@@ -118,6 +119,16 @@
   <tr>
     <th>Template:</th>
     <td colspan="2"><a href="{{ scheduled_email.template.get_absolute_url }}">{{ scheduled_email.template }}</a></td>
+  </tr>
+  <tr>
+    <th>Template variables</th>
+    <td colspan="2">
+      <ul>
+      {% for key, value in body_context_annotations.items %}
+      <li><code>{{ key }}</code>: {{ value|model_documentation_link|urlize }}</li>
+      {% endfor %}
+      </ul>
+    </td>
   </tr>
   <tr>
     <th>Related object:</th>

--- a/amy/templates/emails/scheduled_email_edit.html
+++ b/amy/templates/emails/scheduled_email_edit.html
@@ -1,6 +1,7 @@
 {% extends "base_nav.html" %}
 
 {% load crispy_forms_tags %}
+{% load emails %}
 
 {% block title %}
 <h1>
@@ -14,5 +15,18 @@
 {% include "emails/scheduled_email_header_details.html" with scheduled_email=scheduled_email %}
 
 {% crispy form %}
+
+<div class="row">
+  <div class="col-12 col-lg-2">
+    <strong>Template variables</strong>
+  </div>
+  <div class="col-12 col-lg-10">
+    <ul>
+    {% for key, value in body_context_annotations.items %}
+    <li><code>{{ key }}</code>: {{ value|model_documentation_link|urlize }}</li>
+    {% endfor %}
+    </ul>
+  </div>
+</div>
 
 {% endblock %}

--- a/amy/templates/emails/scheduled_email_edit.html
+++ b/amy/templates/emails/scheduled_email_edit.html
@@ -16,17 +16,4 @@
 
 {% crispy form %}
 
-<div class="row">
-  <div class="col-12 col-lg-2">
-    <strong>Template variables</strong>
-  </div>
-  <div class="col-12 col-lg-10">
-    <ul>
-    {% for key, value in body_context_annotations.items %}
-    <li><code>{{ key }}</code>: {{ value|model_documentation_link|urlize }}</li>
-    {% endfor %}
-    </ul>
-  </div>
-</div>
-
 {% endblock %}


### PR DESCRIPTION
This fixes #2482 by providing links to documentation for every variable used in email template context (e.g. person, event, award, etc.).

It builds on top of #2481.

~~WIP. Needs testing and perhaps some code improvements / refactoring.~~