### PR TITLE
Make GitHub organization check case insensitive

### DIFF
--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -186,7 +186,7 @@ class GetInvolvedForm(forms.ModelForm):
     CARPENTRIES_GITHUB_ORGS = [
         "carpentries",
         "datacarpentry",
-        "librarycarpentry",
+        "LibraryCarpentry",
         "swcarpentry",
         "carpentries-es",
         "Reproducible-Science-Curriculum",
@@ -241,16 +241,19 @@ class GetInvolvedForm(forms.ModelForm):
                     f'"{involvement_type.display_name}".'
                 )
                 raise ValidationError(msg)
-            elif not any(
-                f"github.com/{org}" in url for org in self.CARPENTRIES_GITHUB_ORGS
-            ):
-                msg = (
-                    "This URL is not associated with a repository in any of the "
-                    "GitHub organisations owned by The Carpentries. "
-                    "If you need help resolving this error, please contact us using "
-                    "the details at the top of this form."
-                )
-                raise ValidationError(msg)
+            else:
+                case_insensitive_url = url.casefold()
+                if not any(
+                    f"github.com/{org}".casefold() in case_insensitive_url
+                    for org in self.CARPENTRIES_GITHUB_ORGS
+                ):
+                    msg = (
+                        "This URL is not associated with a repository in any of the "
+                        "GitHub organisations owned by The Carpentries. "
+                        "If you need help resolving this error, please contact us "
+                        "using the details at the top of this form."
+                    )
+                    raise ValidationError(msg)
 
         return url
 

--- a/amy/dashboard/tests/test_forms.py
+++ b/amy/dashboard/tests/test_forms.py
@@ -201,6 +201,21 @@ class TestGetInvolvedForm(TestCase):
             [expected_msg],
         )
 
+    def test_clean_custom_validation__url_case(self):
+        # Arrange
+        github_contribution = Involvement.objects.get(name="GitHub Contribution")
+        data = {
+            "involvement_type": github_contribution,
+            "date": date(2023, 7, 27),
+            "url": "https://GitHub.com/CaRpEnTrIeS",
+        }
+
+        # Act
+        form = GetInvolvedForm(data, instance=self.base_instance)
+
+        # Assert
+        self.assertEqual(form.is_valid(), True)
+
     def test_clean_custom_validation__trainee_notes(self):
         # Arrange
         data = {"involvement_type": self.involvement, "date": date(2023, 7, 27)}


### PR DESCRIPTION
Fixes a bug in v4.2 reported by @karenword in Slack:

> a trainee is reporting that this link is throwing an error claiming it is not associated with a Carpentries repo: `https://github.com/LibraryCarpentry/lc-r/issues/<id>` .

This arises because we have the organization in lowercase (`librarycarpentry`) in our code. Github organization URLs are case insensitive, so we should accept both.