### PR TITLE
[Emails] Disable some notifications for non-admin users

### DIFF
--- a/amy/dashboard/templatetags/notifications.py
+++ b/amy/dashboard/templatetags/notifications.py
@@ -1,6 +1,7 @@
 from typing import cast
 
 from django import template
+from django.conf import settings
 from django.contrib.messages.storage.base import Message
 from django.http import HttpRequest
 
@@ -12,8 +13,8 @@ register = template.Library()
 @register.simple_tag
 def message_allowed(message: Message, request: HttpRequest) -> bool:
     return (
-        "only-for-admins" in message.tags
+        settings.ONLY_FOR_ADMINS_TAG in message.tags
         and request.user
         and cast(Person, request.user).is_admin
-        or "only-for-admins" not in message.tags
+        or settings.ONLY_FOR_ADMINS_TAG not in message.tags
     )

--- a/amy/dashboard/templatetags/notifications.py
+++ b/amy/dashboard/templatetags/notifications.py
@@ -1,0 +1,19 @@
+from typing import cast
+
+from django import template
+from django.contrib.messages.storage.base import Message
+from django.http import HttpRequest
+
+from workshops.models import Person
+
+register = template.Library()
+
+
+@register.simple_tag
+def message_allowed(message: Message, request: HttpRequest) -> bool:
+    return (
+        "only-for-admins" in message.tags
+        and request.user
+        and cast(Person, request.user).is_admin
+        or "only-for-admins" not in message.tags
+    )

--- a/amy/dashboard/tests/test_template_tags.py
+++ b/amy/dashboard/tests/test_template_tags.py
@@ -1,0 +1,70 @@
+from django.contrib.messages import constants
+from django.contrib.messages.storage.base import Message
+from django.test import RequestFactory, TestCase
+
+from dashboard.templatetags.notifications import message_allowed
+from workshops.models import Person
+
+
+class TestMessageAllowed(TestCase):
+    def test_notification_not_tagged_for_admins_displays_for_admins(self) -> None:
+        # Arrange
+        person = Person.objects.create_superuser(
+            "admin", "admin", "admin", "admin@example.org", "admin"
+        )
+        request = RequestFactory().get("/")
+        request.user = person
+        message = Message(constants.INFO, "Test message", extra_tags="")
+
+        # Act
+        result = message_allowed(message, request)
+
+        # Assert
+        self.assertTrue(result)
+
+    def test_notification_not_tagged_for_admins_displays_for_instructors(self) -> None:
+        # Arrange
+        person = Person.objects.create_user(
+            "user", "user", "user", "user@example.org", "user"
+        )
+        request = RequestFactory().get("/")
+        request.user = person
+        message = Message(constants.INFO, "Test message", extra_tags="")
+
+        # Act
+        result = message_allowed(message, request)
+
+        # Assert
+        self.assertTrue(result)
+
+    def test_notification_tagged_for_admins_displays_for_admins(self) -> None:
+        # Arrange
+        person = Person.objects.create_superuser(
+            "admin", "admin", "admin", "admin@example.org", "admin"
+        )
+        request = RequestFactory().get("/")
+        request.user = person
+        message = Message(constants.INFO, "Test message", extra_tags="only-for-admins")
+
+        # Act
+        result = message_allowed(message, request)
+
+        # Assert
+        self.assertTrue(result)
+
+    def test_notification_tagged_for_admins_doesnt_display_for_instructors(
+        self,
+    ) -> None:
+        # Arrange
+        person = Person.objects.create_user(
+            "user", "user", "user", "user@example.org", "user"
+        )
+        request = RequestFactory().get("/")
+        request.user = person
+        message = Message(constants.INFO, "Test message", extra_tags="only-for-admins")
+
+        # Act
+        result = message_allowed(message, request)
+
+        # Assert
+        self.assertFalse(result)

--- a/amy/dashboard/tests/test_template_tags.py
+++ b/amy/dashboard/tests/test_template_tags.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.messages import constants
 from django.contrib.messages.storage.base import Message
 from django.test import RequestFactory, TestCase
@@ -44,7 +45,9 @@ class TestMessageAllowed(TestCase):
         )
         request = RequestFactory().get("/")
         request.user = person
-        message = Message(constants.INFO, "Test message", extra_tags="only-for-admins")
+        message = Message(
+            constants.INFO, "Test message", extra_tags=settings.ONLY_FOR_ADMINS_TAG
+        )
 
         # Act
         result = message_allowed(message, request)
@@ -61,7 +64,9 @@ class TestMessageAllowed(TestCase):
         )
         request = RequestFactory().get("/")
         request.user = person
-        message = Message(constants.INFO, "Test message", extra_tags="only-for-admins")
+        message = Message(
+            constants.INFO, "Test message", extra_tags=settings.ONLY_FOR_ADMINS_TAG
+        )
 
         # Act
         result = message_allowed(message, request)

--- a/amy/emails/tests/test_utils.py
+++ b/amy/emails/tests/test_utils.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest import mock
 
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, TestCase
 from django.utils import timezone
@@ -77,7 +78,7 @@ class TestMessagesMissingTemplate(TestCase):
             request,
             "Email action was not scheduled due to missing template for signal "
             f"{signal}.",
-            extra_tags="only-for-admins",
+            extra_tags=settings.ONLY_FOR_ADMINS_TAG,
         )
 
 
@@ -100,7 +101,7 @@ class TestMessagesActionScheduled(TestCase):
             f'<relative-time datetime="{scheduled_at}"></relative-time>: '
             f'<a href="{scheduled_email.get_absolute_url()}"><code>'
             f"{scheduled_email.pk}</code></a>.",
-            extra_tags="only-for-admins",
+            extra_tags=settings.ONLY_FOR_ADMINS_TAG,
         )
 
 

--- a/amy/emails/tests/test_utils.py
+++ b/amy/emails/tests/test_utils.py
@@ -77,6 +77,7 @@ class TestMessagesMissingTemplate(TestCase):
             request,
             "Email action was not scheduled due to missing template for signal "
             f"{signal}.",
+            extra_tags="only-for-admins",
         )
 
 
@@ -99,6 +100,7 @@ class TestMessagesActionScheduled(TestCase):
             f'<relative-time datetime="{scheduled_at}"></relative-time>: '
             f'<a href="{scheduled_email.get_absolute_url()}"><code>'
             f"{scheduled_email.pk}</code></a>.",
+            extra_tags="only-for-admins",
         )
 
 

--- a/amy/emails/utils.py
+++ b/amy/emails/utils.py
@@ -47,6 +47,7 @@ def messages_missing_template(request: HttpRequest, signal: str) -> None:
     messages.warning(
         request,
         f"Email action was not scheduled due to missing template for signal {signal}.",
+        extra_tags="only-for-admins",
     )
 
 
@@ -64,6 +65,7 @@ def messages_action_scheduled(
             scheduled_email.get_absolute_url(),
             scheduled_email.pk,
         ),
+        extra_tags="only-for-admins",
     )
 
 

--- a/amy/emails/utils.py
+++ b/amy/emails/utils.py
@@ -47,7 +47,7 @@ def messages_missing_template(request: HttpRequest, signal: str) -> None:
     messages.warning(
         request,
         f"Email action was not scheduled due to missing template for signal {signal}.",
-        extra_tags="only-for-admins",
+        extra_tags=settings.ONLY_FOR_ADMINS_TAG,
     )
 
 
@@ -65,7 +65,7 @@ def messages_action_scheduled(
             scheduled_email.get_absolute_url(),
             scheduled_email.pk,
         ),
-        extra_tags="only-for-admins",
+        extra_tags=settings.ONLY_FOR_ADMINS_TAG,
     )
 
 

--- a/amy/templates/base.html
+++ b/amy/templates/base.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static notifications %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -47,7 +47,8 @@
         {% if messages %}
           {% for message in messages %}
             {# if message is tagged as only for admins then show it only for admins #}
-            {% if "only-for-admins" in message.tags and request.user.is_authenticated and request.user.is_admin or "only-for-admins" not in message.tags %}
+            {% message_allowed message request as show_message %}
+            {% if show_message %}
             <div class="alert {{ message.tags }} alert-dismissible fade show" role="alert">
               {% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
               <strong>Error:</strong>

--- a/amy/templates/base.html
+++ b/amy/templates/base.html
@@ -46,19 +46,22 @@
         <div class="{% block maincolumn %}col-sm-12 col-md-12{% endblock maincolumn %} main pb-5">
         {% if messages %}
           {% for message in messages %}
-          <div class="alert {{ message.tags }} alert-dismissible fade show" role="alert">
-            {% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
-            <strong>Error:</strong>
-            {% elif message.level == DEFAULT_MESSAGE_LEVELS.WARNING %}
-            <strong>Warning:</strong>
-            {% elif message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
-            <strong>Success:</strong>
+            {# if message is tagged as only for admins then show it only for admins #}
+            {% if "only-for-admins" in message.tags and request.user.is_authenticated and request.user.is_admin or "only-for-admins" not in message.tags %}
+            <div class="alert {{ message.tags }} alert-dismissible fade show" role="alert">
+              {% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
+              <strong>Error:</strong>
+              {% elif message.level == DEFAULT_MESSAGE_LEVELS.WARNING %}
+              <strong>Warning:</strong>
+              {% elif message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
+              <strong>Success:</strong>
+              {% endif %}
+              {{ message }}
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
             {% endif %}
-            {{ message }}
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
           {% endfor %}
         {% endif %}
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -466,6 +466,7 @@ MESSAGE_TAGS = {
     message_constants.WARNING: "warning alert-warning",
     message_constants.ERROR: "error alert-danger",
 }
+ONLY_FOR_ADMINS_TAG = "only-for-admins"
 
 # django-countries
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes #2498.

Two notifications generated by email actions (`messages_missing_template` and `messages_action_scheduled`) now add extra tag `"only-for-admins"`.

New condition in `base.html` checks for this tag when displaying messages. If the tag is present on the message, then that message is shown only for administrator users. If the tag is not present, then the message is shown as usual.

Writing unit tests for this was a little bit tricky, as I wasn't able to inject adding messages to a view. So instead I moved the logic to the template tag and tested it instead of testing the view output.