### PR TITLE
[#2426] Hide Anymail errors

### DIFF
--- a/amy/workshops/base_views.py
+++ b/amy/workshops/base_views.py
@@ -1,6 +1,7 @@
 from smtplib import SMTPException
 from typing import Optional
 
+from anymail.exceptions import AnymailRequestsAPIError
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -342,7 +343,7 @@ class AutoresponderMixin:
 
         try:
             email.send()
-        except SMTPException as e:
+        except (SMTPException, AnymailRequestsAPIError) as e:
             if not fail_silently:
                 raise e
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -429,7 +429,7 @@ if not DEBUG and (
     not ANYMAIL["MAILGUN_API_KEY"] or not ANYMAIL["MAILGUN_SENDER_DOMAIN"]
 ):
     raise ImproperlyConfigured(
-        "Mailgun settings are required when running " "with DEBUG=False."
+        "Mailgun settings are required when running with DEBUG=False."
     )
 
 


### PR DESCRIPTION
This fixes #2426 by hiding Anymail errors.
The original bug report is caused by test-amy2 attempting to send email without authorization. There's a couple of ways to fix this:
1. disable sending emails in test-amy2 (through AMY_LIVE_EMAIL env variable)
2. catch the exceptions where they are caused (this is the way I chose)
3. set up test-amy2 in a way that it can send real emails
4. switch to sandbox/test-only mode in test-amy2 + mailgun (probably solution that would take the most time).

I wanted to fix this issue quickly, and I didn't want to disable sending emails altogether since we may want to do this in future. So I decided on solution no. 2. 