### PR TITLE
[Emails] Prevent changes to emails in specific states

### DIFF
--- a/amy/emails/controller.py
+++ b/amy/emails/controller.py
@@ -57,10 +57,16 @@ class EmailController:
         author: Person | None = None,
     ) -> ScheduledEmail:
         scheduled_email.scheduled_at = new_scheduled_at
+
+        # Rescheduling a cancelled email will make it scheduled again.
+        state_before = scheduled_email.state
+        if scheduled_email.state == ScheduledEmailStatus.CANCELLED:
+            scheduled_email.state = ScheduledEmailStatus.SCHEDULED
+
         scheduled_email.save()
         ScheduledEmailLog.objects.create(
             details=f"Rescheduled email to run at {new_scheduled_at.isoformat()}",
-            state_before=scheduled_email.state,
+            state_before=state_before,
             state_after=scheduled_email.state,
             scheduled_email=scheduled_email,
             author=author,

--- a/amy/emails/models.py
+++ b/amy/emails/models.py
@@ -125,8 +125,6 @@ ScheduledEmailStatusActions = {
     "edit": [
         ScheduledEmailStatus.SCHEDULED,
         ScheduledEmailStatus.FAILED,
-        # note: will not re-send the email or affect emails already sent
-        ScheduledEmailStatus.SUCCEEDED,
     ],
     "reschedule": [
         ScheduledEmailStatus.SCHEDULED,

--- a/amy/emails/models.py
+++ b/amy/emails/models.py
@@ -111,12 +111,44 @@ class EmailTemplate(ActiveMixin, CreatedUpdatedMixin, models.Model):
 
 
 class ScheduledEmailStatus(models.TextChoices):
-    SCHEDULED = "scheduled"
-    LOCKED = "locked"
-    RUNNING = "running"
-    SUCCEEDED = "succeeded"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
+    SCHEDULED = "scheduled"  # editing, cancelling allowed
+    LOCKED = "locked"  # nothing allowed
+    RUNNING = "running"  # nothing allowed
+    SUCCEEDED = "succeeded"  # editing allowed with note about re-sending
+    FAILED = "failed"  # editing, cancelling allowed
+    CANCELLED = "cancelled"  # allowed to re-schedule
+
+
+# List of states when specific actions are allowed. This is used in per-object
+# permissions to block or allow specific actions.
+ScheduledEmailStatusActions = {
+    "edit": [
+        ScheduledEmailStatus.SCHEDULED,
+        ScheduledEmailStatus.FAILED,
+        # note: will not re-send the email or affect emails already sent
+        ScheduledEmailStatus.SUCCEEDED,
+    ],
+    "reschedule": [
+        ScheduledEmailStatus.SCHEDULED,
+        ScheduledEmailStatus.FAILED,
+        ScheduledEmailStatus.CANCELLED,
+    ],
+    "cancel": [
+        ScheduledEmailStatus.SCHEDULED,
+        ScheduledEmailStatus.FAILED,
+    ],
+}
+
+
+# Displayed in scheduled email details view.
+ScheduledEmailStatusExplanation = {
+    ScheduledEmailStatus.SCHEDULED: "Scheduled to be sent",
+    ScheduledEmailStatus.LOCKED: "Locked for sending; worker is processing it",
+    ScheduledEmailStatus.RUNNING: "Sending in progress",
+    ScheduledEmailStatus.SUCCEEDED: "Sent successfully",
+    ScheduledEmailStatus.FAILED: "Sending failed; worker will re-try soon",
+    ScheduledEmailStatus.CANCELLED: "Sending cancelled",
+}
 
 
 class ScheduledEmail(CreatedUpdatedMixin, models.Model):

--- a/amy/emails/templatetags/emails.py
+++ b/amy/emails/templatetags/emails.py
@@ -1,6 +1,8 @@
 from django import template
 from django.db.models import Model
 
+from emails.models import ScheduledEmailStatus, ScheduledEmailStatusActions
+
 register = template.Library()
 
 
@@ -21,3 +23,12 @@ def model_documentation_link(model: Model) -> str:
     }
     model_name = model.__class__.__name__
     return mapping.get(model_name, "")
+
+
+@register.simple_tag
+def allowed_actions_for_status(status: ScheduledEmailStatus) -> list[str]:
+    return [
+        key
+        for key, statuses in ScheduledEmailStatusActions.items()
+        if status in statuses
+    ]

--- a/amy/emails/tests/test_controller.py
+++ b/amy/emails/tests/test_controller.py
@@ -10,13 +10,11 @@ from workshops.models import Person
 
 
 class TestEmailController(TestCase):
-    def test_schedule_email(self) -> None:
-        # Arrange
-        now = timezone.now()
-        signal = "test_email_template"
-        template = EmailTemplate.objects.create(
+    def setUp(self) -> None:
+        self.signal = "test_email_template"
+        self.template = EmailTemplate.objects.create(
             name="Test Email Template",
-            signal=signal,
+            signal=self.signal,
             from_header="workshops@carpentries.org",
             cc_header=["team@carpentries.org"],
             bcc_header=[],
@@ -24,9 +22,13 @@ class TestEmailController(TestCase):
             body="Hello, {{ name }}! Nice to meet **you**.",
         )
 
+    def test_schedule_email(self) -> None:
+        # Arrange
+        now = timezone.now()
+
         # Act
         scheduled_email = EmailController.schedule_email(
-            signal,
+            self.signal,
             context={"name": "Harry"},
             scheduled_at=now,
             to_header=["harry@potter.com"],
@@ -34,22 +36,24 @@ class TestEmailController(TestCase):
         log = ScheduledEmailLog.objects.get(scheduled_email__pk=scheduled_email.pk)
 
         # Assert
-        self.assertEqual(template, scheduled_email.template)
+        self.assertEqual(self.template, scheduled_email.template)
         self.assertEqual(scheduled_email.subject, "Greetings Harry")
         self.assertEqual(scheduled_email.body, "Hello, Harry! Nice to meet **you**.")
         self.assertEqual(scheduled_email.scheduled_at, now)
         self.assertEqual(log.scheduled_email, scheduled_email)
-        self.assertEqual(log.details, f"Scheduled {signal} to run at {now.isoformat()}")
+        self.assertEqual(
+            log.details, f"Scheduled {self.signal} to run at {now.isoformat()}"
+        )
 
     def test_schedule_email__no_template(self) -> None:
         # Arrange
         now = timezone.now()
-        signal = "test_email_template"
+        self.template.delete()
 
         # Act & Assert
         with self.assertRaises(EmailTemplate.DoesNotExist):
             EmailController.schedule_email(
-                signal,
+                self.signal,
                 context={"name": "Harry"},
                 scheduled_at=now,
                 to_header=["harry@potter.com"],
@@ -58,23 +62,13 @@ class TestEmailController(TestCase):
     def test_schedule_email__inactive_template(self) -> None:
         # Arrange
         now = timezone.now()
-        signal = "test_email_template"
-        EmailTemplate.objects.create(
-            active=False,
-            name="Test Email Template",
-            signal=signal,
-            from_header="workshops@carpentries.org",
-            cc_header=["team@carpentries.org"],
-            bcc_header=[],
-            # invalid Django template syntax
-            subject="Greetings",
-            body="Hello, {{ name }}! Nice to meet **you**.",
-        )
+        self.template.active = False
+        self.template.save()
 
         # Act & Assert
         with self.assertRaises(EmailTemplate.DoesNotExist):
             EmailController.schedule_email(
-                signal,
+                self.signal,
                 context={"name": "Harry"},
                 scheduled_at=now,
                 to_header=["harry@potter.com"],
@@ -83,22 +77,13 @@ class TestEmailController(TestCase):
     def test_schedule_email__invalid_template(self) -> None:
         # Arrange
         now = timezone.now()
-        signal = "test_email_template"
-        EmailTemplate.objects.create(
-            name="Test Email Template",
-            signal=signal,
-            from_header="workshops@carpentries.org",
-            cc_header=["team@carpentries.org"],
-            bcc_header=[],
-            # invalid Django template syntax
-            subject="Greetings {% if name %}{{ name }}",
-            body="Hello, {{ name }}! Nice to meet **you**.",
-        )
+        self.template.subject = "Greetings {% if name %}{{ name }}"
+        self.template.save()
 
         # Act & Assert
         with self.assertRaises(TemplateSyntaxError):
             EmailController.schedule_email(
-                signal,
+                self.signal,
                 context={"name": "James"},
                 scheduled_at=now,
                 to_header=["harry@potter.com"],
@@ -107,21 +92,11 @@ class TestEmailController(TestCase):
     def test_schedule_email__generic_object_link(self) -> None:
         # Arrange
         now = timezone.now()
-        signal = "test_email_template"
         person = Person(personal="Harry", family="Potter")
-        EmailTemplate.objects.create(
-            name="Test Email Template",
-            signal=signal,
-            from_header="workshops@carpentries.org",
-            cc_header=["team@carpentries.org"],
-            bcc_header=[],
-            subject="Greetings {{ name }}",
-            body="Hello, {{ name }}! Nice to meet **you**.",
-        )
 
         # Act
         scheduled_email = EmailController.schedule_email(
-            signal,
+            self.signal,
             context={"name": "Harry"},
             scheduled_at=now,
             to_header=["harry@potter.com"],
@@ -135,20 +110,10 @@ class TestEmailController(TestCase):
         # Arrange
         now = timezone.now()
         person = Person.objects.create(personal="Harry", family="Potter")
-        signal = "test_email_template"
-        EmailTemplate.objects.create(
-            name="Test Email Template",
-            signal=signal,
-            from_header="workshops@carpentries.org",
-            cc_header=["team@carpentries.org"],
-            bcc_header=[],
-            subject="Greetings {{ name }}",
-            body="Hello, {{ name }}! Nice to meet **you**.",
-        )
 
         # Act
         scheduled_email = EmailController.schedule_email(
-            signal,
+            self.signal,
             context={"name": "Harry"},
             scheduled_at=now,
             to_header=["harry@potter.com"],
@@ -164,19 +129,9 @@ class TestEmailController(TestCase):
         old_scheduled_date = datetime(2023, 7, 5, 10, 00, tzinfo=UTC)
         new_scheduled_date = datetime(2024, 7, 5, 10, 00, tzinfo=UTC)
         person = Person.objects.create(personal="Harry", family="Potter")
-        signal = "test_email_template"
-        EmailTemplate.objects.create(
-            name="Test Email Template",
-            signal=signal,
-            from_header="workshops@carpentries.org",
-            cc_header=["team@carpentries.org"],
-            bcc_header=[],
-            subject="Greetings {{ name }}",
-            body="Hello, {{ name }}! Nice to meet **you**.",
-        )
 
         scheduled_email = EmailController.schedule_email(
-            signal,
+            self.signal,
             context={"name": "Harry"},
             scheduled_at=old_scheduled_date,
             to_header=["harry@potter.com"],
@@ -211,19 +166,9 @@ class TestEmailController(TestCase):
         # Arrange
         old_scheduled_date = datetime(2023, 7, 5, 10, 00, tzinfo=UTC)
         new_scheduled_date = datetime(2024, 7, 5, 10, 00, tzinfo=UTC)
-        signal = "test_email_template"
-        EmailTemplate.objects.create(
-            name="Test Email Template",
-            signal=signal,
-            from_header="workshops@carpentries.org",
-            cc_header=["team@carpentries.org"],
-            bcc_header=[],
-            subject="Greetings {{ name }}",
-            body="Hello, {{ name }}! Nice to meet **you**.",
-        )
 
         scheduled_email = EmailController.schedule_email(
-            signal,
+            self.signal,
             context={"name": "Harry"},
             scheduled_at=old_scheduled_date,
             to_header=["harry@potter.com"],
@@ -244,19 +189,9 @@ class TestEmailController(TestCase):
         # Arrange
         now = timezone.now()
         person = Person.objects.create(personal="Harry", family="Potter")
-        signal = "test_email_template"
-        EmailTemplate.objects.create(
-            name="Test Email Template",
-            signal=signal,
-            from_header="workshops@carpentries.org",
-            cc_header=["team@carpentries.org"],
-            bcc_header=[],
-            subject="Greetings {{ name }}",
-            body="Hello, {{ name }}! Nice to meet **you**.",
-        )
 
         scheduled_email = EmailController.schedule_email(
-            signal,
+            self.signal,
             context={"name": "Harry"},
             scheduled_at=now,
             to_header=["harry@potter.com"],

--- a/amy/emails/tests/test_template_tags.py
+++ b/amy/emails/tests/test_template_tags.py
@@ -69,5 +69,5 @@ class TestAllowedActionsForStatusTag(TestCase):
         result1 = allowed_actions_for_status(ScheduledEmailStatus.SUCCEEDED)
         result2 = allowed_actions_for_status(ScheduledEmailStatus.CANCELLED)
         # Assert
-        self.assertEqual(result1, ["edit"])
+        self.assertEqual(result1, [])
         self.assertEqual(result2, ["reschedule"])

--- a/amy/emails/tests/test_template_tags.py
+++ b/amy/emails/tests/test_template_tags.py
@@ -2,7 +2,11 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 
-from emails.templatetags.emails import model_documentation_link
+from emails.models import ScheduledEmailStatus
+from emails.templatetags.emails import (
+    allowed_actions_for_status,
+    model_documentation_link,
+)
 
 
 class TestModelDocumentationLink(TestCase):
@@ -35,3 +39,35 @@ class TestModelDocumentationLink(TestCase):
 
         # Assert
         self.assertEqual(link, "")
+
+
+class TestAllowedActionsForStatusTag(TestCase):
+    def test_allowed_actions_for_status__empty(self) -> None:
+        # Arrange
+        statuses = [
+            ScheduledEmailStatus.LOCKED,
+            ScheduledEmailStatus.RUNNING,
+        ]
+        # Act & Assert
+        for status in statuses:
+            result = allowed_actions_for_status(status)
+            self.assertEqual(result, [])
+
+    def test_allowed_actions_for_status__all_actions(self) -> None:
+        # Arrange
+        statuses = [
+            ScheduledEmailStatus.SCHEDULED,
+            ScheduledEmailStatus.FAILED,
+        ]
+        # Act & Assert
+        for status in statuses:
+            result = allowed_actions_for_status(status)
+            self.assertEqual(result, ["edit", "reschedule", "cancel"])
+
+    def test_allowed_actions_for_status__specific_actions(self) -> None:
+        # Act
+        result1 = allowed_actions_for_status(ScheduledEmailStatus.SUCCEEDED)
+        result2 = allowed_actions_for_status(ScheduledEmailStatus.CANCELLED)
+        # Assert
+        self.assertEqual(result1, ["edit"])
+        self.assertEqual(result2, ["reschedule"])

--- a/amy/emails/tests/test_views.py
+++ b/amy/emails/tests/test_views.py
@@ -458,7 +458,6 @@ class TestScheduledEmailUpdate(TestBase):
                 for state in [
                     ScheduledEmailStatus.SCHEDULED,
                     ScheduledEmailStatus.FAILED,
-                    ScheduledEmailStatus.SUCCEEDED,
                 ]
             ]
         )
@@ -467,7 +466,7 @@ class TestScheduledEmailUpdate(TestBase):
         results = queryset.all()
 
         # Assert - all of the defined scheduled emails can be retrieved with this query
-        self.assertEqual(results.count(), 3)
+        self.assertEqual(results.count(), 2)
 
     @override_settings(EMAIL_MODULE_ENABLED=True)
     def test_disallowed_email_statuses(self) -> None:

--- a/amy/emails/tests/test_views.py
+++ b/amy/emails/tests/test_views.py
@@ -466,7 +466,7 @@ class TestScheduledEmailUpdate(TestBase):
         # Act
         results = queryset.all()
 
-        # Assert - none of the defined scheduled emails can be retrieved with this query
+        # Assert - all of the defined scheduled emails can be retrieved with this query
         self.assertEqual(results.count(), 3)
 
     @override_settings(EMAIL_MODULE_ENABLED=True)
@@ -577,7 +577,7 @@ class TestScheduledEmailReschedule(TestBase):
         # Act
         results = queryset.all()
 
-        # Assert - none of the defined scheduled emails can be retrieved with this query
+        # Assert - all of the defined scheduled emails can be retrieved with this query
         self.assertEqual(results.count(), 3)
 
     @override_settings(EMAIL_MODULE_ENABLED=True)
@@ -682,7 +682,7 @@ class TestScheduledEmailCancel(TestBase):
         # Act
         results = queryset.all()
 
-        # Assert - none of the defined scheduled emails can be retrieved with this query
+        # Assert - all of the defined scheduled emails can be retrieved with this query
         self.assertEqual(results.count(), 2)
 
     @override_settings(EMAIL_MODULE_ENABLED=True)

--- a/amy/emails/tests/test_views.py
+++ b/amy/emails/tests/test_views.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime, timedelta
 
-from django.test import override_settings
+from django.test import RequestFactory, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -9,8 +9,15 @@ from emails.models import (
     ScheduledEmail,
     ScheduledEmailLog,
     ScheduledEmailStatus,
+    ScheduledEmailStatusActions,
+    ScheduledEmailStatusExplanation,
 )
 from emails.types import PersonsMergedContext
+from emails.views import (
+    ScheduledEmailCancel,
+    ScheduledEmailReschedule,
+    ScheduledEmailUpdate,
+)
 from workshops.models import Person
 from workshops.tests.base import TestBase
 
@@ -323,6 +330,15 @@ class TestScheduledEmailDetails(TestBase):
             rv.context["rendered_body"],
             "<p>Hello, Harry! Nice to meet <strong>you</strong>.</p>",
         )
+        self.assertEqual(
+            rv.context["status_explanation"],
+            ScheduledEmailStatusExplanation[
+                ScheduledEmailStatus(scheduled_email.state)
+            ],
+        )
+        self.assertEqual(
+            rv.context["ScheduledEmailStatusActions"], ScheduledEmailStatusActions
+        )
 
 
 class TestScheduledEmailUpdate(TestBase):
@@ -419,6 +435,74 @@ class TestScheduledEmailUpdate(TestBase):
         self.assertEqual(email_log.state_before, email_log.state_after)
         self.assertEqual(email_log.state_after, ScheduledEmailStatus.SCHEDULED)
 
+    @override_settings(EMAIL_MODULE_ENABLED=True)
+    def test_allowed_email_statuses(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        view = ScheduledEmailUpdate(request=request)
+        queryset = view.get_queryset()
+
+        ScheduledEmail.objects.bulk_create(
+            [
+                ScheduledEmail(
+                    scheduled_at=timezone.now() + timedelta(hours=1),
+                    to_header=["peter@spiderman.net"],
+                    from_header="test@example.org",
+                    reply_to_header="",
+                    cc_header=[],
+                    bcc_header=[],
+                    subject="Test",
+                    body="Test",
+                    state=state,
+                )
+                for state in [
+                    ScheduledEmailStatus.SCHEDULED,
+                    ScheduledEmailStatus.FAILED,
+                    ScheduledEmailStatus.SUCCEEDED,
+                ]
+            ]
+        )
+
+        # Act
+        results = queryset.all()
+
+        # Assert - none of the defined scheduled emails can be retrieved with this query
+        self.assertEqual(results.count(), 3)
+
+    @override_settings(EMAIL_MODULE_ENABLED=True)
+    def test_disallowed_email_statuses(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        view = ScheduledEmailUpdate(request=request)
+        queryset = view.get_queryset()
+
+        ScheduledEmail.objects.bulk_create(
+            [
+                ScheduledEmail(
+                    scheduled_at=timezone.now() + timedelta(hours=1),
+                    to_header=["peter@spiderman.net"],
+                    from_header="test@example.org",
+                    reply_to_header="",
+                    cc_header=[],
+                    bcc_header=[],
+                    subject="Test",
+                    body="Test",
+                    state=state,
+                )
+                for state in [
+                    ScheduledEmailStatus.LOCKED,
+                    ScheduledEmailStatus.RUNNING,
+                    ScheduledEmailStatus.CANCELLED,
+                ]
+            ]
+        )
+
+        # Act
+        results = queryset.all()
+
+        # Assert - none of the defined scheduled emails can be retrieved with this query
+        self.assertEqual(results.count(), 0)
+
 
 class TestScheduledEmailReschedule(TestBase):
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
@@ -462,6 +546,74 @@ class TestScheduledEmailReschedule(TestBase):
         scheduled_email.refresh_from_db()
         self.assertEqual(scheduled_email.scheduled_at, new_scheduled_date)
 
+    @override_settings(EMAIL_MODULE_ENABLED=True)
+    def test_allowed_email_statuses(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        view = ScheduledEmailReschedule(request=request)
+        queryset = view.get_queryset()
+
+        ScheduledEmail.objects.bulk_create(
+            [
+                ScheduledEmail(
+                    scheduled_at=timezone.now() + timedelta(hours=1),
+                    to_header=["peter@spiderman.net"],
+                    from_header="test@example.org",
+                    reply_to_header="",
+                    cc_header=[],
+                    bcc_header=[],
+                    subject="Test",
+                    body="Test",
+                    state=state,
+                )
+                for state in [
+                    ScheduledEmailStatus.SCHEDULED,
+                    ScheduledEmailStatus.FAILED,
+                    ScheduledEmailStatus.CANCELLED,
+                ]
+            ]
+        )
+
+        # Act
+        results = queryset.all()
+
+        # Assert - none of the defined scheduled emails can be retrieved with this query
+        self.assertEqual(results.count(), 3)
+
+    @override_settings(EMAIL_MODULE_ENABLED=True)
+    def test_disallowed_email_statuses(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        view = ScheduledEmailReschedule(request=request)
+        queryset = view.get_queryset()
+
+        ScheduledEmail.objects.bulk_create(
+            [
+                ScheduledEmail(
+                    scheduled_at=timezone.now() + timedelta(hours=1),
+                    to_header=["peter@spiderman.net"],
+                    from_header="test@example.org",
+                    reply_to_header="",
+                    cc_header=[],
+                    bcc_header=[],
+                    subject="Test",
+                    body="Test",
+                    state=state,
+                )
+                for state in [
+                    ScheduledEmailStatus.LOCKED,
+                    ScheduledEmailStatus.RUNNING,
+                    ScheduledEmailStatus.SUCCEEDED,
+                ]
+            ]
+        )
+
+        # Act
+        results = queryset.all()
+
+        # Assert - none of the defined scheduled emails can be retrieved with this query
+        self.assertEqual(results.count(), 0)
+
 
 class TestScheduledEmailCancel(TestBase):
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
@@ -499,3 +651,71 @@ class TestScheduledEmailCancel(TestBase):
         self.assertEqual(rv.status_code, 302)
         scheduled_email.refresh_from_db()
         self.assertEqual(scheduled_email.state, ScheduledEmailStatus.CANCELLED)
+
+    @override_settings(EMAIL_MODULE_ENABLED=True)
+    def test_allowed_email_statuses(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        view = ScheduledEmailCancel(request=request)
+        queryset = view.get_queryset()
+
+        ScheduledEmail.objects.bulk_create(
+            [
+                ScheduledEmail(
+                    scheduled_at=timezone.now() + timedelta(hours=1),
+                    to_header=["peter@spiderman.net"],
+                    from_header="test@example.org",
+                    reply_to_header="",
+                    cc_header=[],
+                    bcc_header=[],
+                    subject="Test",
+                    body="Test",
+                    state=state,
+                )
+                for state in [
+                    ScheduledEmailStatus.SCHEDULED,
+                    ScheduledEmailStatus.FAILED,
+                ]
+            ]
+        )
+
+        # Act
+        results = queryset.all()
+
+        # Assert - none of the defined scheduled emails can be retrieved with this query
+        self.assertEqual(results.count(), 2)
+
+    @override_settings(EMAIL_MODULE_ENABLED=True)
+    def test_disallowed_email_statuses(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        view = ScheduledEmailCancel(request=request)
+        queryset = view.get_queryset()
+
+        ScheduledEmail.objects.bulk_create(
+            [
+                ScheduledEmail(
+                    scheduled_at=timezone.now() + timedelta(hours=1),
+                    to_header=["peter@spiderman.net"],
+                    from_header="test@example.org",
+                    reply_to_header="",
+                    cc_header=[],
+                    bcc_header=[],
+                    subject="Test",
+                    body="Test",
+                    state=state,
+                )
+                for state in [
+                    ScheduledEmailStatus.LOCKED,
+                    ScheduledEmailStatus.RUNNING,
+                    ScheduledEmailStatus.SUCCEEDED,
+                    ScheduledEmailStatus.CANCELLED,
+                ]
+            ]
+        )
+
+        # Act
+        results = queryset.all()
+
+        # Assert - none of the defined scheduled emails can be retrieved with this query
+        self.assertEqual(results.count(), 0)

--- a/amy/emails/views.py
+++ b/amy/emails/views.py
@@ -1,9 +1,9 @@
-from typing import Any
+from typing import Any, cast
 
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from flags.views import FlaggedViewMixin
+from django.views.generic.detail import SingleObjectMixin
 from markdownx.utils import markdownify
 
 from emails.controller import EmailController
@@ -155,6 +155,15 @@ class ScheduledEmailUpdate(OnlyForAdminsMixin, FlaggedViewMixin, AMYUpdateView):
     model = ScheduledEmail
     object: ScheduledEmail
 
+    # Will lock this object in the database for the duration of the request.
+    # Most specifically, we want to lock it when we're saving the form. This way the DB
+    # helps us make sure the data is consistent.
+    # Additionally, we're limiting the queryset to only those objects that can be edited
+    # (see ScheduledEmailStatusActions).
+    queryset = ScheduledEmail.objects.filter(
+        state__in=ScheduledEmailStatusActions["edit"]
+    ).select_for_update()
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = f'Scheduled email "{self.object.subject}"'
@@ -174,7 +183,9 @@ class ScheduledEmailUpdate(OnlyForAdminsMixin, FlaggedViewMixin, AMYUpdateView):
         return result
 
 
-class ScheduledEmailReschedule(OnlyForAdminsMixin, FlaggedViewMixin, AMYFormView):
+class ScheduledEmailReschedule(
+    OnlyForAdminsMixin, FlaggedViewMixin, SingleObjectMixin, AMYFormView
+):
     flag_name = "EMAIL_MODULE"
     permission_required = ["emails.view_scheduledemail", "emails.change_scheduledemail"]
     template_name = "emails/scheduled_email_reschedule.html"
@@ -183,9 +194,18 @@ class ScheduledEmailReschedule(OnlyForAdminsMixin, FlaggedViewMixin, AMYFormView
     request: HttpRequest
     title: str
 
+    # Will lock this object in the database for the duration of the request.
+    # Most specifically, we want to lock it when we're saving the form. This way the DB
+    # helps us make sure the data is consistent.
+    # Additionally, we're limiting the queryset to only those objects that can be edited
+    # (see ScheduledEmailStatusActions).
+    queryset = ScheduledEmail.objects.filter(
+        state__in=ScheduledEmailStatusActions["reschedule"]
+    ).select_for_update()
+
     def dispatch(self, request: HttpRequest, *args, **kwargs):
         self.request = request
-        self.object = get_object_or_404(ScheduledEmail, pk=self.kwargs["pk"])
+        self.object = cast(ScheduledEmail, self.get_object())
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs) -> dict[str, Any]:
@@ -210,7 +230,9 @@ class ScheduledEmailReschedule(OnlyForAdminsMixin, FlaggedViewMixin, AMYFormView
         return super().form_valid(form)
 
 
-class ScheduledEmailCancel(OnlyForAdminsMixin, FlaggedViewMixin, AMYFormView):
+class ScheduledEmailCancel(
+    OnlyForAdminsMixin, FlaggedViewMixin, SingleObjectMixin, AMYFormView
+):
     flag_name = "EMAIL_MODULE"
     permission_required = ["emails.view_scheduledemail", "emails.change_scheduledemail"]
     template_name = "emails/scheduled_email_cancel.html"
@@ -219,9 +241,18 @@ class ScheduledEmailCancel(OnlyForAdminsMixin, FlaggedViewMixin, AMYFormView):
     request: HttpRequest
     title: str
 
+    # Will lock this object in the database for the duration of the request.
+    # Most specifically, we want to lock it when we're saving the form. This way the DB
+    # helps us make sure the data is consistent.
+    # Additionally, we're limiting the queryset to only those objects that can be edited
+    # (see ScheduledEmailStatusActions).
+    queryset = ScheduledEmail.objects.filter(
+        state__in=ScheduledEmailStatusActions["cancel"]
+    ).select_for_update()
+
     def dispatch(self, request: HttpRequest, *args, **kwargs):
         self.request = request
-        self.object = get_object_or_404(ScheduledEmail, pk=self.kwargs["pk"])
+        self.object = cast(ScheduledEmail, self.get_object())
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs) -> dict[str, Any]:
@@ -232,7 +263,7 @@ class ScheduledEmailCancel(OnlyForAdminsMixin, FlaggedViewMixin, AMYFormView):
     def get_success_url(self) -> str:
         return self.object.get_absolute_url()
 
-    def form_valid(self, form: ScheduledEmailRescheduleForm):
+    def form_valid(self, form: ScheduledEmailCancelForm):
         if form.cleaned_data.get("confirm"):
             EmailController.cancel_email(
                 self.object,

--- a/amy/emails/views.py
+++ b/amy/emails/views.py
@@ -2,8 +2,8 @@ from typing import Any, cast
 
 from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
-from flags.views import FlaggedViewMixin
 from django.views.generic.detail import SingleObjectMixin
+from flags.views import FlaggedViewMixin
 from markdownx.utils import markdownify
 
 from emails.controller import EmailController

--- a/amy/emails/views.py
+++ b/amy/emails/views.py
@@ -14,7 +14,14 @@ from emails.forms import (
     ScheduledEmailRescheduleForm,
     ScheduledEmailUpdateForm,
 )
-from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailLog
+from emails.models import (
+    EmailTemplate,
+    ScheduledEmail,
+    ScheduledEmailLog,
+    ScheduledEmailStatus,
+    ScheduledEmailStatusActions,
+    ScheduledEmailStatusExplanation,
+)
 from emails.signals import ALL_SIGNALS
 from emails.utils import find_signal_by_name, person_from_request
 from workshops.base_views import (
@@ -131,6 +138,11 @@ class ScheduledEmailDetails(OnlyForAdminsMixin, FlaggedViewMixin, AMYDetailView)
             .order_by("-created_at")
         )
         context["rendered_body"] = markdownify(self.object.body)
+
+        context["status_explanation"] = ScheduledEmailStatusExplanation[
+            ScheduledEmailStatus(self.object.state)
+        ]
+        context["ScheduledEmailStatusActions"] = ScheduledEmailStatusActions
         return context
 
 

--- a/amy/templates/emails/scheduled_email_detail.html
+++ b/amy/templates/emails/scheduled_email_detail.html
@@ -15,11 +15,24 @@
 {% if perms.emails.change_scheduledemail %}
 <div class="edit-object">
   <div class="btn-group">
+    {% if scheduled_email.state in ScheduledEmailStatusActions.edit %}
     <a class="btn btn-primary" href="{% url 'scheduledemail_edit' scheduled_email.id %}">Edit</a>
+    {% else %}
+    <a class="btn btn-primary disabled" disabled href="#">Edit</a>
+    {% endif %}
+
+    {% if scheduled_email.state in ScheduledEmailStatusActions.reschedule %}
     <a class="btn btn-warning" href="{% url 'scheduledemail_reschedule' scheduled_email.id %}">Reschedule</a>
+    {% else %}
+    <a class="btn btn-warning disabled" disabled href="#">Reschedule</a>
+    {% endif %}
   </div>
   <div class="float-right">
+    {% if scheduled_email.state in ScheduledEmailStatusActions.cancel %}
     <a class="btn btn-danger" href="{% url 'scheduledemail_cancel' scheduled_email.id %}">Cancel</a>
+    {% else %}
+    <a class="btn btn-warning disabled" disabled href="#">Cancel</a>
+    {% endif %}
   </div>
 </div>
 {% else %}
@@ -41,7 +54,10 @@
   </tr>
   <tr>
     <th>State:</th>
-    <td colspan="2"><strong>{{ scheduled_email.get_state_display }}</strong></td>
+    <td colspan="2">
+      <strong>{{ scheduled_email.get_state_display }}</strong>
+      <p>{{ status_explanation }}</p>
+    </td>
   </tr>
   <tr>
     <th>Created at:</th>

--- a/amy/templates/emails/scheduled_email_detail.html
+++ b/amy/templates/emails/scheduled_email_detail.html
@@ -12,26 +12,34 @@
 
 {% include "emails/scheduled_email_header_details.html" with scheduled_email=scheduled_email %}
 
+{% allowed_actions_for_status scheduled_email.state as available_status_actions %}
+
 {% if perms.emails.change_scheduledemail %}
 <div class="edit-object">
   <div class="btn-group">
-    {% if scheduled_email.state in ScheduledEmailStatusActions.edit %}
+    {% if "edit" in available_status_actions %}
     <a class="btn btn-primary" href="{% url 'scheduledemail_edit' scheduled_email.id %}">Edit</a>
     {% else %}
-    <a class="btn btn-primary disabled" disabled href="#">Edit</a>
+    <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="You can only edit emails that are in the 'scheduled', 'failed' or 'succeeded' states.">
+      <a class="btn btn-primary disabled" style="pointer-events:none" disabled href="#">Edit</a>
+    </span>
     {% endif %}
 
-    {% if scheduled_email.state in ScheduledEmailStatusActions.reschedule %}
+    {% if "reschedule" in available_status_actions %}
     <a class="btn btn-warning" href="{% url 'scheduledemail_reschedule' scheduled_email.id %}">Reschedule</a>
     {% else %}
-    <a class="btn btn-warning disabled" disabled href="#">Reschedule</a>
+    <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="You can only reschedule emails that are in the 'scheduled', 'failed' or 'cancelled' states.">
+      <a class="btn btn-warning disabled" style="pointer-events:none" disabled href="#">Reschedule</a>
+    </span>
     {% endif %}
   </div>
   <div class="float-right">
-    {% if scheduled_email.state in ScheduledEmailStatusActions.cancel %}
+    {% if "cancel" in available_status_actions %}
     <a class="btn btn-danger" href="{% url 'scheduledemail_cancel' scheduled_email.id %}">Cancel</a>
     {% else %}
-    <a class="btn btn-warning disabled" disabled href="#">Cancel</a>
+    <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="You can only cancel emails that are in the 'scheduled' or 'failed' states.">
+      <a class="btn btn-warning disabled" style="pointer-events:none" disabled href="#">Cancel</a>
+    </span>
     {% endif %}
   </div>
 </div>

--- a/amy/templates/emails/scheduled_email_reschedule.html
+++ b/amy/templates/emails/scheduled_email_reschedule.html
@@ -15,7 +15,8 @@
 
 {% if scheduled_email.state == 'cancelled' %}
 <div class="alert alert-warning" role="alert">
-  <strong>Warning</strong>: if you reschedule a cancelled email, it will become scheduled again and may be sent immediately.
+  <strong>Warning</strong>: if you reschedule a cancelled email, it will become
+  scheduled again and will be sent immediately if the scheduled time is in the past.
 </div>
 {% endif %}
 

--- a/amy/templates/emails/scheduled_email_reschedule.html
+++ b/amy/templates/emails/scheduled_email_reschedule.html
@@ -13,6 +13,12 @@
 
 {% include "emails/scheduled_email_header_details.html" with scheduled_email=scheduled_email %}
 
+{% if scheduled_email.state == 'cancelled' %}
+<div class="alert alert-warning" role="alert">
+  <strong>Warning</strong>: if you reschedule a cancelled email, it will become scheduled again and may be sent immediately.
+</div>
+{% endif %}
+
 {% crispy form %}
 
 {% endblock %}


### PR DESCRIPTION
Fixes #2459.

Based on PR #2491.

This PR introduces whitelist of statuses the scheduled email has to be in in order to edit, reschedule or cancel it.

One of the interesting techniques used here is database-level locking connected with filtering for allowed statuses. This will ensure that an email is in proper status before and during the POST request.

