### PR TITLE
Check that GitHub contributions are associated with a Carpentries GH organisation

### DIFF
--- a/amy/api/tests/test_export.py
+++ b/amy/api/tests/test_export.py
@@ -208,7 +208,7 @@ class TestExportingPersonData(BaseExportingTest):
             involvement_type=github_contribution,
             state="a",  # asked to repeat
             event=None,
-            url="http://example.org/lesson",
+            url="https://github.com/carpentries",
             date=datetime.date(2023, 5, 31),
             trainee_notes="Notes submitted by trainee",
         )
@@ -564,7 +564,7 @@ class TestExportingPersonData(BaseExportingTest):
                 },
                 "state": "Asked to repeat",
                 "event": None,
-                "url": "http://example.org/lesson",
+                "url": "https://github.com/carpentries",
                 "date": "2023-05-31",
                 "trainee_notes": "Notes submitted by trainee",
             },

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -167,7 +167,9 @@ class GetInvolvedForm(forms.ModelForm):
     url = forms.URLField(
         label="URL",
         help_text="A link to the activity, if there is one. For example, a "
-        "workshop website or GitHub contribution.",
+        "workshop website or GitHub contribution. GitHub contributions must be to a "
+        "repository in one of the "
+        '<a href="example.com">GitHub organisations owned by The Carpentries</a>.',
         required=False,
     )
     trainee_notes = forms.CharField(

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -166,10 +166,12 @@ class GetInvolvedForm(forms.ModelForm):
     )
     url = forms.URLField(
         label="URL",
-        help_text="A link to the activity, if there is one. For example, a "
-        "workshop website or GitHub contribution. GitHub contributions must be to a "
-        "repository in one of the "
-        '<a href="example.com">GitHub organisations owned by The Carpentries</a>.',
+        help_text="A link to the activity, if there is one. If you served "
+        "at a workshop, enter the workshop website. "
+        "If you made a GitHub contribution, enter that link and ensure it is "
+        "associated with a repository in one of the "
+        '<a href="https://docs.carpentries.org/topic_folders/communications/tools/github_organisations.html">'  # noqa
+        "GitHub organisations owned by The Carpentries</a>.",
         required=False,
     )
     trainee_notes = forms.CharField(

--- a/amy/dashboard/tests/test_get_involved_views.py
+++ b/amy/dashboard/tests/test_get_involved_views.py
@@ -21,9 +21,9 @@ class TestGetInvolvedViewBase(TestBase):
             },
         )
         self.involvement, _ = Involvement.objects.get_or_create(
-            name="GitHub Contribution",
+            name="Workshop Instructor/Helper",
             defaults={
-                "display_name": "GitHub Contribution",
+                "display_name": "Workshop Instructor/Helper",
                 "url_required": True,
                 "date_required": True,
             },
@@ -69,6 +69,14 @@ class TestGetInvolvedCreateView(TestGetInvolvedViewBase):
 
     def test_create_view_does_not_show_archived_involvements(self):
         # Arrange
+        self.github_contribution, _ = Involvement.objects.get_or_create(
+            name="GitHub Contribution",
+            defaults={
+                "display_name": "GitHub Contribution",
+                "url_required": True,
+                "date_required": True,
+            },
+        )
         self.involvement_to_be_archived.archive()
 
         # Act
@@ -80,7 +88,14 @@ class TestGetInvolvedCreateView(TestGetInvolvedViewBase):
             c[0].instance.pk
             for c in rv.context["form"].fields["involvement_type"].choices
         ]
-        self.assertEqual(choices, [self.involvement.pk, self.involvement_other.pk])
+        self.assertEqual(
+            choices,
+            [
+                self.github_contribution.pk,
+                self.involvement.pk,
+                self.involvement_other.pk,
+            ],
+        )
 
     def test_create_view_does_not_show_admin_fields(self):
         # Act
@@ -95,7 +110,7 @@ class TestGetInvolvedCreateView(TestGetInvolvedViewBase):
         # Arrange
         data = {
             "involvement_type": self.involvement.pk,
-            "url": "https://github.com/carpentries",
+            "url": "https://example.org",
             "date": "2023-07-27",
         }
 
@@ -176,7 +191,7 @@ class TestGetInvolvedCreateView(TestGetInvolvedViewBase):
             (
                 "n",
                 self.user.pk,
-                "https://github.com/carpentries",
+                "https://example.org",
                 self.get_involved.pk,
                 self.involvement.pk,
                 date(2023, 7, 27),

--- a/amy/dashboard/tests/test_get_involved_views.py
+++ b/amy/dashboard/tests/test_get_involved_views.py
@@ -69,14 +69,7 @@ class TestGetInvolvedCreateView(TestGetInvolvedViewBase):
 
     def test_create_view_does_not_show_archived_involvements(self):
         # Arrange
-        self.github_contribution, _ = Involvement.objects.get_or_create(
-            name="GitHub Contribution",
-            defaults={
-                "display_name": "GitHub Contribution",
-                "url_required": True,
-                "date_required": True,
-            },
-        )
+        self.github_contribution = Involvement.objects.get(name="GitHub Contribution")
         self.involvement_to_be_archived.archive()
 
         # Act

--- a/amy/dashboard/tests/test_get_involved_views.py
+++ b/amy/dashboard/tests/test_get_involved_views.py
@@ -95,7 +95,7 @@ class TestGetInvolvedCreateView(TestGetInvolvedViewBase):
         # Arrange
         data = {
             "involvement_type": self.involvement.pk,
-            "url": "https://example.org",
+            "url": "https://github.com/carpentries",
             "date": "2023-07-27",
         }
 
@@ -176,7 +176,7 @@ class TestGetInvolvedCreateView(TestGetInvolvedViewBase):
             (
                 "n",
                 self.user.pk,
-                "https://example.org",
+                "https://github.com/carpentries",
                 self.get_involved.pk,
                 self.involvement.pk,
                 date(2023, 7, 27),

--- a/amy/dashboard/tests/test_instructor_dashboard.py
+++ b/amy/dashboard/tests/test_instructor_dashboard.py
@@ -83,9 +83,12 @@ class TestInstructorStatus(TestBase):
             "Welcome Session",
             "Demo",
         ]
+        workshop_instructor, _ = Involvement.objects.get_or_create(
+            name="Workshop Instructor/Helper"
+        )
         for requirement in requirements:
             if requirement == "Get Involved":
-                involvement = Involvement.objects.get(name="GitHub Contribution")
+                involvement = workshop_instructor
                 date = datetime.today()
                 url = "https://example.com"
             else:
@@ -182,8 +185,8 @@ class TestGetInvolvedStatus(TestBase):
         self.get_involved, _ = TrainingRequirement.objects.get_or_create(
             name="Get Involved", defaults={"involvement_required": True}
         )
-        self.github_contribution, _ = Involvement.objects.get_or_create(
-            name="GitHub Contribution", defaults={"url_required": True}
+        self.workshop_instructor, _ = Involvement.objects.get_or_create(
+            name="Workshop Instructor/Helper", defaults={"url_required": True}
         )
         self.other_involvement, _ = Involvement.objects.get_or_create(
             name="Other", defaults={"display_name": "Other", "notes_required": True}
@@ -194,7 +197,7 @@ class TestGetInvolvedStatus(TestBase):
         self.progress = TrainingProgress.objects.create(
             trainee=self.admin,
             requirement=self.get_involved,
-            involvement_type=self.github_contribution,
+            involvement_type=self.workshop_instructor,
             date=datetime.today(),
             url="https://example.org",
             trainee_notes="Notes from trainee",
@@ -309,7 +312,7 @@ class TestGetInvolvedStatus(TestBase):
         TrainingProgress.objects.create(
             trainee=self.admin,
             requirement=self.get_involved,
-            involvement_type=self.github_contribution,
+            involvement_type=self.workshop_instructor,
             state="n",
         )
 

--- a/amy/dashboard/tests/test_instructor_dashboard.py
+++ b/amy/dashboard/tests/test_instructor_dashboard.py
@@ -186,7 +186,12 @@ class TestGetInvolvedStatus(TestBase):
             name="Get Involved", defaults={"involvement_required": True}
         )
         self.workshop_instructor, _ = Involvement.objects.get_or_create(
-            name="Workshop Instructor/Helper", defaults={"url_required": True}
+            name="Workshop Instructor/Helper",
+            defaults={
+                "display_name": "Served as an Instructor or a helper at a Carpentries "
+                "workshop",
+                "url_required": True,
+            },
         )
         self.other_involvement, _ = Involvement.objects.get_or_create(
             name="Other", defaults={"display_name": "Other", "notes_required": True}
@@ -204,8 +209,8 @@ class TestGetInvolvedStatus(TestBase):
         )
         self.PROGRESS_SUMMARY_BLOCK = (
             "<p>"
-            "<strong>Activity:</strong> Submitted a contribution to a Carpentries "
-            "repository<br/>"
+            "<strong>Activity:</strong> Served as an Instructor or a helper at a "
+            "Carpentries workshop<br/>"
             f'<strong>Date:</strong> {datetime.today().strftime("%B %-d, %Y")}<br/>'
             "<strong>URL:</strong> https://example.org<br/>"
             "<strong>Notes:</strong> Notes from trainee"
@@ -308,6 +313,7 @@ class TestGetInvolvedStatus(TestBase):
 
     def test_get_involved_details_not_provided(self):
         """Check that optional fields are summarised correctly when empty"""
+        # Arrange
         self.progress.delete()
         TrainingProgress.objects.create(
             trainee=self.admin,
@@ -322,8 +328,8 @@ class TestGetInvolvedStatus(TestBase):
         # Assert
         PROGRESS_SUMMARY_BLOCK = (
             "<p>"
-            "<strong>Activity:</strong> Submitted a contribution to a Carpentries "
-            "repository<br/>"
+            "<strong>Activity:</strong> Served as an Instructor or a helper at a "
+            "Carpentries workshop<br/>"
             "<strong>Date:</strong> No date provided<br/>"
             "<strong>URL:</strong> No URL provided<br/>"
             "<strong>Notes:</strong> No notes provided"

--- a/amy/scripts/seed_involvements.py
+++ b/amy/scripts/seed_involvements.py
@@ -37,7 +37,7 @@ INVOLVEMENTS: list[InvolvementDef] = [
         "notes_required": True,
     },
     {
-        "display_name": "Submitted a contribution to a Carpentries repository",
+        "display_name": "Submitted a contribution to a Carpentries repository on GitHub",  # noqa
         "name": "GitHub Contribution",
         "url_required": True,
         "date_required": True,

--- a/amy/scripts/seed_involvements.py
+++ b/amy/scripts/seed_involvements.py
@@ -30,7 +30,7 @@ INVOLVEMENTS: list[InvolvementDef] = [
         "notes_required": False,
     },
     {
-        "display_name": "Attended an Instructor meeting, regional meetup, or other community meeting",  # noqa
+        "display_name": "Attended a regional meetup, skill-up, or other community meeting",  # noqa
         "name": "Community Meeting",
         "url_required": False,
         "date_required": True,

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -152,7 +152,7 @@
   </table>
 
 
-  <p>In the case of any questions, please send us email at <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org</a></p>
+  <p>If you have any questions, please contact us at <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org</a></p>
 </div>
 
 {% endblock %}

--- a/amy/templates/get_involved_form.html
+++ b/amy/templates/get_involved_form.html
@@ -15,10 +15,8 @@
   Only submit an activity that you have already completed.
 </p>
 <p>
-  If submitting a GitHub contribution, please be sure your contribution is to a repository in one of the 
-  <a href="https://docs.carpentries.org/topic_folders/communications/tools/github_organisations.html">
-    GitHub organisations owned by The Carpentries
-  </a>.
+  If you have any questions or difficulty completing the form, please contact us at 
+  <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org</a>.
 </p>
 {% crispy form %}
 {% endblock %}

--- a/amy/trainings/tests/test_filters.py
+++ b/amy/trainings/tests/test_filters.py
@@ -42,9 +42,9 @@ class TestTraineeFilter(TestBase):
             involvement_required=True,
         )
         self.url_and_date_required, _ = Involvement.objects.get_or_create(
-            name="GitHub Contribution",
+            name="Workshop Instructor/Helper",
             defaults={
-                "display_name": "GitHub Contribution",
+                "display_name": "Workshop Instructor/Helper",
                 "url_required": True,
                 "date_required": True,
             },

--- a/amy/trainings/tests/test_trainees.py
+++ b/amy/trainings/tests/test_trainees.py
@@ -34,7 +34,7 @@ class TestTraineesView(TestBase):
         self.welcome = TrainingRequirement.objects.get(name="Welcome Session")
         self.demo = TrainingRequirement.objects.get(name="Demo")
         self.involvement, _ = Involvement.objects.get_or_create(
-            name="GitHub Contribution", defaults={"url_required": True}
+            name="Workshop Instructor/Helper", defaults={"url_required": True}
         )
 
         self.ttt_event = Event.objects.create(

--- a/amy/trainings/tests/test_training_progress.py
+++ b/amy/trainings/tests/test_training_progress.py
@@ -47,14 +47,6 @@ class TestTrainingProgressValidation(TestBase):
                 "date_required": True,
             },
         )
-        self.github_url_required, _ = Involvement.objects.get_or_create(
-            name="GitHub Contribution",
-            defaults={
-                "display_name": "GitHub Contribution",
-                "url_required": True,
-                "date_required": True,
-            },
-        )
         self.notes_required, _ = Involvement.objects.get_or_create(
             name="Other without date",
             defaults={
@@ -139,7 +131,7 @@ class TestTrainingProgressValidation(TestBase):
         )
         p2 = TrainingProgress.objects.create(
             requirement=self.get_involved,
-            involvement_type=self.github_url_required,
+            involvement_type=github_url_required,
             trainee=self.admin,
             url="http://example.com",
             date=datetime(2023, 5, 31),
@@ -449,7 +441,7 @@ class TestCRUDViews(TestBase):
                 "date_required": True,
             },
         )
-        self.involvement2, _ = Involvement.objects.get_or_create(
+        self.involvement_to_be_archived, _ = Involvement.objects.get_or_create(
             name="To be archived",
             defaults={
                 "display_name": "To be archived",
@@ -488,7 +480,7 @@ class TestCRUDViews(TestBase):
         self.assertEqual(int(rv.context["form"].initial["trainee"]), self.ironman.pk)
 
     def test_create_view_does_not_show_archived_involvements(self):
-        self.involvement2.archive()
+        self.involvement_to_be_archived.archive()
         rv = self.client.get(
             reverse("trainingprogress_add"), {"type": self.get_involved.pk}
         )

--- a/amy/trainings/tests/test_training_progress.py
+++ b/amy/trainings/tests/test_training_progress.py
@@ -40,6 +40,14 @@ class TestTrainingProgressValidation(TestBase):
             involvement_required=True,
         )
         self.url_and_date_required, _ = Involvement.objects.get_or_create(
+            name="Workshop Instructor/Helper",
+            defaults={
+                "display_name": "Workshop Instructor/Helper",
+                "url_required": True,
+                "date_required": True,
+            },
+        )
+        self.github_url_required, _ = Involvement.objects.get_or_create(
             name="GitHub Contribution",
             defaults={
                 "display_name": "GitHub Contribution",
@@ -112,6 +120,33 @@ class TestTrainingProgressValidation(TestBase):
         p2.full_clean()
         p3.full_clean()
         p4.full_clean()  # involvement URLs can be optional
+
+    def test_url_associated_with_github_organisation(self):
+        github_url_required, _ = Involvement.objects.get_or_create(
+            name="GitHub Contribution",
+            defaults={
+                "display_name": "GitHub Contribution",
+                "url_required": True,
+                "date_required": True,
+            },
+        )
+        p1 = TrainingProgress.objects.create(
+            requirement=self.get_involved,
+            involvement_type=github_url_required,
+            trainee=self.admin,
+            url="https://github.com/carpentries/amy/issues/2470",
+            date=datetime(2023, 5, 31),
+        )
+        p2 = TrainingProgress.objects.create(
+            requirement=self.get_involved,
+            involvement_type=self.github_url_required,
+            trainee=self.admin,
+            url="http://example.com",
+            date=datetime(2023, 5, 31),
+        )
+        p1.full_clean()
+        with self.assertValidationErrors(["url"]):
+            p2.full_clean()
 
     def test_event_is_required(self):
         p1 = TrainingProgress.objects.create(

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -2678,7 +2678,9 @@ class TrainingProgress(CreatedUpdatedMixin, models.Model):
         if not any(f"github.com/{org}" in url for org in self.CARPENTRIES_GITHUB_ORGS):
             msg = (
                 "This URL is not associated with a repository in any of the "
-                "GitHub organisations owned by The Carpentries."
+                "GitHub organisations owned by The Carpentries. "
+                "If you need help resolving this error, please contact us using the "
+                "details at the top of this form."
             )
             return ValidationError(msg)
 

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -2612,6 +2612,22 @@ class TrainingProgress(CreatedUpdatedMixin, models.Model):
     )
     notes = models.TextField(blank=True)
 
+    CARPENTRIES_GITHUB_ORGS = [
+        "carpentries",
+        "datacarpentry",
+        "librarycarpentry",
+        "swcarpentry",
+        "carpentries-es",
+        "Reproducible-Science-Curriculum",
+        "CarpentryCon",
+        "CarpentryConnect",
+        "carpentries-workshops",
+        "data-lessons",
+        "carpentries-lab",
+        "carpentries-incubator",
+        "carpentrieslab",
+    ]
+
     def get_absolute_url(self):
         return reverse("trainingprogress_edit", args=[str(self.id)])
 
@@ -2651,13 +2667,20 @@ class TrainingProgress(CreatedUpdatedMixin, models.Model):
                 and involvement_type.url_required
             ):
                 return self.get_required_error(involvement_type)
+        else:
+            if not requirement.url_required and not requirement.involvement_required:
+                return self.get_not_required_error(involvement_type)
+            elif involvement_type and involvement_type.name == "GitHub Contribution":
+                return self.clean_github_url(self.url)
 
-        elif (
-            self.url
-            and not requirement.url_required
-            and not requirement.involvement_required
-        ):
-            return self.get_not_required_error(involvement_type)
+    def clean_github_url(self, url):
+        """Check if URL is associated with a Carpentries GitHub organisation"""
+        if not any(f"github.com/{org}" in url for org in self.CARPENTRIES_GITHUB_ORGS):
+            msg = (
+                "This URL is not associated with a repository in any of the "
+                "GitHub organisations owned by The Carpentries."
+            )
+            return ValidationError(msg)
 
     def clean_event(
         self,


### PR DESCRIPTION
Fixes #2470. Depends on #2492.

This just checks for "github.com/ORG" in the URL text, for all of our organisations as listed in the Carpentries Handbook: https://docs.carpentries.org/topic_folders/communications/tools/github_organisations.html.

In future we might look at storing a machine-readable list of organisations centrally and pulling the list from that, but for now @maneesha and I agreed to hardcode this list.

Screenshot:
![Get Involved form with an invalid URL entered. Error and help text appears above the URL field. Error text: This URL is not associated with a repository in any of the GitHub organisations owned by The Carpentries. If you need help resolving this error, please contact us using the details at the top of this form. Help text: A link to the activity, if there is one. If you served at a workshop, enter the workshop website. If you made a GitHub contribution, enter that link and ensure it is associated with a repository in one of the GitHub organisations owned by The Carpentries (linked).](https://github.com/carpentries/amy/assets/20683271/de4f5c4f-6e2e-42e8-87c1-04c85205e592)