### PR TITLE
[Emails] Enable field `active` on EmailTemplates

### DIFF
--- a/amy/emails/forms.py
+++ b/amy/emails/forms.py
@@ -21,6 +21,7 @@ class EmailTemplateCreateForm(forms.ModelForm):
         model = EmailTemplate
         fields = [
             "name",
+            "active",
             "signal",
             "from_header",
             "reply_to_header",

--- a/amy/emails/tests/test_controller.py
+++ b/amy/emails/tests/test_controller.py
@@ -55,6 +55,31 @@ class TestEmailController(TestCase):
                 to_header=["harry@potter.com"],
             )
 
+    def test_schedule_email__inactive_template(self) -> None:
+        # Arrange
+        now = timezone.now()
+        signal = "test_email_template"
+        EmailTemplate.objects.create(
+            active=False,
+            name="Test Email Template",
+            signal=signal,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            # invalid Django template syntax
+            subject="Greetings",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+
+        # Act & Assert
+        with self.assertRaises(EmailTemplate.DoesNotExist):
+            EmailController.schedule_email(
+                signal,
+                context={"name": "Harry"},
+                scheduled_at=now,
+                to_header=["harry@potter.com"],
+            )
+
     def test_schedule_email__invalid_template(self) -> None:
         # Arrange
         now = timezone.now()

--- a/amy/templates/emails/email_template_list.html
+++ b/amy/templates/emails/email_template_list.html
@@ -14,6 +14,7 @@
       <tr>
         <th>ID</th>
         <th>Name</th>
+        <th>Active</th>
         <th>Signal</th>
         <th>From</th>
         <th>Reply-To</th>
@@ -26,6 +27,7 @@
       <tr>
         <td><a href="{{ template.get_absolute_url }}">{{ template.id }}</a></td>
         <td>{{ template.name }}</td>
+        <td>{{ template.active|yesno }}</td>
         <td><code>{{ template.signal }}</code></td>
         <td>{{ template.from_header }}</td>
         <td>{{ template.reply_to_header|default:"&mdash;" }}</td>


### PR DESCRIPTION
This fixes #2499. The field was added to EmailTemplate forms and displayed in the email template list+detail views.

Email Controller tests were extended to ensure only active templates are considered.
