### PR TITLE
Update conditions for progress messages at top of page

### DIFF
--- a/amy/dashboard/tests/test_instructor_dashboard.py
+++ b/amy/dashboard/tests/test_instructor_dashboard.py
@@ -116,6 +116,64 @@ class TestInstructorStatus(TestBase):
             "certification",
         )
 
+    def test_deadline_shown_when_training_passed(self):
+        """Test that checkout deadline is displayed when trainee has passed training,
+        but not completed all other steps."""
+        self._setUpOrganizations()
+        event = Event.objects.create(
+            slug="event-ttt",
+            start=date(2023, 6, 4),
+            end=date(2023, 6, 5),
+            host=self.org_alpha,
+        )
+        TrainingProgress.objects.create(
+            trainee=self.admin,
+            requirement=TrainingRequirement.objects.get(name="Training"),
+            event=event,
+            state="p",
+        )
+
+        rv = self.client.get(self.progress_url)
+        # check that the right if/else block is used
+        self.assertContains(
+            rv,
+            "Please review your progress towards Instructor certification below.",
+        )
+        # check that the deadline is shown
+        self.assertContains(
+            rv,
+            "Based on your training dates of",
+        )
+
+    def test_deadline_not_shown_when_training_not_passed(self):
+        """Test that checkout deadline is displayed when trainee has passed training,
+        but not completed all other steps."""
+        self._setUpOrganizations()
+        event = Event.objects.create(
+            slug="event-ttt",
+            start=date(2023, 6, 4),
+            end=date(2023, 6, 5),
+            host=self.org_alpha,
+        )
+        TrainingProgress.objects.create(
+            trainee=self.admin,
+            requirement=TrainingRequirement.objects.get(name="Training"),
+            event=event,
+            state="f",
+        )
+
+        rv = self.client.get(self.progress_url)
+        # check that the right if/else block is used
+        self.assertContains(
+            rv,
+            "Please review your progress towards Instructor certification below.",
+        )
+        # check that no deadline is shown
+        self.assertNotContains(
+            rv,
+            "Based on your training dates of",
+        )
+
 
 class TestInstructorTrainingStatus(TestBase):
     """Test that instructor dashboard displays status of passing Instructor

--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -27,21 +27,23 @@
     You will receive your certificate and more information by email in 1-2 weeks.
   </p>
   </div>
-  {% elif user.passed_training or user.passed_get_involved or user.passed_welcome or user.passed_demo %}
+  {% elif progress_training or progress_get_involved or progress_welcome or progress_demo %}
   <div class="alert alert-info" role="alert">
     <p>
-      Please review your progress towards Instructor certification below. 
-      {% if progress_training %}
+      Please review your progress towards Instructor certification below.
+    </p>
+    {% if progress_training and user.passed_training %}
+    <p>
         {% checkout_deadline progress_training.event.end as deadline %}
         Based on your training dates of {% human_daterange progress_training.event.start progress_training.event.end %}, the 90-day deadline to complete these 
         requirements is <strong>{{ deadline | date:'F j, Y'}}</strong>.
-      {% endif %}
     </p>
     <p>
       If you would like an extension, please contact us at 
       <a href="mailto:instructor.training@carpentries.org">instructor.training@carpentries.org</a>
       and refer to your confirmation email for your updated deadline.
     </p>
+    {% endif %}
     <p>
       If you have recently completed a training or step towards checkout, 
       please allow 7-10 days for this information to show up in your profile.


### PR DESCRIPTION
Fixes #2508 .

More explanation in https://github.com/carpentries/amy/issues/2508#issuecomment-1671458935.

Required for v4.2 so we aren't displaying misleading information about checkout deadlines.