### PR TITLE
Add cancel button and fix validation bug on Get Involved form

### DIFF
--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -170,7 +170,7 @@ class GetInvolvedForm(forms.ModelForm):
         "provide details here.",
         required=False,
     )
-    helper = BootstrapHelper(add_cancel_button=False)
+    helper = BootstrapHelper(add_cancel_button=True)
 
     class Meta:
         model = TrainingProgress

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -143,6 +143,12 @@ class AutoUpdateProfileForm(forms.ModelForm):
 
 
 class GetInvolvedForm(forms.ModelForm):
+    """Trainee-facing form for submitting training progress.
+
+    All fields have required=False to prevent confusion, as required fields change
+    based on the involvement choice.
+    """
+
     involvement_type = forms.ModelChoiceField(
         label="Activity",
         help_text="If your activity is not included in this list, please select "
@@ -189,7 +195,7 @@ class GetInvolvedForm(forms.ModelForm):
         """
         involvement_type = self.cleaned_data["involvement_type"]
         trainee_notes = self.cleaned_data["trainee_notes"]
-        if involvement_type.notes_required and not trainee_notes:
+        if involvement_type and involvement_type.notes_required and not trainee_notes:
             raise ValidationError(
                 f'This field is required for activity "{involvement_type}".'
             )

--- a/amy/dashboard/tests/test_forms.py
+++ b/amy/dashboard/tests/test_forms.py
@@ -153,3 +153,27 @@ class TestGetInvolvedForm(TestCase):
             ['This field is required for activity "Other".'],
         )
         self.assertNotIn("notes", form.errors.keys())
+
+    def test_clean_custom_validation__no_involvement_type(self):
+        """Check that trainee_notes validation works when no involvement is chosen"""
+        # Arrange
+        person = Person.objects.create(
+            personal="Test", family="User", email="test@user.com"
+        )
+        data = {}
+        base_instance = TrainingProgress(
+            trainee=person,
+            state="n",  # not evaluated yet
+            requirement=TrainingRequirement.objects.get(name="Get Involved"),
+        )
+
+        # Act
+        form = GetInvolvedForm(data, instance=base_instance)
+
+        # Assert
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(
+            form.errors["involvement_type"],
+            ['This field is required for progress type "Get Involved".'],
+        )
+        self.assertNotIn("trainee_notes", form.errors.keys())


### PR DESCRIPTION
Form was raising a server error if submitted blank, because the validation on `trainee_notes` was expecting `involvement_type` to be set.
Note that `involvement_type` is always required in `TrainingProgress` creation, but it has `required=False` set on the form. This is because at least one _other_ field will always be required, but this is only determined at validation time, so showing an asterisk on only one field and not the rest doesn't quite represent how the form works.