### PR TITLE
Remove use of text-white to override text colour

### DIFF
--- a/amy/templates/requests/all_trainingrequests.html
+++ b/amy/templates/requests/all_trainingrequests.html
@@ -121,7 +121,7 @@
     </table>
 
     <div class="btn-group" role="group" aria-label="Actions for list of training requests">
-      <a class="btn btn-info text-white" bulk-email-on-click>Mail selected</a>
+      <a class="btn btn-info" bulk-email-on-click>Mail selected</a>
       <a class="btn btn-secondary" href="{% url 'api:training-requests' %}?format=csv&" amy-download-selected>Download selected</a>
       <a class="btn btn-dark" href="{% url 'api:training-requests' %}?format=csv2&manualscore=1" amy-download-selected>Download selected for bulk manual scoring</a>
     </div>

--- a/amy/templates/workshops/workshop_staff.html
+++ b/amy/templates/workshops/workshop_staff.html
@@ -52,7 +52,7 @@
     </form>
     <p>
       <div class="btn-group" role="group" aria-label="Buttons">
-        <a class="btn btn-primary text-white" bulk-email-on-click>Contact selected</a>
+        <a class="btn btn-primary" bulk-email-on-click>Contact selected</a>
         <a class="btn btn-secondary" href="{% url 'workshop_staff_csv' %}?{{ request.GET.urlencode }}">Download as CSV</a>
       </div>
     </p>


### PR DESCRIPTION
Fixes a contrast bug introduced by #2490 . The override is no longer needed as the text colour choice is handled better by Bootstrap under the new palette.

Current `develop` branch:
![Button with cyan background and white text](https://github.com/carpentries/amy/assets/20683271/137f0005-e4cb-4e7f-a465-66b6d9f16aa3)
This branch:
![Button with cyan background and dark grey text](https://github.com/carpentries/amy/assets/20683271/f4cb7d82-24d6-4122-86bc-576ed6ac8def)
