### PR TITLE
[Emails] Refactor receivers into class-based actions

### DIFF
--- a/amy/emails/actions/admin_signs_instructor_up_for_workshop.py
+++ b/amy/emails/actions/admin_signs_instructor_up_for_workshop.py
@@ -1,58 +1,50 @@
+from datetime import datetime
 from typing import Any
 
-from django.dispatch import receiver
 from typing_extensions import Unpack
 
-from emails.controller import EmailController, EmailControllerMissingRecipientsException
-from emails.models import EmailTemplate
 from emails.signals import admin_signs_instructor_up_for_workshop_signal
 from emails.types import AdminSignsInstructorUpContext, AdminSignsInstructorUpKwargs
-from emails.utils import (
-    immediate_action,
-    messages_action_scheduled,
-    messages_missing_recipients,
-    messages_missing_template,
-    person_from_request,
-)
+from emails.utils import immediate_action
 from recruitment.models import InstructorRecruitmentSignup
 from workshops.models import Event, Person
-from workshops.utils.feature_flags import feature_flag_enabled
+
+from .base_action import BaseAction
 
 
-@receiver(admin_signs_instructor_up_for_workshop_signal)
-@feature_flag_enabled("EMAIL_MODULE")
-def admin_signs_instructor_up_for_workshop_receiver(
-    sender: Any, **kwargs: Unpack[AdminSignsInstructorUpKwargs]
-) -> None:
-    request = kwargs["request"]
-    person_id = kwargs["person_id"]
-    event_id = kwargs["event_id"]
-    instructor_recruitment_signup_id = kwargs["instructor_recruitment_signup_id"]
-
-    scheduled_at = immediate_action()
-    person = Person.objects.get(pk=person_id)
-    event = Event.objects.get(pk=event_id)
-    instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
-        pk=instructor_recruitment_signup_id
-    )
-    context: AdminSignsInstructorUpContext = {
-        "person": person,
-        "event": event,
-        "instructor_recruitment_signup": instructor_recruitment_signup,
-    }
+class AdminSignsInstructorUpForWorkshopReceiver(BaseAction):
     signal = admin_signs_instructor_up_for_workshop_signal.signal_name
-    try:
-        scheduled_email = EmailController.schedule_email(
-            signal=signal,
-            context=context,
-            scheduled_at=scheduled_at,
-            to_header=[person.email] if person.email else [],
-            generic_relation_obj=instructor_recruitment_signup,
-            author=person_from_request(request),
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        return immediate_action()
+
+    def get_context(
+        self, **kwargs: Unpack[AdminSignsInstructorUpKwargs]
+    ) -> AdminSignsInstructorUpContext:
+        person = Person.objects.get(pk=kwargs["person_id"])
+        event = Event.objects.get(pk=kwargs["event_id"])
+        instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
+            pk=kwargs["instructor_recruitment_signup_id"]
         )
-    except EmailControllerMissingRecipientsException:
-        messages_missing_recipients(request, signal)
-    except EmailTemplate.DoesNotExist:
-        messages_missing_template(request, signal)
-    else:
-        messages_action_scheduled(request, signal, scheduled_email)
+        return {
+            "person": person,
+            "event": event,
+            "instructor_recruitment_signup": instructor_recruitment_signup,
+        }
+
+    def get_generic_relation_object(
+        self, context: AdminSignsInstructorUpContext, **kwargs
+    ) -> Any:
+        return context["instructor_recruitment_signup"]
+
+    def get_recipients(self, **kwargs) -> list[str]:
+        person = Person.objects.get(pk=kwargs["person_id"])
+        return [person.email] if person.email else []
+
+
+admin_signs_instructor_up_for_workshop_receiver = (
+    AdminSignsInstructorUpForWorkshopReceiver()
+)
+admin_signs_instructor_up_for_workshop_signal.connect(
+    admin_signs_instructor_up_for_workshop_receiver
+)

--- a/amy/emails/actions/admin_signs_instructor_up_for_workshop.py
+++ b/amy/emails/actions/admin_signs_instructor_up_for_workshop.py
@@ -1,15 +1,13 @@
 from datetime import datetime
-from typing import Any
 
 from typing_extensions import Unpack
 
+from emails.actions.base_action import BaseAction
 from emails.signals import admin_signs_instructor_up_for_workshop_signal
 from emails.types import AdminSignsInstructorUpContext, AdminSignsInstructorUpKwargs
 from emails.utils import immediate_action
 from recruitment.models import InstructorRecruitmentSignup
 from workshops.models import Event, Person
-
-from .base_action import BaseAction
 
 
 class AdminSignsInstructorUpForWorkshopReceiver(BaseAction):
@@ -34,11 +32,13 @@ class AdminSignsInstructorUpForWorkshopReceiver(BaseAction):
 
     def get_generic_relation_object(
         self, context: AdminSignsInstructorUpContext, **kwargs
-    ) -> Any:
+    ) -> InstructorRecruitmentSignup:
         return context["instructor_recruitment_signup"]
 
-    def get_recipients(self, **kwargs) -> list[str]:
-        person = Person.objects.get(pk=kwargs["person_id"])
+    def get_recipients(
+        self, context: AdminSignsInstructorUpContext, **kwargs
+    ) -> list[str]:
+        person = context["person"]
         return [person.email] if person.email else []
 
 

--- a/amy/emails/actions/base_action.py
+++ b/amy/emails/actions/base_action.py
@@ -3,15 +3,23 @@ from datetime import datetime
 import logging
 from typing import Any
 
+from django.contrib.contenttypes.models import ContentType
 from flags.state import flag_enabled
 
-from emails.controller import EmailController, EmailControllerMissingRecipientsException
-from emails.models import EmailTemplate
+from emails.controller import (
+    EmailController,
+    EmailControllerMissingRecipientsException,
+    EmailControllerMissingTemplateException,
+)
+from emails.models import EmailTemplate, ScheduledEmail
 from emails.signals import SignalNameEnum
 from emails.utils import (
+    messages_action_cancelled,
     messages_action_scheduled,
+    messages_action_updated,
     messages_missing_recipients,
     messages_missing_template,
+    messages_missing_template_link,
     person_from_request,
 )
 
@@ -79,3 +87,95 @@ class BaseAction(ABC):
             messages_missing_template(request, self.signal)
         else:
             messages_action_scheduled(request, self.signal, scheduled_email)
+
+
+class BaseActionUpdate(BaseAction):
+    def __call__(self, sender: Any, **kwargs) -> None:
+        if not feature_flag_enabled("EMAIL_MODULE", f"{self.signal}_update", **kwargs):
+            return
+
+        request = kwargs.pop("request")
+
+        context = self.get_context(**kwargs)
+        scheduled_at = self.get_scheduled_at(**kwargs)
+        generic_relation_obj = self.get_generic_relation_object(context, **kwargs)
+        signal_name = self.signal
+
+        ct = ContentType.objects.get_for_model(generic_relation_obj)
+        try:
+            scheduled_email = (
+                ScheduledEmail.objects.select_for_update()
+                .select_related("template")
+                .get(
+                    generic_relation_content_type=ct,
+                    generic_relation_pk=generic_relation_obj.pk,
+                    template__signal=signal_name,
+                    state="scheduled",
+                )
+            )
+
+        except ScheduledEmail.DoesNotExist:
+            logger.warning(
+                f"Scheduled email for signal {signal_name} and {generic_relation_obj=} "
+                "does not exist."
+            )
+            return
+
+        except ScheduledEmail.MultipleObjectsReturned:
+            logger.warning(
+                f"Too many scheduled emails for signal {signal_name} and "
+                f"{generic_relation_obj=}. Can't update them."
+            )
+            return
+
+        try:
+            scheduled_email = EmailController.update_scheduled_email(
+                scheduled_email=scheduled_email,
+                context=context,
+                scheduled_at=scheduled_at,
+                to_header=self.get_recipients(context, **kwargs),
+                generic_relation_obj=generic_relation_obj,
+                author=person_from_request(request),
+            )
+        except EmailControllerMissingRecipientsException:
+            messages_missing_recipients(request, signal_name)
+        except EmailControllerMissingTemplateException:
+            # Note: this is not realistically possible because the scheduled email
+            # is looked up using a specific template signal.
+            messages_missing_template_link(request, scheduled_email)
+        else:
+            messages_action_updated(request, signal_name, scheduled_email)
+
+
+class BaseActionCancel(BaseAction):
+    # Method is not needed in this action.
+    def get_recipients(self, context: dict[str, Any], **kwargs) -> list[str]:
+        raise NotImplementedError()
+
+    # Method is not needed in this action.
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        raise NotImplementedError()
+
+    def __call__(self, sender: Any, **kwargs) -> None:
+        if not feature_flag_enabled("EMAIL_MODULE", f"{self.signal}_remove", **kwargs):
+            return
+
+        request = kwargs["request"]
+        context = self.get_context(**kwargs)
+        generic_relation_obj = self.get_generic_relation_object(context, **kwargs)
+        signal_name = self.signal
+
+        ct = ContentType.objects.get_for_model(generic_relation_obj)
+        scheduled_emails = ScheduledEmail.objects.filter(
+            generic_relation_content_type=ct,
+            generic_relation_pk=generic_relation_obj.pk,
+            template__signal=signal_name,
+            state="scheduled",
+        ).select_for_update()
+
+        for scheduled_email in scheduled_emails:
+            scheduled_email = EmailController.cancel_email(
+                scheduled_email=scheduled_email,
+                author=person_from_request(request),
+            )
+            messages_action_cancelled(request, signal_name, scheduled_email)

--- a/amy/emails/actions/base_action.py
+++ b/amy/emails/actions/base_action.py
@@ -1,0 +1,81 @@
+from abc import ABC, abstractmethod
+from datetime import datetime
+import logging
+from typing import Any
+
+from flags.state import flag_enabled
+
+from emails.controller import EmailController, EmailControllerMissingRecipientsException
+from emails.models import EmailTemplate
+from emails.signals import SignalNameEnum
+from emails.utils import (
+    messages_action_scheduled,
+    messages_missing_recipients,
+    messages_missing_template,
+    person_from_request,
+)
+
+logger = logging.getLogger("amy")
+
+
+def feature_flag_enabled(feature_flag: str, signal_name: str, **kwargs) -> bool:
+    request = kwargs.get("request")
+    if not request:
+        logger.debug(
+            f"Cannot check {feature_flag} feature flag, `request` parameter "
+            f"to {signal_name} is missing"
+        )
+        return False
+
+    if not flag_enabled(feature_flag, request=request):
+        logger.debug(f"{feature_flag} feature flag not set, skipping {signal_name}")
+        return False
+
+    return True
+
+
+class BaseAction(ABC):
+    signal: SignalNameEnum
+
+    @abstractmethod
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_context(self, **kwargs) -> dict[str, Any]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_generic_relation_object(self, context: dict[str, Any], **kwargs) -> Any:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_recipients(self, **kwargs) -> list[str]:
+        raise NotImplementedError()
+
+    def __call__(self, sender: Any, **kwargs) -> None:
+        if not feature_flag_enabled("EMAIL_MODULE", self.signal, **kwargs):
+            return
+
+        request = kwargs.pop("request")
+
+        context = self.get_context(**kwargs)
+        scheduled_at = self.get_scheduled_at(**kwargs)
+
+        try:
+            scheduled_email = EmailController.schedule_email(
+                signal=self.signal,
+                context=context,
+                scheduled_at=scheduled_at,
+                to_header=self.get_recipients(**kwargs),
+                generic_relation_obj=self.get_generic_relation_object(
+                    context, **kwargs
+                ),
+                author=person_from_request(request),
+            )
+        except EmailControllerMissingRecipientsException:
+            messages_missing_recipients(request, self.signal)
+        except EmailTemplate.DoesNotExist:
+            messages_missing_template(request, self.signal)
+        else:
+            messages_action_scheduled(request, self.signal, scheduled_email)

--- a/amy/emails/actions/base_action.py
+++ b/amy/emails/actions/base_action.py
@@ -50,7 +50,7 @@ class BaseAction(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_recipients(self, **kwargs) -> list[str]:
+    def get_recipients(self, context: dict[str, Any], **kwargs) -> list[str]:
         raise NotImplementedError()
 
     def __call__(self, sender: Any, **kwargs) -> None:
@@ -67,7 +67,7 @@ class BaseAction(ABC):
                 signal=self.signal,
                 context=context,
                 scheduled_at=scheduled_at,
-                to_header=self.get_recipients(**kwargs),
+                to_header=self.get_recipients(context, **kwargs),
                 generic_relation_obj=self.get_generic_relation_object(
                     context, **kwargs
                 ),

--- a/amy/emails/actions/instructor_badge_awarded.py
+++ b/amy/emails/actions/instructor_badge_awarded.py
@@ -1,52 +1,41 @@
-from typing import Any
+from datetime import datetime
 
-from django.dispatch import receiver
 from typing_extensions import Unpack
 
-from emails.controller import EmailController, EmailControllerMissingRecipientsException
-from emails.models import EmailTemplate
+from emails.actions.base_action import BaseAction
 from emails.signals import instructor_badge_awarded_signal
 from emails.types import InstructorBadgeAwardedContext, InstructorBadgeAwardedKwargs
-from emails.utils import (
-    immediate_action,
-    messages_action_scheduled,
-    messages_missing_recipients,
-    messages_missing_template,
-    person_from_request,
-)
+from emails.utils import immediate_action
 from workshops.models import Award, Person
-from workshops.utils.feature_flags import feature_flag_enabled
 
 
-@receiver(instructor_badge_awarded_signal)
-@feature_flag_enabled("EMAIL_MODULE")
-def instructor_badge_awarded_receiver(
-    sender: Any, **kwargs: Unpack[InstructorBadgeAwardedKwargs]
-) -> None:
-    request = kwargs["request"]
-    person_id = kwargs["person_id"]
-    award_id = kwargs["award_id"]
-
-    scheduled_at = immediate_action()
-    person = Person.objects.get(pk=person_id)
-    award = Award.objects.get(pk=award_id)
-    context: InstructorBadgeAwardedContext = {
-        "person": person,
-        "award": award,
-    }
+class InstructorBadgeAwardedReceiver(BaseAction):
     signal = instructor_badge_awarded_signal.signal_name
-    try:
-        scheduled_email = EmailController.schedule_email(
-            signal=signal,
-            context=context,
-            scheduled_at=scheduled_at,
-            to_header=[person.email] if person.email else [],
-            generic_relation_obj=award,
-            author=person_from_request(request),
-        )
-    except EmailControllerMissingRecipientsException:
-        messages_missing_recipients(request, signal)
-    except EmailTemplate.DoesNotExist:
-        messages_missing_template(request, signal)
-    else:
-        messages_action_scheduled(request, signal, scheduled_email)
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        return immediate_action()
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorBadgeAwardedKwargs]
+    ) -> InstructorBadgeAwardedContext:
+        person = Person.objects.get(pk=kwargs["person_id"])
+        award = Award.objects.get(pk=kwargs["award_id"])
+        return {
+            "person": person,
+            "award": award,
+        }
+
+    def get_generic_relation_object(
+        self, context: InstructorBadgeAwardedContext, **kwargs
+    ) -> Award:
+        return context["award"]
+
+    def get_recipients(
+        self, context: InstructorBadgeAwardedContext, **kwargs
+    ) -> list[str]:
+        person = context["person"]
+        return [person.email] if person.email else []
+
+
+instructor_badge_awarded_receiver = InstructorBadgeAwardedReceiver()
+instructor_badge_awarded_signal.connect(instructor_badge_awarded_receiver)

--- a/amy/emails/actions/instructor_confirmed_for_workshop.py
+++ b/amy/emails/actions/instructor_confirmed_for_workshop.py
@@ -1,58 +1,48 @@
-from typing import Any
+from datetime import datetime
 
-from django.dispatch import receiver
 from typing_extensions import Unpack
 
-from emails.controller import EmailController, EmailControllerMissingRecipientsException
-from emails.models import EmailTemplate
+from emails.actions.base_action import BaseAction
 from emails.signals import instructor_confirmed_for_workshop_signal
 from emails.types import InstructorConfirmedContext, InstructorConfirmedKwargs
-from emails.utils import (
-    immediate_action,
-    messages_action_scheduled,
-    messages_missing_recipients,
-    messages_missing_template,
-    person_from_request,
-)
+from emails.utils import immediate_action
 from recruitment.models import InstructorRecruitmentSignup
 from workshops.models import Event, Person
-from workshops.utils.feature_flags import feature_flag_enabled
 
 
-@receiver(instructor_confirmed_for_workshop_signal)
-@feature_flag_enabled("EMAIL_MODULE")
-def instructor_confirmed_for_workshop_receiver(
-    sender: Any, **kwargs: Unpack[InstructorConfirmedKwargs]
-) -> None:
-    request = kwargs["request"]
-    person_id = kwargs["person_id"]
-    event_id = kwargs["event_id"]
-    instructor_recruitment_signup_id = kwargs["instructor_recruitment_signup_id"]
-
-    scheduled_at = immediate_action()
-    person = Person.objects.get(pk=person_id)
-    event = Event.objects.get(pk=event_id)
-    instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
-        pk=instructor_recruitment_signup_id
-    )
-    context: InstructorConfirmedContext = {
-        "person": person,
-        "event": event,
-        "instructor_recruitment_signup": instructor_recruitment_signup,
-    }
+class InstructorConfirmedForWorkshopReceiver(BaseAction):
     signal = instructor_confirmed_for_workshop_signal.signal_name
-    try:
-        scheduled_email = EmailController.schedule_email(
-            signal=signal,
-            context=context,
-            scheduled_at=scheduled_at,
-            to_header=[person.email] if person.email else [],
-            generic_relation_obj=instructor_recruitment_signup,
-            author=person_from_request(request),
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        return immediate_action()
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorConfirmedKwargs]
+    ) -> InstructorConfirmedContext:
+        person = Person.objects.get(pk=kwargs["person_id"])
+        event = Event.objects.get(pk=kwargs["event_id"])
+        instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
+            pk=kwargs["instructor_recruitment_signup_id"]
         )
-    except EmailControllerMissingRecipientsException:
-        messages_missing_recipients(request, signal)
-    except EmailTemplate.DoesNotExist:
-        messages_missing_template(request, signal)
-    else:
-        messages_action_scheduled(request, signal, scheduled_email)
+        return {
+            "person": person,
+            "event": event,
+            "instructor_recruitment_signup": instructor_recruitment_signup,
+        }
+
+    def get_generic_relation_object(
+        self, context: InstructorConfirmedContext, **kwargs
+    ) -> InstructorRecruitmentSignup:
+        return context["instructor_recruitment_signup"]
+
+    def get_recipients(
+        self, context: InstructorConfirmedContext, **kwargs
+    ) -> list[str]:
+        person = context["person"]
+        return [person.email] if person.email else []
+
+
+instructor_confirmed_for_workshop_receiver = InstructorConfirmedForWorkshopReceiver()
+instructor_confirmed_for_workshop_signal.connect(
+    instructor_confirmed_for_workshop_receiver
+)

--- a/amy/emails/actions/instructor_declined_from_workshop.py
+++ b/amy/emails/actions/instructor_declined_from_workshop.py
@@ -1,58 +1,46 @@
-from typing import Any
+from datetime import datetime
 
-from django.dispatch import receiver
 from typing_extensions import Unpack
 
-from emails.controller import EmailController, EmailControllerMissingRecipientsException
-from emails.models import EmailTemplate
+from emails.actions.base_action import BaseAction
 from emails.signals import instructor_declined_from_workshop_signal
 from emails.types import InstructorDeclinedContext, InstructorDeclinedKwargs
-from emails.utils import (
-    immediate_action,
-    messages_action_scheduled,
-    messages_missing_recipients,
-    messages_missing_template,
-    person_from_request,
-)
+from emails.utils import immediate_action
 from recruitment.models import InstructorRecruitmentSignup
 from workshops.models import Event, Person
-from workshops.utils.feature_flags import feature_flag_enabled
 
 
-@receiver(instructor_declined_from_workshop_signal)
-@feature_flag_enabled("EMAIL_MODULE")
-def instructor_declined_from_workshop_receiver(
-    sender: Any, **kwargs: Unpack[InstructorDeclinedKwargs]
-) -> None:
-    request = kwargs["request"]
-    person_id = kwargs["person_id"]
-    event_id = kwargs["event_id"]
-    instructor_recruitment_signup_id = kwargs["instructor_recruitment_signup_id"]
-
-    scheduled_at = immediate_action()
-    person = Person.objects.get(pk=person_id)
-    event = Event.objects.get(pk=event_id)
-    instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
-        pk=instructor_recruitment_signup_id
-    )
-    context: InstructorDeclinedContext = {
-        "person": person,
-        "event": event,
-        "instructor_recruitment_signup": instructor_recruitment_signup,
-    }
+class InstructorDeclinedFromWorkshopReceiver(BaseAction):
     signal = instructor_declined_from_workshop_signal.signal_name
-    try:
-        scheduled_email = EmailController.schedule_email(
-            signal=signal,
-            context=context,
-            scheduled_at=scheduled_at,
-            to_header=[person.email] if person.email else [],
-            generic_relation_obj=instructor_recruitment_signup,
-            author=person_from_request(request),
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        return immediate_action()
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorDeclinedKwargs]
+    ) -> InstructorDeclinedContext:
+        person = Person.objects.get(pk=kwargs["person_id"])
+        event = Event.objects.get(pk=kwargs["event_id"])
+        instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
+            pk=kwargs["instructor_recruitment_signup_id"]
         )
-    except EmailControllerMissingRecipientsException:
-        messages_missing_recipients(request, signal)
-    except EmailTemplate.DoesNotExist:
-        messages_missing_template(request, signal)
-    else:
-        messages_action_scheduled(request, signal, scheduled_email)
+        return {
+            "person": person,
+            "event": event,
+            "instructor_recruitment_signup": instructor_recruitment_signup,
+        }
+
+    def get_generic_relation_object(
+        self, context: InstructorDeclinedContext, **kwargs
+    ) -> InstructorRecruitmentSignup:
+        return context["instructor_recruitment_signup"]
+
+    def get_recipients(self, context: InstructorDeclinedContext, **kwargs) -> list[str]:
+        person = context["person"]
+        return [person.email] if person.email else []
+
+
+instructor_declined_from_workshop_receiver = InstructorDeclinedFromWorkshopReceiver()
+instructor_declined_from_workshop_signal.connect(
+    instructor_declined_from_workshop_receiver
+)

--- a/amy/emails/actions/instructor_signs_up_for_workshop.py
+++ b/amy/emails/actions/instructor_signs_up_for_workshop.py
@@ -1,58 +1,46 @@
-from typing import Any
+from datetime import datetime
 
-from django.dispatch import receiver
 from typing_extensions import Unpack
 
-from emails.controller import EmailController, EmailControllerMissingRecipientsException
-from emails.models import EmailTemplate
+from emails.actions.base_action import BaseAction
 from emails.signals import instructor_signs_up_for_workshop_signal
 from emails.types import InstructorSignupContext, InstructorSignupKwargs
-from emails.utils import (
-    immediate_action,
-    messages_action_scheduled,
-    messages_missing_recipients,
-    messages_missing_template,
-    person_from_request,
-)
+from emails.utils import immediate_action
 from recruitment.models import InstructorRecruitmentSignup
 from workshops.models import Event, Person
-from workshops.utils.feature_flags import feature_flag_enabled
 
 
-@receiver(instructor_signs_up_for_workshop_signal)
-@feature_flag_enabled("EMAIL_MODULE")
-def instructor_signs_up_for_workshop_receiver(
-    sender: Any, **kwargs: Unpack[InstructorSignupKwargs]
-) -> None:
-    request = kwargs["request"]
-    person_id = kwargs["person_id"]
-    event_id = kwargs["event_id"]
-    instructor_recruitment_signup_id = kwargs["instructor_recruitment_signup_id"]
-
-    scheduled_at = immediate_action()
-    person = Person.objects.get(pk=person_id)
-    event = Event.objects.get(pk=event_id)
-    instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
-        pk=instructor_recruitment_signup_id
-    )
-    context: InstructorSignupContext = {
-        "person": person,
-        "event": event,
-        "instructor_recruitment_signup": instructor_recruitment_signup,
-    }
+class InstructorSignsUpForWorkshopReceiver(BaseAction):
     signal = instructor_signs_up_for_workshop_signal.signal_name
-    try:
-        scheduled_email = EmailController.schedule_email(
-            signal=signal,
-            context=context,
-            scheduled_at=scheduled_at,
-            to_header=[person.email] if person.email else [],
-            generic_relation_obj=instructor_recruitment_signup,
-            author=person_from_request(request),
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        return immediate_action()
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorSignupKwargs]
+    ) -> InstructorSignupContext:
+        person = Person.objects.get(pk=kwargs["person_id"])
+        event = Event.objects.get(pk=kwargs["event_id"])
+        instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
+            pk=kwargs["instructor_recruitment_signup_id"]
         )
-    except EmailControllerMissingRecipientsException:
-        messages_missing_recipients(request, signal)
-    except EmailTemplate.DoesNotExist:
-        messages_missing_template(request, signal)
-    else:
-        messages_action_scheduled(request, signal, scheduled_email)
+        return {
+            "person": person,
+            "event": event,
+            "instructor_recruitment_signup": instructor_recruitment_signup,
+        }
+
+    def get_generic_relation_object(
+        self, context: InstructorSignupContext, **kwargs
+    ) -> InstructorRecruitmentSignup:
+        return context["instructor_recruitment_signup"]
+
+    def get_recipients(self, context: InstructorSignupContext, **kwargs) -> list[str]:
+        person = context["person"]
+        return [person.email] if person.email else []
+
+
+instructor_signs_up_for_workshop_receiver = InstructorSignsUpForWorkshopReceiver()
+instructor_signs_up_for_workshop_signal.connect(
+    instructor_signs_up_for_workshop_receiver
+)

--- a/amy/emails/actions/instructor_training_approaching.py
+++ b/amy/emails/actions/instructor_training_approaching.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 from typing import Any
 
@@ -7,12 +8,13 @@ from django.http import HttpRequest
 from django.utils import timezone
 from typing_extensions import Unpack
 
+from emails.actions.base_action import BaseAction
 from emails.controller import (
     EmailController,
     EmailControllerMissingRecipientsException,
     EmailControllerMissingTemplateException,
 )
-from emails.models import EmailTemplate, ScheduledEmail
+from emails.models import ScheduledEmail
 from emails.signals import (
     INSTRUCTOR_TRAINING_APPROACHING_SIGNAL_NAME,
     Signal,
@@ -27,10 +29,8 @@ from emails.types import (
 )
 from emails.utils import (
     messages_action_cancelled,
-    messages_action_scheduled,
     messages_action_updated,
     messages_missing_recipients,
-    messages_missing_template,
     messages_missing_template_link,
     one_month_before,
     person_from_request,
@@ -107,43 +107,40 @@ def run_instructor_training_approaching_strategy(
     )
 
 
-@receiver(instructor_training_approaching_signal)
-@feature_flag_enabled("EMAIL_MODULE")
-def instructor_training_approaching_receiver(
-    sender: Any, **kwargs: Unpack[InstructorTrainingApproachingKwargs]
-) -> None:
-    request = kwargs["request"]
-    event = kwargs["event"]
-    event_start_date = kwargs["event_start_date"]
-    instructors = [
-        task.person
-        for task in Task.objects.filter(event=event, role__name="instructor")
-    ]
-    instructor_emails = [
-        instructor.email for instructor in instructors if instructor.email
-    ]
+class InstructorTrainingApproachingReceiver(BaseAction):
+    signal = instructor_training_approaching_signal.signal_name
 
-    scheduled_at = one_month_before(event_start_date)
-    context: InstructorTrainingApproachingContext = {
-        "event": event,
-        "instructors": instructors,
-    }
-    signal_name = INSTRUCTOR_TRAINING_APPROACHING_SIGNAL_NAME
-    try:
-        scheduled_email = EmailController.schedule_email(
-            signal=signal_name,
-            context=context,
-            scheduled_at=scheduled_at,
-            to_header=instructor_emails,
-            generic_relation_obj=event,
-            author=person_from_request(request),
-        )
-    except EmailControllerMissingRecipientsException:
-        messages_missing_recipients(request, signal_name)
-    except EmailTemplate.DoesNotExist:
-        messages_missing_template(request, signal_name)
-    else:
-        messages_action_scheduled(request, signal_name, scheduled_email)
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        event_start_date = kwargs["event_start_date"]
+        return one_month_before(event_start_date)
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorTrainingApproachingKwargs]
+    ) -> InstructorTrainingApproachingContext:
+        event = kwargs["event"]
+        instructors = [
+            task.person
+            for task in Task.objects.filter(event=event, role__name="instructor")
+        ]
+        return {
+            "event": event,
+            "instructors": instructors,
+        }
+
+    def get_generic_relation_object(
+        self, context: InstructorTrainingApproachingContext, **kwargs
+    ) -> Event:
+        return context["event"]
+
+    def get_recipients(
+        self, context: InstructorTrainingApproachingContext, **kwargs
+    ) -> list[str]:
+        instructors = context["instructors"]
+        return [instructor.email for instructor in instructors if instructor.email]
+
+
+instructor_training_approaching_receiver = InstructorTrainingApproachingReceiver()
+instructor_training_approaching_signal.connect(instructor_training_approaching_receiver)
 
 
 @receiver(instructor_training_approaching_update_signal)

--- a/amy/emails/actions/instructor_training_approaching.py
+++ b/amy/emails/actions/instructor_training_approaching.py
@@ -1,19 +1,12 @@
 from datetime import datetime
 import logging
-from typing import Any
 
 from django.contrib.contenttypes.models import ContentType
-from django.dispatch import receiver
 from django.http import HttpRequest
 from django.utils import timezone
 from typing_extensions import Unpack
 
-from emails.actions.base_action import BaseAction
-from emails.controller import (
-    EmailController,
-    EmailControllerMissingRecipientsException,
-    EmailControllerMissingTemplateException,
-)
+from emails.actions.base_action import BaseAction, BaseActionCancel, BaseActionUpdate
 from emails.models import ScheduledEmail
 from emails.signals import (
     INSTRUCTOR_TRAINING_APPROACHING_SIGNAL_NAME,
@@ -27,16 +20,8 @@ from emails.types import (
     InstructorTrainingApproachingKwargs,
     StrategyEnum,
 )
-from emails.utils import (
-    messages_action_cancelled,
-    messages_action_updated,
-    messages_missing_recipients,
-    messages_missing_template_link,
-    one_month_before,
-    person_from_request,
-)
+from emails.utils import one_month_before
 from workshops.models import Event, Task
-from workshops.utils.feature_flags import feature_flag_enabled
 
 logger = logging.getLogger("amy")
 
@@ -139,99 +124,78 @@ class InstructorTrainingApproachingReceiver(BaseAction):
         return [instructor.email for instructor in instructors if instructor.email]
 
 
+class InstructorTrainingApproachingUpdateReceiver(BaseActionUpdate):
+    signal = instructor_training_approaching_update_signal.signal_name
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        event_start_date = kwargs["event_start_date"]
+        return one_month_before(event_start_date)
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorTrainingApproachingKwargs]
+    ) -> InstructorTrainingApproachingContext:
+        event = kwargs["event"]
+        instructors = [
+            task.person
+            for task in Task.objects.filter(event=event, role__name="instructor")
+        ]
+        return {
+            "event": event,
+            "instructors": instructors,
+        }
+
+    def get_generic_relation_object(
+        self, context: InstructorTrainingApproachingContext, **kwargs
+    ) -> Event:
+        return context["event"]
+
+    def get_recipients(
+        self, context: InstructorTrainingApproachingContext, **kwargs
+    ) -> list[str]:
+        instructors = context["instructors"]
+        return [instructor.email for instructor in instructors if instructor.email]
+
+
+class InstructorTrainingApproachingCancelReceiver(BaseActionCancel):
+    signal = instructor_training_approaching_remove_signal.signal_name
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorTrainingApproachingKwargs]
+    ) -> InstructorTrainingApproachingContext:
+        event = kwargs["event"]
+        instructors = [
+            task.person
+            for task in Task.objects.filter(event=event, role__name="instructor")
+        ]
+        return {
+            "event": event,
+            "instructors": instructors,
+        }
+
+    def get_generic_relation_object(
+        self, context: InstructorTrainingApproachingContext, **kwargs
+    ) -> Event:
+        return context["event"]
+
+
+# -----------------------------------------------------------------------------
+# Receivers
+
 instructor_training_approaching_receiver = InstructorTrainingApproachingReceiver()
 instructor_training_approaching_signal.connect(instructor_training_approaching_receiver)
 
 
-@receiver(instructor_training_approaching_update_signal)
-@feature_flag_enabled("EMAIL_MODULE")
-def instructor_training_approaching_update_receiver(
-    sender: Any, **kwargs: Unpack[InstructorTrainingApproachingKwargs]
-) -> None:
-    request = kwargs["request"]
-    event = kwargs["event"]
-    event_start_date = kwargs["event_start_date"]
-    instructors = [
-        task.person
-        for task in Task.objects.filter(event=event, role__name="instructor")
-    ]
-    instructor_emails = [
-        instructor.email for instructor in instructors if instructor.email
-    ]
-
-    scheduled_at = one_month_before(event_start_date)
-    context: InstructorTrainingApproachingContext = {
-        "event": event,
-        "instructors": instructors,
-    }
-    signal_name = INSTRUCTOR_TRAINING_APPROACHING_SIGNAL_NAME
-
-    ct = ContentType.objects.get_for_model(event)  # type: ignore
-    try:
-        scheduled_email = (
-            ScheduledEmail.objects.select_for_update()
-            .select_related("template")
-            .get(
-                generic_relation_content_type=ct,
-                generic_relation_pk=event.pk,
-                template__signal=signal_name,
-                state="scheduled",
-            )
-        )
-
-    except ScheduledEmail.DoesNotExist:
-        logger.warning(
-            f"Scheduled email for signal {signal_name} and event {event} "
-            "does not exist."
-        )
-        return
-
-    except ScheduledEmail.MultipleObjectsReturned:
-        logger.warning(
-            f"Too many scheduled emails for signal {signal_name} and event {event}."
-            " Can't update them."
-        )
-        return
-
-    try:
-        scheduled_email = EmailController.update_scheduled_email(
-            scheduled_email=scheduled_email,
-            context=context,
-            scheduled_at=scheduled_at,
-            to_header=instructor_emails,
-            generic_relation_obj=event,
-            author=person_from_request(request),
-        )
-    except EmailControllerMissingRecipientsException:
-        messages_missing_recipients(request, signal_name)
-    except EmailControllerMissingTemplateException:
-        # Note: this is not realistically possible because the scheduled email
-        # is looked up using a specific template signal.
-        messages_missing_template_link(request, scheduled_email)
-    else:
-        messages_action_updated(request, signal_name, scheduled_email)
+instructor_training_approaching_update_receiver = (
+    InstructorTrainingApproachingUpdateReceiver()
+)
+instructor_training_approaching_update_signal.connect(
+    instructor_training_approaching_update_receiver
+)
 
 
-@receiver(instructor_training_approaching_remove_signal)
-@feature_flag_enabled("EMAIL_MODULE")
-def instructor_training_approaching_remove_receiver(
-    sender: Any, **kwargs: Unpack[InstructorTrainingApproachingKwargs]
-) -> None:
-    request = kwargs["request"]
-    event = kwargs["event"]
-    signal_name = INSTRUCTOR_TRAINING_APPROACHING_SIGNAL_NAME
-
-    ct = ContentType.objects.get_for_model(event)  # type: ignore
-    scheduled_emails = ScheduledEmail.objects.filter(
-        generic_relation_content_type=ct,
-        generic_relation_pk=event.pk,
-        template__signal=signal_name,
-        state="scheduled",
-    ).select_for_update()
-
-    for scheduled_email in scheduled_emails:
-        scheduled_email = EmailController.cancel_email(
-            scheduled_email=scheduled_email,
-            author=person_from_request(request),
-        )
-        messages_action_cancelled(request, signal_name, scheduled_email)
+instructor_training_approaching_remove_receiver = (
+    InstructorTrainingApproachingCancelReceiver()
+)
+instructor_training_approaching_remove_signal.connect(
+    instructor_training_approaching_remove_receiver
+)

--- a/amy/emails/actions/persons_merged.py
+++ b/amy/emails/actions/persons_merged.py
@@ -1,47 +1,37 @@
-from typing import Any
+from datetime import datetime
 
-from django.dispatch import receiver
 from typing_extensions import Unpack
 
-from emails.controller import EmailController, EmailControllerMissingRecipientsException
-from emails.models import EmailTemplate
+from emails.actions.base_action import BaseAction
 from emails.signals import persons_merged_signal
 from emails.types import PersonsMergedContext, PersonsMergedKwargs
-from emails.utils import (
-    immediate_action,
-    messages_action_scheduled,
-    messages_missing_recipients,
-    messages_missing_template,
-    person_from_request,
-)
+from emails.utils import immediate_action
 from workshops.models import Person
-from workshops.utils.feature_flags import feature_flag_enabled
 
 
-@receiver(persons_merged_signal)
-@feature_flag_enabled("EMAIL_MODULE")
-def persons_merged_receiver(sender: Any, **kwargs: Unpack[PersonsMergedKwargs]) -> None:
-    request = kwargs["request"]
-    selected_person_id = kwargs["selected_person_id"]
-
-    scheduled_at = immediate_action()
-    person = Person.objects.get(pk=selected_person_id)
-    context: PersonsMergedContext = {
-        "person": person,
-    }
+class PersonsMergedReceiver(BaseAction):
     signal = persons_merged_signal.signal_name
-    try:
-        scheduled_email = EmailController.schedule_email(
-            signal=signal,
-            context=context,
-            scheduled_at=scheduled_at,
-            to_header=[person.email] if person.email else [],
-            generic_relation_obj=person,
-            author=person_from_request(request),
-        )
-    except EmailControllerMissingRecipientsException:
-        messages_missing_recipients(request, signal)
-    except EmailTemplate.DoesNotExist:
-        messages_missing_template(request, signal)
-    else:
-        messages_action_scheduled(request, signal, scheduled_email)
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        return immediate_action()
+
+    def get_context(
+        self, **kwargs: Unpack[PersonsMergedKwargs]
+    ) -> PersonsMergedContext:
+        person = Person.objects.get(pk=kwargs["selected_person_id"])
+        return {
+            "person": person,
+        }
+
+    def get_generic_relation_object(
+        self, context: PersonsMergedContext, **kwargs
+    ) -> Person:
+        return context["person"]
+
+    def get_recipients(self, context: PersonsMergedContext, **kwargs) -> list[str]:
+        person = context["person"]
+        return [person.email] if person.email else []
+
+
+persons_merged_receiver = PersonsMergedReceiver()
+persons_merged_signal.connect(persons_merged_receiver)

--- a/amy/emails/tests/actions/test_admin_signs_instructor_up_for_workshop.py
+++ b/amy/emails/tests/actions/test_admin_signs_instructor_up_for_workshop.py
@@ -1,5 +1,5 @@
 from datetime import UTC, date, datetime, timedelta
-from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
@@ -14,8 +14,8 @@ from workshops.tests.base import TestBase
 
 
 class TestAdminSignsInstructorUpForWorkshopReceiver(TestCase):
-    @mock.patch("workshops.utils.feature_flags.logger")
-    def test_disabled_when_no_feature_flag(self, mock_logger) -> None:
+    @patch("emails.actions.base_action.logger")
+    def test_disabled_when_no_feature_flag(self, mock_logger: MagicMock) -> None:
         # Arrange
         request = RequestFactory().get("/")
         with self.settings(FLAGS={"EMAIL_MODULE": [("boolean", False)]}):
@@ -24,7 +24,7 @@ class TestAdminSignsInstructorUpForWorkshopReceiver(TestCase):
             # Assert
             mock_logger.debug.assert_called_once_with(
                 "EMAIL_MODULE feature flag not set, skipping "
-                "admin_signs_instructor_up_for_workshop_receiver"
+                "admin_signs_instructor_up_for_workshop"
             )
 
     def test_receiver_connected_to_signal(self) -> None:
@@ -68,9 +68,8 @@ class TestAdminSignsInstructorUpForWorkshopReceiver(TestCase):
         request = RequestFactory().get("/")
 
         # Act
-        with mock.patch(
-            "emails.actions.admin_signs_instructor_up_for_workshop"
-            ".messages_action_scheduled"
+        with patch(
+            "emails.actions.base_action.messages_action_scheduled"
         ) as mock_messages_action_scheduled:
             admin_signs_instructor_up_for_workshop_signal.send(
                 sender=signup,
@@ -90,17 +89,12 @@ class TestAdminSignsInstructorUpForWorkshopReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch(
-        "emails.actions.admin_signs_instructor_up_for_workshop"
-        ".messages_action_scheduled"
-    )
-    @mock.patch(
-        "emails.actions.admin_signs_instructor_up_for_workshop.immediate_action"
-    )
+    @patch("emails.actions.base_action.messages_action_scheduled")
+    @patch("emails.actions.admin_signs_instructor_up_for_workshop.immediate_action")
     def test_email_scheduled(
         self,
-        mock_immediate_action: mock.MagicMock,
-        mock_messages_action_scheduled: mock.MagicMock,
+        mock_immediate_action: MagicMock,
+        mock_messages_action_scheduled: MagicMock,
     ) -> None:
         # Arrange
         organization = Organization.objects.first()
@@ -127,9 +121,8 @@ class TestAdminSignsInstructorUpForWorkshopReceiver(TestCase):
         scheduled_at = NOW + timedelta(hours=1)
 
         # Act
-        with mock.patch(
-            "emails.actions.admin_signs_instructor_up_for_workshop"
-            ".EmailController.schedule_email"
+        with patch(
+            "emails.actions.base_action.EmailController.schedule_email"
         ) as mock_schedule_email:
             admin_signs_instructor_up_for_workshop_signal.send(
                 sender=signup,
@@ -151,12 +144,9 @@ class TestAdminSignsInstructorUpForWorkshopReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch(
-        "emails.actions.admin_signs_instructor_up_for_workshop"
-        ".messages_missing_recipients"
-    )
+    @patch("emails.actions.base_action.messages_missing_recipients")
     def test_missing_recipients(
-        self, mock_messages_missing_recipients: mock.MagicMock
+        self, mock_messages_missing_recipients: MagicMock
     ) -> None:
         # Arrange
         organization = Organization.objects.first()
@@ -187,13 +177,8 @@ class TestAdminSignsInstructorUpForWorkshopReceiver(TestCase):
         mock_messages_missing_recipients.assert_called_once_with(request, signal)
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch(
-        "emails.actions.admin_signs_instructor_up_for_workshop"
-        ".messages_missing_template"
-    )
-    def test_missing_template(
-        self, mock_messages_missing_template: mock.MagicMock
-    ) -> None:
+    @patch("emails.actions.base_action.messages_missing_template")
+    def test_missing_template(self, mock_messages_missing_template: MagicMock) -> None:
         # Arrange
         organization = Organization.objects.first()
         event = Event.objects.create(
@@ -226,15 +211,12 @@ class TestAdminSignsInstructorUpForWorkshopReceiver(TestCase):
 class TestAdminSignsInstructorUpForWorkshopReceiverIntegration(TestBase):
     @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch("django.contrib.messages.views.messages")
-    @mock.patch(
-        "emails.actions.admin_signs_instructor_up_for_workshop"
-        ".messages_action_scheduled"
-    )
+    @patch("django.contrib.messages.views.messages")
+    @patch("emails.actions.base_action.messages_action_scheduled")
     def test_integration(
         self,
-        mock_messages_action_scheduled: mock.MagicMock,
-        mock_contrib_messages_views: mock.MagicMock,
+        mock_messages_action_scheduled: MagicMock,
+        mock_contrib_messages_views: MagicMock,
     ) -> None:
         # Arrange
         host = Organization.objects.create(domain="test.com", fullname="Test")

--- a/amy/emails/tests/actions/test_base_action.py
+++ b/amy/emails/tests/actions/test_base_action.py
@@ -1,0 +1,581 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, TestCase, override_settings
+from django.utils import timezone as django_timezone
+
+from emails.actions.base_action import (
+    BaseAction,
+    BaseActionCancel,
+    BaseActionUpdate,
+    feature_flag_enabled,
+)
+from emails.controller import (
+    EmailControllerMissingRecipientsException,
+    EmailControllerMissingTemplateException,
+)
+from emails.models import EmailTemplate, ScheduledEmail
+from emails.signals import SignalNameEnum
+from workshops.models import Event, Organization
+
+
+class TestFeatureFlagEnabled(TestCase):
+    feature_flag = "TEST_FEATURE_FLAG"
+    signal_name = "test_signal_name"
+
+    @patch("emails.actions.base_action.logger")
+    def test_feature_flag_enabled__missing_request(self, mock_logger: MagicMock):
+        # Arrange
+        kwargs = {}
+
+        # Act
+        result = feature_flag_enabled(self.feature_flag, self.signal_name, **kwargs)
+
+        # Assert
+        self.assertEqual(result, False)
+        mock_logger.debug.assert_called_once_with(
+            f"Cannot check {self.feature_flag} feature flag, `request` parameter "
+            f"to {self.signal_name} is missing"
+        )
+
+    @override_settings(FLAGS={feature_flag: [("boolean", False)]})
+    @patch("emails.actions.base_action.logger")
+    def test_feature_flag_enabled__feature_flag_disabled(self, mock_logger: MagicMock):
+        # Arrange
+        request = RequestFactory().get("/")
+
+        # Act
+        result = feature_flag_enabled(
+            self.feature_flag, self.signal_name, request=request
+        )
+
+        # Assert
+        self.assertEqual(result, False)
+        mock_logger.debug.assert_called_once_with(
+            f"{self.feature_flag} feature flag not set, skipping {self.signal_name}"
+        )
+
+    @override_settings(FLAGS={feature_flag: [("boolean", True)]})
+    @patch("emails.actions.base_action.logger")
+    def test_feature_flag_enabled(self, mock_logger: MagicMock):
+        # Arrange
+        request = RequestFactory().get("/")
+
+        # Act
+        result = feature_flag_enabled(
+            self.feature_flag, self.signal_name, request=request
+        )
+
+        # Assert
+        self.assertEqual(result, True)
+
+
+class BaseActionForTesting(BaseAction):
+    signal = SignalNameEnum.persons_merged
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        return datetime(2023, 10, 18, 23, 00, tzinfo=timezone.utc)
+
+    def get_context(self, **kwargs) -> dict[str, Any]:
+        return {}
+
+    def get_generic_relation_object(self, context: dict[str, Any], **kwargs) -> Any:
+        return 0
+
+    def get_recipients(self, context: dict[str, Any], **kwargs) -> list[str]:
+        return []
+
+
+class BaseActionUpdateForTesting(BaseActionUpdate):
+    signal = SignalNameEnum.persons_merged
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        return datetime(2023, 10, 18, 23, 00, tzinfo=timezone.utc)
+
+    def get_context(self, **kwargs) -> dict[str, Any]:
+        return {}
+
+    def get_generic_relation_object(self, context: dict[str, Any], **kwargs) -> Any:
+        return Event.objects.get_or_create(
+            defaults=dict(
+                host=Organization.objects.first(),
+                administrator=Organization.objects.first(),
+            ),
+            slug="test-event",
+        )[0]
+
+    def get_recipients(self, context: dict[str, Any], **kwargs) -> list[str]:
+        return []
+
+
+class BaseActionCancelForTesting(BaseActionCancel):
+    signal = SignalNameEnum.persons_merged
+
+    def get_scheduled_at(self, **kwargs) -> datetime:
+        return datetime(2023, 10, 18, 23, 00, tzinfo=timezone.utc)
+
+    def get_context(self, **kwargs) -> dict[str, Any]:
+        return {}
+
+    def get_generic_relation_object(self, context: dict[str, Any], **kwargs) -> Any:
+        return Event.objects.get_or_create(
+            defaults=dict(
+                host=Organization.objects.first(),
+                administrator=Organization.objects.first(),
+            ),
+            slug="test-event",
+        )[0]
+
+    def get_recipients(self, context: dict[str, Any], **kwargs) -> list[str]:
+        return []
+
+
+class TestBaseAction(TestCase):
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.person_from_request")
+    @patch("emails.actions.base_action.EmailController.schedule_email")
+    @patch("emails.actions.base_action.messages_action_scheduled")
+    def test_call(
+        self,
+        mock_action_scheduled: MagicMock,
+        mock_schedule_email: MagicMock,
+        mock_person_from_request: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionForTesting()
+
+        scheduled_email = MagicMock()
+        mock_schedule_email.return_value = scheduled_email
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        instance(sender, **kwargs)
+        context = instance.get_context()
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", instance.signal, **kwargs
+        )
+        mock_person_from_request.assert_called_once_with(request)
+        mock_schedule_email.assert_called_once_with(
+            signal=instance.signal,
+            context=context,
+            scheduled_at=instance.get_scheduled_at(),
+            to_header=instance.get_recipients(context),
+            generic_relation_obj=instance.get_generic_relation_object(context),
+            author=mock_person_from_request.return_value,
+        )
+        mock_action_scheduled.assert_called_once_with(
+            request, instance.signal, scheduled_email
+        )
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=False)
+    @patch("emails.actions.base_action.EmailController.schedule_email")
+    def test_call__feature_flag_not_enabled(
+        self,
+        mock_schedule_email: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionForTesting()
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        result = instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", instance.signal, **kwargs
+        )
+        mock_schedule_email.assert_not_called()
+        self.assertIsNone(result)
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.EmailController.schedule_email")
+    @patch("emails.actions.base_action.messages_missing_recipients")
+    def test_call__missing_recipients(
+        self,
+        mock_messages_missing_recipients: MagicMock,
+        mock_schedule_email: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionForTesting()
+        mock_schedule_email.side_effect = EmailControllerMissingRecipientsException()
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", instance.signal, **kwargs
+        )
+        mock_messages_missing_recipients.assert_called_once_with(
+            request, instance.signal
+        )
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.EmailController.schedule_email")
+    @patch("emails.actions.base_action.messages_missing_template")
+    def test_call__missing_template(
+        self,
+        mock_messages_missing_template: MagicMock,
+        mock_schedule_email: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionForTesting()
+        mock_schedule_email.side_effect = EmailTemplate.DoesNotExist()
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", instance.signal, **kwargs
+        )
+        mock_messages_missing_template.assert_called_once_with(request, instance.signal)
+
+
+class TestBaseActionUpdate(TestCase):
+    def setUpEmailTemplate(self, signal: SignalNameEnum) -> EmailTemplate:
+        return EmailTemplate.objects.create(
+            name="Test Email Template1",
+            signal=signal,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ name }}",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+
+    def setUpScheduledEmail(
+        self, template: EmailTemplate, generic_object: Any
+    ) -> ScheduledEmail:
+        return ScheduledEmail.objects.create(
+            scheduled_at=django_timezone.now() + timedelta(hours=1),
+            to_header=["peter@spiderman.net", "harry@potter.co.uk"],
+            from_header="",
+            reply_to_header="",
+            cc_header=[],
+            bcc_header=[],
+            subject="Test subject",
+            body="Test content",
+            template=template,
+            generic_relation=generic_object,
+        )
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.person_from_request")
+    @patch("emails.actions.base_action.EmailController.update_scheduled_email")
+    @patch("emails.actions.base_action.messages_action_updated")
+    def test_call(
+        self,
+        mock_action_updated: MagicMock,
+        mock_update_scheduled_email: MagicMock,
+        mock_person_from_request: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionUpdateForTesting()
+        event = instance.get_generic_relation_object({})
+
+        template = self.setUpEmailTemplate(instance.signal)
+        scheduled_email = self.setUpScheduledEmail(template, event)
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        instance(sender, **kwargs)
+        context = instance.get_context()
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", f"{instance.signal}_update", **kwargs
+        )
+        mock_person_from_request.assert_called_once_with(request)
+        mock_update_scheduled_email.assert_called_once_with(
+            scheduled_email=scheduled_email,
+            context=context,
+            scheduled_at=instance.get_scheduled_at(),
+            to_header=instance.get_recipients(context),
+            generic_relation_obj=instance.get_generic_relation_object(context),
+            author=mock_person_from_request.return_value,
+        )
+        mock_action_updated.assert_called_once_with(
+            request, instance.signal, mock_update_scheduled_email.return_value
+        )
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=False)
+    @patch("emails.actions.base_action.EmailController.update_scheduled_email")
+    def test_call__feature_flag_not_enabled(
+        self,
+        mock_update_scheduled_email: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionUpdateForTesting()
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        result = instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", f"{instance.signal}_update", **kwargs
+        )
+        mock_update_scheduled_email.assert_not_called()
+        self.assertIsNone(result)
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.logger")
+    def test_call__no_scheduled_email(
+        self,
+        mock_logger: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionUpdateForTesting()
+        event = instance.get_generic_relation_object({})
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        result = instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", f"{instance.signal}_update", **kwargs
+        )
+        self.assertIsNone(result)
+        mock_logger.warning.assert_called_once_with(
+            f"Scheduled email for signal {instance.signal} and "
+            f"generic_relation_obj={event!r} does not exist."
+        )
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.logger")
+    def test_call__multiple_scheduled_emails(
+        self,
+        mock_logger: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionUpdateForTesting()
+        event = instance.get_generic_relation_object({})
+
+        template = self.setUpEmailTemplate(instance.signal)
+        self.setUpScheduledEmail(template, event)
+        self.setUpScheduledEmail(template, event)
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        result = instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", f"{instance.signal}_update", **kwargs
+        )
+        self.assertIsNone(result)
+        mock_logger.warning.assert_called_once_with(
+            f"Too many scheduled emails for signal {instance.signal} and "
+            f"generic_relation_obj={event!r}. Can't update them."
+        )
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.EmailController.update_scheduled_email")
+    @patch("emails.actions.base_action.messages_missing_recipients")
+    def test_call__missing_recipients(
+        self,
+        mock_messages_missing_recipients: MagicMock,
+        mock_update_scheduled_email: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionUpdateForTesting()
+        event = instance.get_generic_relation_object({})
+        mock_update_scheduled_email.side_effect = (
+            EmailControllerMissingRecipientsException()
+        )
+
+        template = self.setUpEmailTemplate(instance.signal)
+        self.setUpScheduledEmail(template, event)
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", f"{instance.signal}_update", **kwargs
+        )
+        mock_messages_missing_recipients.assert_called_once_with(
+            request, instance.signal
+        )
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.EmailController.update_scheduled_email")
+    @patch("emails.actions.base_action.messages_missing_template_link")
+    def test_call__missing_template_link(
+        self,
+        mock_messages_missing_template_link: MagicMock,
+        mock_update_scheduled_email: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionUpdateForTesting()
+        event = instance.get_generic_relation_object({})
+        mock_update_scheduled_email.side_effect = (
+            EmailControllerMissingTemplateException()
+        )
+
+        template = self.setUpEmailTemplate(instance.signal)
+        scheduled_email = self.setUpScheduledEmail(template, event)
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", f"{instance.signal}_update", **kwargs
+        )
+        mock_messages_missing_template_link.assert_called_once_with(
+            request, scheduled_email
+        )
+
+
+class TestBaseActionCancel(TestCase):
+    def setUpEmailTemplate(self, signal: SignalNameEnum) -> EmailTemplate:
+        return EmailTemplate.objects.create(
+            name="Test Email Template1",
+            signal=signal,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ name }}",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+
+    def setUpScheduledEmail(
+        self, template: EmailTemplate, generic_object: Any
+    ) -> ScheduledEmail:
+        return ScheduledEmail.objects.create(
+            scheduled_at=django_timezone.now() + timedelta(hours=1),
+            to_header=["peter@spiderman.net", "harry@potter.co.uk"],
+            from_header="",
+            reply_to_header="",
+            cc_header=[],
+            bcc_header=[],
+            subject="Test subject",
+            body="Test content",
+            template=template,
+            generic_relation=generic_object,
+        )
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.person_from_request")
+    @patch("emails.actions.base_action.EmailController.cancel_email")
+    @patch("emails.actions.base_action.messages_action_cancelled")
+    def test_call(
+        self,
+        mock_action_cancelled: MagicMock,
+        mock_cancel_email: MagicMock,
+        mock_person_from_request: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionCancelForTesting()
+        event = instance.get_generic_relation_object({})
+
+        template = self.setUpEmailTemplate(instance.signal)
+        scheduled_email = self.setUpScheduledEmail(template, event)
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", f"{instance.signal}_remove", **kwargs
+        )
+        mock_person_from_request.assert_called_once_with(request)
+        mock_cancel_email.assert_called_once_with(
+            scheduled_email=scheduled_email,
+            author=mock_person_from_request.return_value,
+        )
+        mock_action_cancelled.assert_called_once_with(
+            request, instance.signal, mock_cancel_email.return_value
+        )
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=False)
+    @patch("emails.actions.base_action.EmailController.cancel_email")
+    def test_call__feature_flag_not_enabled(
+        self,
+        mock_cancel_email: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionCancelForTesting()
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        result = instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", f"{instance.signal}_remove", **kwargs
+        )
+        mock_cancel_email.assert_not_called()
+        self.assertIsNone(result)
+
+    @patch("emails.actions.base_action.feature_flag_enabled", return_value=True)
+    @patch("emails.actions.base_action.EmailController.cancel_email")
+    @patch("emails.actions.base_action.messages_action_cancelled")
+    def test_call__no_scheduled_emails(
+        self,
+        mock_action_cancelled: MagicMock,
+        mock_cancel_email: MagicMock,
+        mock_feature_flag_enabled: MagicMock,
+    ) -> None:
+        # Arrange
+        instance = BaseActionCancelForTesting()
+
+        # Act
+        sender = MagicMock()
+        request = RequestFactory().get("/")
+        kwargs = {"request": request}
+        instance(sender, **kwargs)
+
+        # Assert
+        mock_feature_flag_enabled.assert_called_once_with(
+            "EMAIL_MODULE", f"{instance.signal}_remove", **kwargs
+        )
+        mock_cancel_email.assert_not_called()
+        mock_action_cancelled.assert_not_called()

--- a/amy/emails/tests/actions/test_instructor_declined_from_workshop.py
+++ b/amy/emails/tests/actions/test_instructor_declined_from_workshop.py
@@ -1,5 +1,5 @@
 from datetime import UTC, date, datetime, timedelta
-from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
@@ -14,8 +14,8 @@ from workshops.tests.base import TestBase
 
 
 class TestInstructorDeclinedFromWorkshopReceiver(TestCase):
-    @mock.patch("workshops.utils.feature_flags.logger")
-    def test_disabled_when_no_feature_flag(self, mock_logger) -> None:
+    @patch("emails.actions.base_action.logger")
+    def test_disabled_when_no_feature_flag(self, mock_logger: MagicMock) -> None:
         # Arrange
         request = RequestFactory().get("/")
         with self.settings(FLAGS={"EMAIL_MODULE": [("boolean", False)]}):
@@ -24,7 +24,7 @@ class TestInstructorDeclinedFromWorkshopReceiver(TestCase):
             # Assert
             mock_logger.debug.assert_called_once_with(
                 "EMAIL_MODULE feature flag not set, skipping "
-                "instructor_declined_from_workshop_receiver"
+                "instructor_declined_from_workshop"
             )
 
     def test_receiver_connected_to_signal(self) -> None:
@@ -68,8 +68,8 @@ class TestInstructorDeclinedFromWorkshopReceiver(TestCase):
         request = RequestFactory().get("/")
 
         # Act
-        with mock.patch(
-            "emails.actions.instructor_declined_from_workshop.messages_action_scheduled"
+        with patch(
+            "emails.actions.base_action.messages_action_scheduled"
         ) as mock_messages_action_scheduled:
             instructor_declined_from_workshop_signal.send(
                 sender=signup,
@@ -89,14 +89,12 @@ class TestInstructorDeclinedFromWorkshopReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch(
-        "emails.actions.instructor_declined_from_workshop.messages_action_scheduled"
-    )
-    @mock.patch("emails.actions.instructor_declined_from_workshop.immediate_action")
+    @patch("emails.actions.base_action.messages_action_scheduled")
+    @patch("emails.actions.instructor_declined_from_workshop.immediate_action")
     def test_email_scheduled(
         self,
-        mock_immediate_action: mock.MagicMock,
-        mock_messages_action_scheduled: mock.MagicMock,
+        mock_immediate_action: MagicMock,
+        mock_messages_action_scheduled: MagicMock,
     ) -> None:
         # Arrange
         organization = Organization.objects.first()
@@ -123,9 +121,8 @@ class TestInstructorDeclinedFromWorkshopReceiver(TestCase):
         scheduled_at = NOW + timedelta(hours=1)
 
         # Act
-        with mock.patch(
-            "emails.actions.instructor_declined_from_workshop"
-            ".EmailController.schedule_email"
+        with patch(
+            "emails.actions.base_action.EmailController.schedule_email"
         ) as mock_schedule_email:
             instructor_declined_from_workshop_signal.send(
                 sender=signup,
@@ -147,11 +144,9 @@ class TestInstructorDeclinedFromWorkshopReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch(
-        "emails.actions.instructor_declined_from_workshop.messages_missing_recipients"
-    )
+    @patch("emails.actions.base_action.messages_missing_recipients")
     def test_missing_recipients(
-        self, mock_messages_missing_recipients: mock.MagicMock
+        self, mock_messages_missing_recipients: MagicMock
     ) -> None:
         # Arrange
         organization = Organization.objects.first()
@@ -182,12 +177,8 @@ class TestInstructorDeclinedFromWorkshopReceiver(TestCase):
         mock_messages_missing_recipients.assert_called_once_with(request, signal)
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch(
-        "emails.actions.instructor_declined_from_workshop.messages_missing_template"
-    )
-    def test_missing_template(
-        self, mock_messages_missing_template: mock.MagicMock
-    ) -> None:
+    @patch("emails.actions.base_action.messages_missing_template")
+    def test_missing_template(self, mock_messages_missing_template: MagicMock) -> None:
         # Arrange
         organization = Organization.objects.first()
         event = Event.objects.create(
@@ -220,14 +211,12 @@ class TestInstructorDeclinedFromWorkshopReceiver(TestCase):
 class TestInstructorDeclinedFromWorkshopReceiverIntegration(TestBase):
     @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch("django.contrib.messages.views.messages")
-    @mock.patch(
-        "emails.actions.instructor_declined_from_workshop.messages_action_scheduled"
-    )
+    @patch("django.contrib.messages.views.messages")
+    @patch("emails.actions.base_action.messages_action_scheduled")
     def test_integration(
         self,
-        mock_messages_action_scheduled: mock.MagicMock,
-        mock_contrib_messages_views: mock.MagicMock,
+        mock_messages_action_scheduled: MagicMock,
+        mock_contrib_messages_views: MagicMock,
     ) -> None:
         # Arrange
         self._setUpRoles()

--- a/amy/emails/tests/actions/test_instructor_signs_up_for_workshop.py
+++ b/amy/emails/tests/actions/test_instructor_signs_up_for_workshop.py
@@ -1,5 +1,5 @@
 from datetime import UTC, date, datetime, timedelta
-from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
@@ -14,8 +14,8 @@ from workshops.tests.base import TestBase, consent_to_all_required_consents
 
 
 class TestInstructorSignsUpForWorkshopReceiver(TestCase):
-    @mock.patch("workshops.utils.feature_flags.logger")
-    def test_disabled_when_no_feature_flag(self, mock_logger) -> None:
+    @patch("emails.actions.base_action.logger")
+    def test_disabled_when_no_feature_flag(self, mock_logger: MagicMock) -> None:
         # Arrange
         request = RequestFactory().get("/")
         with self.settings(FLAGS={"EMAIL_MODULE": [("boolean", False)]}):
@@ -24,7 +24,7 @@ class TestInstructorSignsUpForWorkshopReceiver(TestCase):
             # Assert
             mock_logger.debug.assert_called_once_with(
                 "EMAIL_MODULE feature flag not set, skipping "
-                "instructor_signs_up_for_workshop_receiver"
+                "instructor_signs_up_for_workshop"
             )
 
     def test_receiver_connected_to_signal(self) -> None:
@@ -68,8 +68,8 @@ class TestInstructorSignsUpForWorkshopReceiver(TestCase):
         request = RequestFactory().get("/")
 
         # Act
-        with mock.patch(
-            "emails.actions.instructor_signs_up_for_workshop.messages_action_scheduled"
+        with patch(
+            "emails.actions.base_action.messages_action_scheduled"
         ) as mock_messages_action_scheduled:
             instructor_signs_up_for_workshop_signal.send(
                 sender=signup,
@@ -89,14 +89,12 @@ class TestInstructorSignsUpForWorkshopReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch(
-        "emails.actions.instructor_signs_up_for_workshop.messages_action_scheduled"
-    )
-    @mock.patch("emails.actions.instructor_signs_up_for_workshop.immediate_action")
+    @patch("emails.actions.base_action.messages_action_scheduled")
+    @patch("emails.actions.instructor_signs_up_for_workshop.immediate_action")
     def test_email_scheduled(
         self,
-        mock_immediate_action: mock.MagicMock,
-        mock_messages_action_scheduled: mock.MagicMock,
+        mock_immediate_action: MagicMock,
+        mock_messages_action_scheduled: MagicMock,
     ) -> None:
         # Arrange
         organization = Organization.objects.first()
@@ -123,9 +121,8 @@ class TestInstructorSignsUpForWorkshopReceiver(TestCase):
         scheduled_at = NOW + timedelta(hours=1)
 
         # Act
-        with mock.patch(
-            "emails.actions.instructor_signs_up_for_workshop"
-            ".EmailController.schedule_email"
+        with patch(
+            "emails.actions.base_action.EmailController.schedule_email"
         ) as mock_schedule_email:
             instructor_signs_up_for_workshop_signal.send(
                 sender=signup,
@@ -147,11 +144,9 @@ class TestInstructorSignsUpForWorkshopReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch(
-        "emails.actions.instructor_signs_up_for_workshop.messages_missing_recipients"
-    )
+    @patch("emails.actions.base_action.messages_missing_recipients")
     def test_missing_recipients(
-        self, mock_messages_missing_recipients: mock.MagicMock
+        self, mock_messages_missing_recipients: MagicMock
     ) -> None:
         # Arrange
         organization = Organization.objects.first()
@@ -182,12 +177,8 @@ class TestInstructorSignsUpForWorkshopReceiver(TestCase):
         mock_messages_missing_recipients.assert_called_once_with(request, signal)
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch(
-        "emails.actions.instructor_signs_up_for_workshop.messages_missing_template"
-    )
-    def test_missing_template(
-        self, mock_messages_missing_template: mock.MagicMock
-    ) -> None:
+    @patch("emails.actions.base_action.messages_missing_template")
+    def test_missing_template(self, mock_messages_missing_template: MagicMock) -> None:
         # Arrange
         organization = Organization.objects.first()
         event = Event.objects.create(
@@ -220,14 +211,12 @@ class TestInstructorSignsUpForWorkshopReceiver(TestCase):
 class TestInstructorSignsUpForWorkshopReceiverIntegration(TestBase):
     @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch("django.contrib.messages.views.messages")
-    @mock.patch(
-        "emails.actions.instructor_signs_up_for_workshop.messages_action_scheduled"
-    )
+    @patch("django.contrib.messages.views.messages")
+    @patch("emails.actions.base_action.messages_action_scheduled")
     def test_integration(
         self,
-        mock_messages_action_scheduled: mock.MagicMock,
-        mock_contrib_messages_views: mock.MagicMock,
+        mock_messages_action_scheduled: MagicMock,
+        mock_contrib_messages_views: MagicMock,
     ) -> None:
         # Arrange
         host = Organization.objects.create(domain="test.com", fullname="Test")

--- a/amy/emails/tests/actions/test_instructor_training_approaching_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_receiver.py
@@ -122,7 +122,8 @@ class TestInstructorTrainingApproachingReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.persons_merged.EmailController.schedule_email"
+            "emails.actions.instructor_training_approaching"
+            ".EmailController.schedule_email"
         ) as mock_schedule_email:
             instructor_training_approaching_signal.send(
                 sender=self.event,

--- a/amy/emails/tests/actions/test_instructor_training_approaching_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_receiver.py
@@ -50,7 +50,7 @@ class TestInstructorTrainingApproachingReceiver(TestCase):
             event=self.event, person=self.instructor2, role=instructor_role
         )
 
-    @patch("workshops.utils.feature_flags.logger")
+    @patch("emails.actions.base_action.logger")
     def test_disabled_when_no_feature_flag(self, mock_logger) -> None:
         # Arrange
         request = RequestFactory().get("/")
@@ -60,7 +60,7 @@ class TestInstructorTrainingApproachingReceiver(TestCase):
             # Assert
             mock_logger.debug.assert_called_once_with(
                 "EMAIL_MODULE feature flag not set, skipping "
-                "instructor_training_approaching_receiver"
+                "instructor_training_approaching"
             )
 
     def test_receiver_connected_to_signal(self) -> None:
@@ -85,7 +85,7 @@ class TestInstructorTrainingApproachingReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.instructor_training_approaching.messages_action_scheduled"
+            "emails.actions.base_action.messages_action_scheduled"
         ) as mock_messages_action_scheduled:
             instructor_training_approaching_signal.send(
                 sender=self.event,
@@ -103,7 +103,7 @@ class TestInstructorTrainingApproachingReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @patch("emails.actions.instructor_training_approaching.messages_action_scheduled")
+    @patch("emails.actions.base_action.messages_action_scheduled")
     @patch("emails.actions.instructor_training_approaching.one_month_before")
     def test_email_scheduled(
         self,
@@ -122,8 +122,7 @@ class TestInstructorTrainingApproachingReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.instructor_training_approaching"
-            ".EmailController.schedule_email"
+            "emails.actions.base_action.EmailController.schedule_email"
         ) as mock_schedule_email:
             instructor_training_approaching_signal.send(
                 sender=self.event,
@@ -143,7 +142,7 @@ class TestInstructorTrainingApproachingReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @patch("emails.actions.instructor_training_approaching.messages_missing_recipients")
+    @patch("emails.actions.base_action.messages_missing_recipients")
     def test_missing_recipients(
         self, mock_messages_missing_recipients: MagicMock
     ) -> None:
@@ -167,7 +166,7 @@ class TestInstructorTrainingApproachingReceiver(TestCase):
         mock_messages_missing_recipients.assert_called_once_with(request, signal)
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @patch("emails.actions.instructor_training_approaching.messages_missing_template")
+    @patch("emails.actions.base_action.messages_missing_template")
     def test_missing_template(self, mock_messages_missing_template: MagicMock) -> None:
         # Arrange
         request = RequestFactory().get("/")

--- a/amy/emails/tests/actions/test_instructor_training_approaching_remove_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_remove_receiver.py
@@ -283,8 +283,7 @@ class TestInstructorTrainingApproachingReceiverRemoveIntegration(TestBase):
         request = RequestFactory().get("/")
 
         with patch(
-            "emails.actions.instructor_training_approaching."
-            "messages_action_scheduled"
+            "emails.actions.base_action.messages_action_scheduled"
         ) as mock_action_scheduled:
             run_instructor_training_approaching_strategy(
                 instructor_training_approaching_strategy(event),

--- a/amy/emails/tests/actions/test_instructor_training_approaching_remove_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_remove_receiver.py
@@ -56,7 +56,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
             body="Hello, {{ name }}! Nice to meet **you**.",
         )
 
-    @patch("workshops.utils.feature_flags.logger")
+    @patch("emails.actions.base_action.logger")
     def test_disabled_when_no_feature_flag(self, mock_logger) -> None:
         # Arrange
         request = RequestFactory().get("/")
@@ -66,7 +66,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
             # Assert
             mock_logger.debug.assert_called_once_with(
                 "EMAIL_MODULE feature flag not set, skipping "
-                "instructor_training_approaching_remove_receiver"
+                "instructor_training_approaching_remove"
             )
 
     def test_receiver_connected_to_signal(self) -> None:
@@ -102,7 +102,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.instructor_training_approaching.messages_action_cancelled"
+            "emails.actions.base_action.messages_action_cancelled"
         ) as mock_messages_action_cancelled:
             instructor_training_approaching_remove_signal.send(
                 sender=self.event,
@@ -120,7 +120,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @patch("emails.actions.instructor_training_approaching.messages_action_cancelled")
+    @patch("emails.actions.base_action.messages_action_cancelled")
     def test_email_cancelled(
         self,
         mock_messages_action_cancelled: MagicMock,
@@ -140,8 +140,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.instructor_training_approaching"
-            ".EmailController.cancel_email"
+            "emails.actions.base_action.EmailController.cancel_email"
         ) as mock_cancel_email:
             instructor_training_approaching_remove_signal.send(
                 sender=self.event,
@@ -157,7 +156,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @patch("emails.actions.instructor_training_approaching.messages_action_cancelled")
+    @patch("emails.actions.base_action.messages_action_cancelled")
     def test_multiple_emails_cancelled(
         self,
         mock_messages_action_cancelled: MagicMock,
@@ -186,8 +185,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.instructor_training_approaching"
-            ".EmailController.cancel_email"
+            "emails.actions.base_action.EmailController.cancel_email"
         ) as mock_cancel_email:
             instructor_training_approaching_remove_signal.send(
                 sender=self.event,

--- a/amy/emails/tests/actions/test_instructor_training_approaching_remove_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_remove_receiver.py
@@ -140,7 +140,8 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.persons_merged.EmailController.cancel_email"
+            "emails.actions.instructor_training_approaching"
+            ".EmailController.cancel_email"
         ) as mock_cancel_email:
             instructor_training_approaching_remove_signal.send(
                 sender=self.event,
@@ -185,7 +186,8 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.persons_merged.EmailController.cancel_email"
+            "emails.actions.instructor_training_approaching"
+            ".EmailController.cancel_email"
         ) as mock_cancel_email:
             instructor_training_approaching_remove_signal.send(
                 sender=self.event,

--- a/amy/emails/tests/actions/test_instructor_training_approaching_update_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_update_receiver.py
@@ -56,7 +56,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
             body="Hello, {{ name }}! Nice to meet **you**.",
         )
 
-    @patch("workshops.utils.feature_flags.logger")
+    @patch("emails.actions.base_action.logger")
     def test_disabled_when_no_feature_flag(self, mock_logger) -> None:
         # Arrange
         request = RequestFactory().get("/")
@@ -66,7 +66,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
             # Assert
             mock_logger.debug.assert_called_once_with(
                 "EMAIL_MODULE feature flag not set, skipping "
-                "instructor_training_approaching_update_receiver"
+                "instructor_training_approaching_update"
             )
 
     def test_receiver_connected_to_signal(self) -> None:
@@ -102,7 +102,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.instructor_training_approaching.messages_action_updated"
+            "emails.actions.base_action.messages_action_updated"
         ) as mock_messages_action_updated:
             instructor_training_approaching_update_signal.send(
                 sender=self.event,
@@ -120,7 +120,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @patch("emails.actions.instructor_training_approaching.messages_action_updated")
+    @patch("emails.actions.base_action.messages_action_updated")
     @patch("emails.actions.instructor_training_approaching.one_month_before")
     def test_email_updated(
         self,
@@ -148,8 +148,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.instructor_training_approaching"
-            ".EmailController.update_scheduled_email"
+            "emails.actions.base_action.EmailController.update_scheduled_email"
         ) as mock_update_scheduled_email:
             instructor_training_approaching_update_signal.send(
                 sender=self.event,
@@ -169,8 +168,8 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @patch("emails.actions.instructor_training_approaching.logger")
-    @patch("emails.actions.instructor_training_approaching.EmailController")
+    @patch("emails.actions.base_action.logger")
+    @patch("emails.actions.base_action.EmailController")
     def test_previously_scheduled_email_not_existing(
         self, mock_email_controller: MagicMock, mock_logger: MagicMock
     ) -> None:
@@ -190,12 +189,13 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
         # Assert
         mock_email_controller.update_scheduled_email.assert_not_called()
         mock_logger.warning.assert_called_once_with(
-            f"Scheduled email for signal {signal} and event {event} does not exist."
+            f"Scheduled email for signal {signal} and generic_relation_obj={event!r} "
+            "does not exist."
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @patch("emails.actions.instructor_training_approaching.logger")
-    @patch("emails.actions.instructor_training_approaching.EmailController")
+    @patch("emails.actions.base_action.logger")
+    @patch("emails.actions.base_action.EmailController")
     def test_multiple_previously_scheduled_emails(
         self, mock_email_controller: MagicMock, mock_logger: MagicMock
     ) -> None:
@@ -234,12 +234,12 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
         # Assert
         mock_email_controller.update_scheduled_email.assert_not_called()
         mock_logger.warning.assert_called_once_with(
-            f"Too many scheduled emails for signal {signal} and event {event}."
-            " Can't update them."
+            f"Too many scheduled emails for signal {signal} and "
+            f"generic_relation_obj={event!r}. Can't update them."
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @patch("emails.actions.instructor_training_approaching.messages_missing_recipients")
+    @patch("emails.actions.base_action.messages_missing_recipients")
     def test_missing_recipients(
         self, mock_messages_missing_recipients: MagicMock
     ) -> None:

--- a/amy/emails/tests/actions/test_instructor_training_approaching_update_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_update_receiver.py
@@ -343,8 +343,7 @@ class TestInstructorTrainingApproachingReceiverUpdateIntegration(TestBase):
         request = RequestFactory().get("/")
 
         with patch(
-            "emails.actions.instructor_training_approaching."
-            "messages_action_scheduled"
+            "emails.actions.base_action.messages_action_scheduled"
         ) as mock_action_scheduled:
             run_instructor_training_approaching_strategy(
                 instructor_training_approaching_strategy(event),

--- a/amy/emails/tests/actions/test_instructor_training_approaching_update_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_update_receiver.py
@@ -148,7 +148,8 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
 
         # Act
         with patch(
-            "emails.actions.persons_merged.EmailController.update_scheduled_email"
+            "emails.actions.instructor_training_approaching"
+            ".EmailController.update_scheduled_email"
         ) as mock_update_scheduled_email:
             instructor_training_approaching_update_signal.send(
                 sender=self.event,

--- a/amy/emails/tests/actions/test_persons_merged.py
+++ b/amy/emails/tests/actions/test_persons_merged.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime, timedelta
-from unittest import mock
+from unittest.mock import MagicMock, patch
 from urllib.parse import urlencode
 
 from django.test import RequestFactory, TestCase, override_settings
@@ -13,8 +13,8 @@ from workshops.tests.base import TestBase
 
 
 class TestPersonsMergedReceiver(TestCase):
-    @mock.patch("workshops.utils.feature_flags.logger")
-    def test_disabled_when_no_feature_flag(self, mock_logger) -> None:
+    @patch("emails.actions.base_action.logger")
+    def test_disabled_when_no_feature_flag(self, mock_logger: MagicMock) -> None:
         # Arrange
         request = RequestFactory().get("/")
         with self.settings(FLAGS={"EMAIL_MODULE": [("boolean", False)]}):
@@ -22,7 +22,7 @@ class TestPersonsMergedReceiver(TestCase):
             persons_merged_receiver(None, request=request)
             # Assert
             mock_logger.debug.assert_called_once_with(
-                "EMAIL_MODULE feature flag not set, skipping persons_merged_receiver"
+                "EMAIL_MODULE feature flag not set, skipping persons_merged"
             )
 
     def test_receiver_connected_to_signal(self) -> None:
@@ -54,8 +54,8 @@ class TestPersonsMergedReceiver(TestCase):
         request = RequestFactory().get("/")
 
         # Act
-        with mock.patch(
-            "emails.actions.persons_merged.messages_action_scheduled"
+        with patch(
+            "emails.actions.base_action.messages_action_scheduled"
         ) as mock_messages_action_scheduled:
             persons_merged_signal.send(
                 sender=person,
@@ -74,12 +74,12 @@ class TestPersonsMergedReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch("emails.actions.persons_merged.messages_action_scheduled")
-    @mock.patch("emails.actions.persons_merged.immediate_action")
+    @patch("emails.actions.base_action.messages_action_scheduled")
+    @patch("emails.actions.persons_merged.immediate_action")
     def test_email_scheduled(
         self,
-        mock_immediate_action: mock.MagicMock,
-        mock_messages_action_scheduled: mock.MagicMock,
+        mock_immediate_action: MagicMock,
+        mock_messages_action_scheduled: MagicMock,
     ) -> None:
         # Arrange
         NOW = datetime(2023, 6, 1, 10, 0, 0, tzinfo=UTC)
@@ -91,8 +91,8 @@ class TestPersonsMergedReceiver(TestCase):
         scheduled_at = NOW + timedelta(hours=1)
 
         # Act
-        with mock.patch(
-            "emails.actions.persons_merged.EmailController.schedule_email"
+        with patch(
+            "emails.actions.base_action.EmailController.schedule_email"
         ) as mock_schedule_email:
             persons_merged_signal.send(
                 sender=person,
@@ -113,9 +113,9 @@ class TestPersonsMergedReceiver(TestCase):
         )
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch("emails.actions.persons_merged.messages_missing_recipients")
+    @patch("emails.actions.base_action.messages_missing_recipients")
     def test_missing_recipients(
-        self, mock_messages_missing_recipients: mock.MagicMock
+        self, mock_messages_missing_recipients: MagicMock
     ) -> None:
         # Arrange
         person = Person.objects.create()  # no email will cause missing recipients error
@@ -135,10 +135,8 @@ class TestPersonsMergedReceiver(TestCase):
         mock_messages_missing_recipients.assert_called_once_with(request, signal)
 
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
-    @mock.patch("emails.actions.persons_merged.messages_missing_template")
-    def test_missing_template(
-        self, mock_messages_missing_template: mock.MagicMock
-    ) -> None:
+    @patch("emails.actions.base_action.messages_missing_template")
+    def test_missing_template(self, mock_messages_missing_template: MagicMock) -> None:
         # Arrange
         person = Person.objects.create(email="test@example.org")
         request = RequestFactory().get("/")


### PR DESCRIPTION
This fixes #2530 by moving all existing signals/receivers into class-based actions.

Three class based actions currently exist:

1. A base one which just adds new scheduled emails
2. An update action: it fetches exactly one scheduled email and updates its fields
3. A cancel action: it fetches multiple scheduled emails and cancels all of them.