### PR TITLE
[Emails] Completed instructor training not yet badged

### DIFF
--- a/amy/emails/actions/__init__.py
+++ b/amy/emails/actions/__init__.py
@@ -17,4 +17,9 @@ from emails.actions.instructor_training_approaching import (
     instructor_training_approaching_remove_receiver,
     instructor_training_approaching_update_receiver,
 )
+from emails.actions.instructor_training_completed_not_badged import (
+    instructor_training_completed_not_badged_receiver,
+    instructor_training_completed_not_badged_remove_receiver,
+    instructor_training_completed_not_badged_update_receiver,
+)
 from emails.actions.persons_merged import persons_merged_receiver

--- a/amy/emails/actions/admin_signs_instructor_up_for_workshop.py
+++ b/amy/emails/actions/admin_signs_instructor_up_for_workshop.py
@@ -13,7 +13,9 @@ from workshops.models import Event, Person
 class AdminSignsInstructorUpForWorkshopReceiver(BaseAction):
     signal = admin_signs_instructor_up_for_workshop_signal.signal_name
 
-    def get_scheduled_at(self, **kwargs) -> datetime:
+    def get_scheduled_at(
+        self, **kwargs: Unpack[AdminSignsInstructorUpKwargs]
+    ) -> datetime:
         return immediate_action()
 
     def get_context(
@@ -31,12 +33,16 @@ class AdminSignsInstructorUpForWorkshopReceiver(BaseAction):
         }
 
     def get_generic_relation_object(
-        self, context: AdminSignsInstructorUpContext, **kwargs
+        self,
+        context: AdminSignsInstructorUpContext,
+        **kwargs: Unpack[AdminSignsInstructorUpKwargs],
     ) -> InstructorRecruitmentSignup:
         return context["instructor_recruitment_signup"]
 
     def get_recipients(
-        self, context: AdminSignsInstructorUpContext, **kwargs
+        self,
+        context: AdminSignsInstructorUpContext,
+        **kwargs: Unpack[AdminSignsInstructorUpKwargs],
     ) -> list[str]:
         person = context["person"]
         return [person.email] if person.email else []

--- a/amy/emails/actions/base_action.py
+++ b/amy/emails/actions/base_action.py
@@ -89,6 +89,8 @@ class BaseAction(ABC):
             messages_action_scheduled(request, self.signal, scheduled_email)
 
 
+# TODO: turn into a generic class that combines BaseAction,
+#       BaseActionUpdate and BaseActionCancel for the complex signals.
 class BaseActionUpdate(BaseAction):
     def __call__(self, sender: Any, **kwargs) -> None:
         if not feature_flag_enabled("EMAIL_MODULE", f"{self.signal}_update", **kwargs):
@@ -147,6 +149,8 @@ class BaseActionUpdate(BaseAction):
             messages_action_updated(request, signal_name, scheduled_email)
 
 
+# TODO: turn into a generic class that combines BaseAction,
+#       BaseActionUpdate and BaseActionCancel for the complex signals.
 class BaseActionCancel(BaseAction):
     # Method is not needed in this action.
     def get_recipients(self, context: dict[str, Any], **kwargs) -> list[str]:

--- a/amy/emails/actions/base_action.py
+++ b/amy/emails/actions/base_action.py
@@ -11,7 +11,7 @@ from emails.controller import (
     EmailControllerMissingRecipientsException,
     EmailControllerMissingTemplateException,
 )
-from emails.models import EmailTemplate, ScheduledEmail
+from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailStatus
 from emails.signals import SignalNameEnum
 from emails.utils import (
     messages_action_cancelled,
@@ -112,7 +112,7 @@ class BaseActionUpdate(BaseAction):
                     generic_relation_content_type=ct,
                     generic_relation_pk=generic_relation_obj.pk,
                     template__signal=signal_name,
-                    state="scheduled",
+                    state=ScheduledEmailStatus.SCHEDULED,
                 )
             )
 
@@ -174,7 +174,7 @@ class BaseActionCancel(BaseAction):
             generic_relation_content_type=ct,
             generic_relation_pk=generic_relation_obj.pk,
             template__signal=signal_name,
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
         ).select_for_update()
 
         for scheduled_email in scheduled_emails:

--- a/amy/emails/actions/instructor_badge_awarded.py
+++ b/amy/emails/actions/instructor_badge_awarded.py
@@ -12,7 +12,9 @@ from workshops.models import Award, Person
 class InstructorBadgeAwardedReceiver(BaseAction):
     signal = instructor_badge_awarded_signal.signal_name
 
-    def get_scheduled_at(self, **kwargs) -> datetime:
+    def get_scheduled_at(
+        self, **kwargs: Unpack[InstructorBadgeAwardedKwargs]
+    ) -> datetime:
         return immediate_action()
 
     def get_context(
@@ -26,12 +28,16 @@ class InstructorBadgeAwardedReceiver(BaseAction):
         }
 
     def get_generic_relation_object(
-        self, context: InstructorBadgeAwardedContext, **kwargs
+        self,
+        context: InstructorBadgeAwardedContext,
+        **kwargs: Unpack[InstructorBadgeAwardedKwargs],
     ) -> Award:
         return context["award"]
 
     def get_recipients(
-        self, context: InstructorBadgeAwardedContext, **kwargs
+        self,
+        context: InstructorBadgeAwardedContext,
+        **kwargs: Unpack[InstructorBadgeAwardedKwargs],
     ) -> list[str]:
         person = context["person"]
         return [person.email] if person.email else []

--- a/amy/emails/actions/instructor_confirmed_for_workshop.py
+++ b/amy/emails/actions/instructor_confirmed_for_workshop.py
@@ -13,7 +13,7 @@ from workshops.models import Event, Person
 class InstructorConfirmedForWorkshopReceiver(BaseAction):
     signal = instructor_confirmed_for_workshop_signal.signal_name
 
-    def get_scheduled_at(self, **kwargs) -> datetime:
+    def get_scheduled_at(self, **kwargs: Unpack[InstructorConfirmedKwargs]) -> datetime:
         return immediate_action()
 
     def get_context(
@@ -31,12 +31,16 @@ class InstructorConfirmedForWorkshopReceiver(BaseAction):
         }
 
     def get_generic_relation_object(
-        self, context: InstructorConfirmedContext, **kwargs
+        self,
+        context: InstructorConfirmedContext,
+        **kwargs: Unpack[InstructorConfirmedKwargs],
     ) -> InstructorRecruitmentSignup:
         return context["instructor_recruitment_signup"]
 
     def get_recipients(
-        self, context: InstructorConfirmedContext, **kwargs
+        self,
+        context: InstructorConfirmedContext,
+        **kwargs: Unpack[InstructorConfirmedKwargs],
     ) -> list[str]:
         person = context["person"]
         return [person.email] if person.email else []

--- a/amy/emails/actions/instructor_declined_from_workshop.py
+++ b/amy/emails/actions/instructor_declined_from_workshop.py
@@ -13,7 +13,7 @@ from workshops.models import Event, Person
 class InstructorDeclinedFromWorkshopReceiver(BaseAction):
     signal = instructor_declined_from_workshop_signal.signal_name
 
-    def get_scheduled_at(self, **kwargs) -> datetime:
+    def get_scheduled_at(self, **kwargs: Unpack[InstructorDeclinedKwargs]) -> datetime:
         return immediate_action()
 
     def get_context(
@@ -31,11 +31,17 @@ class InstructorDeclinedFromWorkshopReceiver(BaseAction):
         }
 
     def get_generic_relation_object(
-        self, context: InstructorDeclinedContext, **kwargs
+        self,
+        context: InstructorDeclinedContext,
+        **kwargs: Unpack[InstructorDeclinedKwargs],
     ) -> InstructorRecruitmentSignup:
         return context["instructor_recruitment_signup"]
 
-    def get_recipients(self, context: InstructorDeclinedContext, **kwargs) -> list[str]:
+    def get_recipients(
+        self,
+        context: InstructorDeclinedContext,
+        **kwargs: Unpack[InstructorDeclinedKwargs],
+    ) -> list[str]:
         person = context["person"]
         return [person.email] if person.email else []
 

--- a/amy/emails/actions/instructor_signs_up_for_workshop.py
+++ b/amy/emails/actions/instructor_signs_up_for_workshop.py
@@ -13,7 +13,7 @@ from workshops.models import Event, Person
 class InstructorSignsUpForWorkshopReceiver(BaseAction):
     signal = instructor_signs_up_for_workshop_signal.signal_name
 
-    def get_scheduled_at(self, **kwargs) -> datetime:
+    def get_scheduled_at(self, **kwargs: Unpack[InstructorSignupKwargs]) -> datetime:
         return immediate_action()
 
     def get_context(
@@ -31,11 +31,13 @@ class InstructorSignsUpForWorkshopReceiver(BaseAction):
         }
 
     def get_generic_relation_object(
-        self, context: InstructorSignupContext, **kwargs
+        self, context: InstructorSignupContext, **kwargs: Unpack[InstructorSignupKwargs]
     ) -> InstructorRecruitmentSignup:
         return context["instructor_recruitment_signup"]
 
-    def get_recipients(self, context: InstructorSignupContext, **kwargs) -> list[str]:
+    def get_recipients(
+        self, context: InstructorSignupContext, **kwargs: Unpack[InstructorSignupKwargs]
+    ) -> list[str]:
         person = context["person"]
         return [person.email] if person.email else []
 

--- a/amy/emails/actions/instructor_training_approaching.py
+++ b/amy/emails/actions/instructor_training_approaching.py
@@ -95,7 +95,9 @@ def run_instructor_training_approaching_strategy(
 class InstructorTrainingApproachingReceiver(BaseAction):
     signal = instructor_training_approaching_signal.signal_name
 
-    def get_scheduled_at(self, **kwargs) -> datetime:
+    def get_scheduled_at(
+        self, **kwargs: Unpack[InstructorTrainingApproachingKwargs]
+    ) -> datetime:
         event_start_date = kwargs["event_start_date"]
         return one_month_before(event_start_date)
 
@@ -113,12 +115,16 @@ class InstructorTrainingApproachingReceiver(BaseAction):
         }
 
     def get_generic_relation_object(
-        self, context: InstructorTrainingApproachingContext, **kwargs
+        self,
+        context: InstructorTrainingApproachingContext,
+        **kwargs: Unpack[InstructorTrainingApproachingKwargs],
     ) -> Event:
         return context["event"]
 
     def get_recipients(
-        self, context: InstructorTrainingApproachingContext, **kwargs
+        self,
+        context: InstructorTrainingApproachingContext,
+        **kwargs: Unpack[InstructorTrainingApproachingKwargs],
     ) -> list[str]:
         instructors = context["instructors"]
         return [instructor.email for instructor in instructors if instructor.email]
@@ -127,7 +133,9 @@ class InstructorTrainingApproachingReceiver(BaseAction):
 class InstructorTrainingApproachingUpdateReceiver(BaseActionUpdate):
     signal = instructor_training_approaching_update_signal.signal_name
 
-    def get_scheduled_at(self, **kwargs) -> datetime:
+    def get_scheduled_at(
+        self, **kwargs: Unpack[InstructorTrainingApproachingKwargs]
+    ) -> datetime:
         event_start_date = kwargs["event_start_date"]
         return one_month_before(event_start_date)
 
@@ -145,12 +153,16 @@ class InstructorTrainingApproachingUpdateReceiver(BaseActionUpdate):
         }
 
     def get_generic_relation_object(
-        self, context: InstructorTrainingApproachingContext, **kwargs
+        self,
+        context: InstructorTrainingApproachingContext,
+        **kwargs: Unpack[InstructorTrainingApproachingKwargs],
     ) -> Event:
         return context["event"]
 
     def get_recipients(
-        self, context: InstructorTrainingApproachingContext, **kwargs
+        self,
+        context: InstructorTrainingApproachingContext,
+        **kwargs: Unpack[InstructorTrainingApproachingKwargs],
     ) -> list[str]:
         instructors = context["instructors"]
         return [instructor.email for instructor in instructors if instructor.email]
@@ -173,7 +185,9 @@ class InstructorTrainingApproachingCancelReceiver(BaseActionCancel):
         }
 
     def get_generic_relation_object(
-        self, context: InstructorTrainingApproachingContext, **kwargs
+        self,
+        context: InstructorTrainingApproachingContext,
+        **kwargs: Unpack[InstructorTrainingApproachingKwargs],
     ) -> Event:
         return context["event"]
 

--- a/amy/emails/actions/instructor_training_approaching.py
+++ b/amy/emails/actions/instructor_training_approaching.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from typing_extensions import Unpack
 
 from emails.actions.base_action import BaseAction, BaseActionCancel, BaseActionUpdate
-from emails.models import ScheduledEmail
+from emails.models import ScheduledEmail, ScheduledEmailStatus
 from emails.signals import (
     INSTRUCTOR_TRAINING_APPROACHING_SIGNAL_NAME,
     Signal,
@@ -49,7 +49,7 @@ def instructor_training_approaching_strategy(event: Event) -> StrategyEnum:
         generic_relation_content_type=ct,
         generic_relation_pk=event.pk,
         template__signal=INSTRUCTOR_TRAINING_APPROACHING_SIGNAL_NAME,
-        state="scheduled",
+        state=ScheduledEmailStatus.SCHEDULED,
     ).exists()
     logger.debug(f"{has_email_scheduled=}")
 

--- a/amy/emails/actions/instructor_training_approaching.py
+++ b/amy/emails/actions/instructor_training_approaching.py
@@ -26,6 +26,7 @@ from workshops.models import Event, Task
 logger = logging.getLogger("amy")
 
 
+# TODO: move out to a common file
 class EmailStrategyException(Exception):
     pass
 
@@ -65,6 +66,7 @@ def instructor_training_approaching_strategy(event: Event) -> StrategyEnum:
     return result
 
 
+# TODO: turn into a generic function/class
 def run_instructor_training_approaching_strategy(
     strategy: StrategyEnum, request: HttpRequest, event: Event
 ) -> None:

--- a/amy/emails/actions/instructor_training_completed_not_badged.py
+++ b/amy/emails/actions/instructor_training_completed_not_badged.py
@@ -20,7 +20,7 @@ from emails.types import (
     StrategyEnum,
 )
 from emails.utils import two_months_after
-from workshops.models import Person, TrainingProgress
+from workshops.models import Person, TrainingProgress, TrainingRequirement
 
 from .instructor_training_approaching import EmailStrategyException
 
@@ -154,15 +154,21 @@ def get_context(
     passed_requirements = list(
         TrainingProgress.objects.filter(trainee=person, state="p")
     )
-    missing_requirements = list(
+    not_passed_requirements = list(
         TrainingProgress.objects.filter(trainee=person).exclude(state="p")
+    )
+    not_graded_requirements = list(
+        TrainingRequirement.objects.filter(
+            name__in=["Training", "Get Involved", "Welcome Session", "Demo"]
+        ).exclude(trainingprogress__trainee=person)
     )
     training_completed_date = kwargs["training_completed_date"]
 
     return {
         "person": person,
         "passed_requirements": passed_requirements,
-        "missing_requirements": missing_requirements,
+        "not_passed_requirements": not_passed_requirements,
+        "not_graded_requirements": not_graded_requirements,
         "training_completed_date": training_completed_date,
     }
 

--- a/amy/emails/actions/instructor_training_completed_not_badged.py
+++ b/amy/emails/actions/instructor_training_completed_not_badged.py
@@ -120,6 +120,11 @@ def run_instructor_training_completed_not_badged_strategy(
     if not training_completed_date:
         try:
             training_completed_date = find_training_completion_date(person)
+        except TrainingProgress.MultipleObjectsReturned as exc:
+            raise EmailStrategyException(
+                "Unable to determine training completion date. Person has "
+                "multiple passed training progresses."
+            ) from exc
         except TrainingProgress.DoesNotExist as exc:
             raise EmailStrategyException(
                 "Unable to determine training completion date. Person doesn't have "

--- a/amy/emails/actions/instructor_training_completed_not_badged.py
+++ b/amy/emails/actions/instructor_training_completed_not_badged.py
@@ -61,12 +61,7 @@ def instructor_training_completed_not_badged_strategy(person: Person) -> Strateg
         )
     )
 
-    all_requirements_passed = (
-        bool(person_annotated.passed_training)
-        and bool(person_annotated.passed_get_involved)
-        and bool(person_annotated.passed_welcome)
-        and bool(person_annotated.passed_demo)
-    )
+    all_requirements_passed = bool(person_annotated.instructor_eligible)
 
     ct = ContentType.objects.get_for_model(person)  # type: ignore
     has_email_scheduled = ScheduledEmail.objects.filter(

--- a/amy/emails/actions/instructor_training_completed_not_badged.py
+++ b/amy/emails/actions/instructor_training_completed_not_badged.py
@@ -64,6 +64,7 @@ def instructor_training_completed_not_badged_strategy(
     return result
 
 
+# TODO: turn into a generic function/class
 def run_instructor_training_completed_not_badged_strategy(
     strategy: StrategyEnum, request: HttpRequest, person: Person
 ) -> None:

--- a/amy/emails/actions/instructor_training_completed_not_badged.py
+++ b/amy/emails/actions/instructor_training_completed_not_badged.py
@@ -1,0 +1,202 @@
+from datetime import datetime
+import logging
+
+from django.http import HttpRequest
+from typing_extensions import Unpack
+
+from emails.actions.base_action import BaseAction, BaseActionCancel, BaseActionUpdate
+from emails.signals import (
+    Signal,
+    instructor_training_completed_not_badged_remove_signal,
+    instructor_training_completed_not_badged_signal,
+    instructor_training_completed_not_badged_update_signal,
+)
+from emails.types import (
+    InstructorTrainingCompletedNotBadgedContext,
+    InstructorTrainingCompletedNotBadgedKwargs,
+    StrategyEnum,
+)
+from emails.utils import two_months_after
+from workshops.models import Award, Person
+
+from .instructor_training_approaching import EmailStrategyException
+
+logger = logging.getLogger("amy")
+
+
+def instructor_training_completed_not_badged_strategy(
+    person: Person,
+) -> StrategyEnum:
+    logger.info(f"Running InstructorTrainingCompletedNotBadged strategy for {person}")
+
+    person_annotated = (
+        Person.objects.annotate_with_instructor_eligibility().get(  # type: ignore
+            pk=person.pk
+        )
+    )
+
+    has_instructor_role = Award.objects.filter(
+        role__name="instructor", person=person
+    ).exists()
+
+    all_requirements_passed = (
+        person_annotated.passed_training
+        and person_annotated.passed_get_involved
+        and person_annotated.passed_welcome
+        and person_annotated.passed_demo
+    )
+
+    if has_instructor_role or all_requirements_passed:
+        result = StrategyEnum.REMOVE
+    elif person_annotated.passed_training and not all_requirements_passed:
+        result = StrategyEnum.CREATE
+    elif (
+        person_annotated.passed_training
+        or person_annotated.passed_get_involved
+        or person_annotated.passed_welcome
+        or person_annotated.passed_demo
+    ):
+        result = StrategyEnum.UPDATE
+    else:
+        result = StrategyEnum.NOOP
+
+    logger.debug(f"InstructorTrainingCompletedNotBadged strategy {result = }")
+    return result
+
+
+def run_instructor_training_completed_not_badged_strategy(
+    strategy: StrategyEnum, request: HttpRequest, person: Person
+) -> None:
+    mapping: dict[StrategyEnum, Signal | None] = {
+        StrategyEnum.CREATE: instructor_training_completed_not_badged_signal,
+        StrategyEnum.UPDATE: instructor_training_completed_not_badged_update_signal,
+        StrategyEnum.REMOVE: instructor_training_completed_not_badged_remove_signal,
+        StrategyEnum.NOOP: None,
+    }
+    if strategy not in mapping:
+        raise EmailStrategyException(f"Unknown strategy {strategy}")
+
+    signal = mapping[strategy]
+
+    if not signal:
+        logger.debug(f"Strategy {strategy} for {person} is a no-op")
+        return
+
+    logger.debug(f"Sending signal for {person} as result of strategy {strategy}")
+    signal.send(
+        sender=person,
+        request=request,
+        person=person,
+    )
+
+
+class InstructorTrainingCompletedNotBadgedReceiver(BaseAction):
+    signal = instructor_training_completed_not_badged_signal.signal_name
+
+    def get_scheduled_at(
+        self, **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs]
+    ) -> datetime:
+        training_completed_date = kwargs["training_completed_date"]
+        return two_months_after(training_completed_date)
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs]
+    ) -> InstructorTrainingCompletedNotBadgedContext:
+        person = kwargs["person"]
+        return {
+            "person": person,
+        }
+
+    def get_generic_relation_object(
+        self,
+        context: InstructorTrainingCompletedNotBadgedContext,
+        **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs],
+    ) -> Person:
+        return context["person"]
+
+    def get_recipients(
+        self,
+        context: InstructorTrainingCompletedNotBadgedContext,
+        **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs],
+    ) -> list[str]:
+        person = context["person"]
+        return [person.email] if person.email else []
+
+
+class InstructorTrainingCompletedNotBadgedUpdateReceiver(BaseActionUpdate):
+    signal = instructor_training_completed_not_badged_update_signal.signal_name
+
+    def get_scheduled_at(
+        self, **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs]
+    ) -> datetime:
+        training_completed_date = kwargs["training_completed_date"]
+        return two_months_after(training_completed_date)
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs]
+    ) -> InstructorTrainingCompletedNotBadgedContext:
+        person = kwargs["person"]
+        return {
+            "person": person,
+        }
+
+    def get_generic_relation_object(
+        self,
+        context: InstructorTrainingCompletedNotBadgedContext,
+        **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs],
+    ) -> Person:
+        return context["person"]
+
+    def get_recipients(
+        self,
+        context: InstructorTrainingCompletedNotBadgedContext,
+        **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs],
+    ) -> list[str]:
+        person = context["person"]
+        return [person.email] if person.email else []
+
+
+class InstructorTrainingCompletedNotBadgedCancelReceiver(BaseActionCancel):
+    signal = instructor_training_completed_not_badged_remove_signal.signal_name
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs]
+    ) -> InstructorTrainingCompletedNotBadgedContext:
+        person = kwargs["person"]
+        return {
+            "person": person,
+        }
+
+    def get_generic_relation_object(
+        self,
+        context: InstructorTrainingCompletedNotBadgedContext,
+        **kwargs: Unpack[InstructorTrainingCompletedNotBadgedKwargs],
+    ) -> Person:
+        return context["person"]
+
+
+# -----------------------------------------------------------------------------
+# Receivers
+
+instructor_training_completed_not_badged_receiver = (
+    InstructorTrainingCompletedNotBadgedReceiver()
+)
+instructor_training_completed_not_badged_signal.connect(
+    instructor_training_completed_not_badged_receiver
+)
+
+
+instructor_training_completed_not_badged_update_receiver = (
+    InstructorTrainingCompletedNotBadgedUpdateReceiver()
+)
+instructor_training_completed_not_badged_update_signal.connect(
+    instructor_training_completed_not_badged_update_receiver
+)
+
+
+instructor_training_completed_not_badged_remove_receiver = (
+    InstructorTrainingCompletedNotBadgedCancelReceiver()
+)
+instructor_training_completed_not_badged_remove_signal.connect(
+    instructor_training_completed_not_badged_remove_receiver
+)

--- a/amy/emails/actions/persons_merged.py
+++ b/amy/emails/actions/persons_merged.py
@@ -12,7 +12,7 @@ from workshops.models import Person
 class PersonsMergedReceiver(BaseAction):
     signal = persons_merged_signal.signal_name
 
-    def get_scheduled_at(self, **kwargs) -> datetime:
+    def get_scheduled_at(self, **kwargs: Unpack[PersonsMergedKwargs]) -> datetime:
         return immediate_action()
 
     def get_context(
@@ -24,11 +24,13 @@ class PersonsMergedReceiver(BaseAction):
         }
 
     def get_generic_relation_object(
-        self, context: PersonsMergedContext, **kwargs
+        self, context: PersonsMergedContext, **kwargs: Unpack[PersonsMergedKwargs]
     ) -> Person:
         return context["person"]
 
-    def get_recipients(self, context: PersonsMergedContext, **kwargs) -> list[str]:
+    def get_recipients(
+        self, context: PersonsMergedContext, **kwargs: Unpack[PersonsMergedKwargs]
+    ) -> list[str]:
         person = context["person"]
         return [person.email] if person.email else []
 

--- a/amy/emails/controller.py
+++ b/amy/emails/controller.py
@@ -46,7 +46,7 @@ class EmailController:
         body = EmailTemplate.render_template(engine, template.body, dict(context))
 
         scheduled_email = ScheduledEmail.objects.create(
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             scheduled_at=scheduled_at,
             to_header=to_header,
             from_header=template.from_header,

--- a/amy/emails/controller.py
+++ b/amy/emails/controller.py
@@ -129,7 +129,6 @@ class EmailController:
 
         signal = template.signal
         engine = EmailTemplate.get_engine()
-        old_state = scheduled_email.state
 
         subject = EmailTemplate.render_template(engine, template.subject, dict(context))
         body = EmailTemplate.render_template(engine, template.body, dict(context))
@@ -143,8 +142,8 @@ class EmailController:
 
         ScheduledEmailLog.objects.create(
             details=f"Updated {signal}",
-            state_before=old_state,
-            state_after=ScheduledEmailStatus.SCHEDULED,
+            state_before=scheduled_email.state,
+            state_after=scheduled_email.state,
             scheduled_email=scheduled_email,
             author=author,
         )

--- a/amy/emails/signals.py
+++ b/amy/emails/signals.py
@@ -10,6 +10,7 @@ from emails.types import (
     InstructorDeclinedContext,
     InstructorSignupContext,
     InstructorTrainingApproachingContext,
+    InstructorTrainingCompletedNotBadgedContext,
     PersonsMergedContext,
 )
 
@@ -94,19 +95,19 @@ INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME = (
 )
 instructor_training_completed_not_badged_signal = Signal(
     signal_name=INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME,
-    context_type=InstructorTrainingApproachingContext,
+    context_type=InstructorTrainingCompletedNotBadgedContext,
 )
 # Emitted when conditions for the previous signal may have changed and
 # the email should be re-calculated.
 instructor_training_completed_not_badged_update_signal = Signal(
     signal_name=INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME,
-    context_type=InstructorTrainingApproachingContext,
+    context_type=InstructorTrainingCompletedNotBadgedContext,
 )
 # Emitted when conditions for the previous signal may have changed and
 # the email should be cancelled.
 instructor_training_completed_not_badged_remove_signal = Signal(
     signal_name=INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME,
-    context_type=InstructorTrainingApproachingContext,
+    context_type=InstructorTrainingCompletedNotBadgedContext,
 )
 
 ALL_SIGNALS = [item for item in locals().values() if isinstance(item, Signal)]

--- a/amy/emails/signals.py
+++ b/amy/emails/signals.py
@@ -22,6 +22,9 @@ class SignalNameEnum(StrEnum):
     admin_signs_instructor_up_for_workshop = "admin_signs_instructor_up_for_workshop"
     persons_merged = "persons_merged"
     instructor_training_approaching = "instructor_training_approaching"
+    instructor_training_completed_not_badged = (
+        "instructor_training_completed_not_badged"
+    )
 
     @staticmethod
     def choices() -> list[tuple[str, str]]:

--- a/amy/emails/signals.py
+++ b/amy/emails/signals.py
@@ -85,4 +85,25 @@ instructor_training_approaching_remove_signal = Signal(
     context_type=InstructorTrainingApproachingContext,
 )
 
+# Runs 2 months after completing training.
+INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME = (
+    "instructor_training_completed_not_badged"
+)
+instructor_training_completed_not_badged_signal = Signal(
+    signal_name=INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME,
+    context_type=InstructorTrainingApproachingContext,
+)
+# Emitted when conditions for the previous signal may have changed and
+# the email should be re-calculated.
+instructor_training_completed_not_badged_update_signal = Signal(
+    signal_name=INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME,
+    context_type=InstructorTrainingApproachingContext,
+)
+# Emitted when conditions for the previous signal may have changed and
+# the email should be cancelled.
+instructor_training_completed_not_badged_remove_signal = Signal(
+    signal_name=INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME,
+    context_type=InstructorTrainingApproachingContext,
+)
+
 ALL_SIGNALS = [item for item in locals().values() if isinstance(item, Signal)]

--- a/amy/emails/templatetags/emails.py
+++ b/amy/emails/templatetags/emails.py
@@ -1,28 +1,8 @@
 from django import template
-from django.db.models import Model
 
 from emails.models import ScheduledEmailStatus, ScheduledEmailStatusActions
 
 register = template.Library()
-
-
-@register.filter
-def model_documentation_link(model: Model) -> str:
-    # This is a limited mapping of model to its documentation link. It should
-    # be expanded as needed.
-    # If our model documentation grows, we should consider including link to model
-    # documentation inside every model. Then this mapping would become obsolete.
-    mapping = {
-        "InstructorRecruitmentSignup": (
-            "https://carpentries.github.io/amy/design/database_models/"
-            "#instructorrecruitmentsignup"
-        ),
-        "Event": "https://carpentries.github.io/amy/amy_database_structure/#events",
-        "Award": "https://carpentries.github.io/amy/design/database_models/#award",
-        "Person": "https://carpentries.github.io/amy/amy_database_structure/#persons",
-    }
-    model_name = model.__class__.__name__
-    return mapping.get(model_name, "")
 
 
 @register.simple_tag

--- a/amy/emails/tests/actions/test_instructor_training_approaching_remove_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_remove_receiver.py
@@ -96,7 +96,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
 
@@ -134,7 +134,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
 
@@ -170,7 +170,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
         scheduled_email2 = ScheduledEmail.objects.create(
@@ -179,7 +179,7 @@ class TestInstructorTrainingApproachingRemoveReceiver(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
 

--- a/amy/emails/tests/actions/test_instructor_training_approaching_strategy.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_strategy.py
@@ -8,7 +8,7 @@ from emails.actions.instructor_training_approaching import (
     instructor_training_approaching_strategy,
     run_instructor_training_approaching_strategy,
 )
-from emails.models import EmailTemplate, ScheduledEmail
+from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailStatus
 from emails.signals import INSTRUCTOR_TRAINING_APPROACHING_SIGNAL_NAME
 from emails.types import StrategyEnum
 from workshops.models import Event, Organization, Person, Role, Tag, Task
@@ -73,7 +73,7 @@ class TestInstructorTrainingApproachingStrategy(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
 
@@ -102,7 +102,7 @@ class TestInstructorTrainingApproachingStrategy(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
 

--- a/amy/emails/tests/actions/test_instructor_training_approaching_update_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_training_approaching_update_receiver.py
@@ -96,7 +96,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
 
@@ -136,7 +136,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
         context = {
@@ -209,7 +209,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
         ScheduledEmail.objects.create(
@@ -218,7 +218,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
         event = self.event
@@ -252,7 +252,7 @@ class TestInstructorTrainingApproachingUpdateReceiver(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=ScheduledEmailStatus.SCHEDULED,
             generic_relation=self.event,
         )
         signal = INSTRUCTOR_TRAINING_APPROACHING_SIGNAL_NAME

--- a/amy/emails/tests/actions/test_instructor_training_completed_not_badged_common_functions.py
+++ b/amy/emails/tests/actions/test_instructor_training_completed_not_badged_common_functions.py
@@ -1,0 +1,132 @@
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, TestCase
+
+from emails.actions.instructor_training_completed_not_badged import (
+    get_context,
+    get_generic_relation_object,
+    get_recipients,
+    get_scheduled_at,
+)
+from emails.types import InstructorTrainingCompletedNotBadgedContext
+from workshops.models import Person, TrainingProgress, TrainingRequirement
+
+
+class TestInstructorTrainingCompletedNotBadgedCommonFunctions(TestCase):
+    def setUpTrainingProgresses(self, person: Person) -> None:
+        requirements = TrainingRequirement.objects.all()  # should be 4 of them
+        self.progresses = [
+            TrainingProgress(state="p", trainee=person, requirement=requirements[0]),
+            TrainingProgress(state="f", trainee=person, requirement=requirements[1]),
+            TrainingProgress(state="f", trainee=person, requirement=requirements[2]),
+            TrainingProgress(state="p", trainee=person, requirement=requirements[3]),
+        ]
+        TrainingProgress.objects.bulk_create(self.progresses)
+
+    def setUpContext(
+        self, person: Person, training_completed_date: datetime
+    ) -> InstructorTrainingCompletedNotBadgedContext:
+        return {
+            "person": person,
+            "passed_requirements": [self.progresses[0], self.progresses[3]],
+            "missing_requirements": [self.progresses[1], self.progresses[2]],
+            "training_completed_date": training_completed_date,
+        }
+
+    @patch("emails.utils.datetime", wraps=datetime)
+    def test_get_scheduled_at(self, mock_datetime: MagicMock) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        person = Person()
+        training_completed_date = datetime(2023, 1, 1)
+        mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        # Act
+        scheduled_at = get_scheduled_at(
+            request=request,
+            person=person,
+            training_completed_date=training_completed_date,
+        )
+
+        # Assert
+        self.assertEqual(scheduled_at, datetime(2023, 3, 2, 12, 0, 0, tzinfo=UTC))
+
+    def test_get_context(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        person = Person.objects.create(username="test")
+        training_completed_date = datetime.now()
+        self.setUpTrainingProgresses(person)
+
+        # Act
+        context = get_context(
+            request=request,
+            person=person,
+            training_completed_date=training_completed_date,
+        )
+
+        # Assert
+        self.assertEqual(
+            context,
+            {
+                "person": person,
+                "passed_requirements": [self.progresses[0], self.progresses[3]],
+                "missing_requirements": [self.progresses[1], self.progresses[2]],
+                "training_completed_date": training_completed_date,
+            },
+        )
+
+    def test_get_generic_relation_object(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        person = Person.objects.create(username="test")
+        training_completed_date = datetime.now()
+        self.setUpTrainingProgresses(person)
+
+        # Act
+        obj = get_generic_relation_object(
+            context=self.setUpContext(person, training_completed_date),
+            request=request,
+            person=person,
+            training_completed_date=training_completed_date,
+        )
+
+        # Assert
+        self.assertEqual(obj, person)
+
+    def test_get_recipients(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        person = Person.objects.create(username="test", email="test@example.org")
+        training_completed_date = datetime.now()
+        self.setUpTrainingProgresses(person)
+
+        # Act
+        obj = get_recipients(
+            context=self.setUpContext(person, training_completed_date),
+            request=request,
+            person=person,
+            training_completed_date=training_completed_date,
+        )
+
+        # Assert
+        self.assertEqual(obj, [person.email])
+
+    def test_get_recipients__no_email(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        person = Person.objects.create(username="test")  # no email for this person
+        training_completed_date = datetime.now()
+        self.setUpTrainingProgresses(person)
+
+        # Act
+        obj = get_recipients(
+            context=self.setUpContext(person, training_completed_date),
+            request=request,
+            person=person,
+            training_completed_date=training_completed_date,
+        )
+
+        # Assert
+        self.assertEqual(obj, [])

--- a/amy/emails/tests/actions/test_instructor_training_completed_not_badged_common_functions.py
+++ b/amy/emails/tests/actions/test_instructor_training_completed_not_badged_common_functions.py
@@ -15,12 +15,21 @@ from workshops.models import Person, TrainingProgress, TrainingRequirement
 
 class TestInstructorTrainingCompletedNotBadgedCommonFunctions(TestCase):
     def setUpTrainingProgresses(self, person: Person) -> None:
-        requirements = TrainingRequirement.objects.all()  # should be 4 of them
+        self.requirements = TrainingRequirement.objects.filter(
+            name__in=["Training", "Get Involved", "Welcome Session", "Demo"]
+        )
         self.progresses = [
-            TrainingProgress(state="p", trainee=person, requirement=requirements[0]),
-            TrainingProgress(state="f", trainee=person, requirement=requirements[1]),
-            TrainingProgress(state="f", trainee=person, requirement=requirements[2]),
-            TrainingProgress(state="p", trainee=person, requirement=requirements[3]),
+            TrainingProgress(
+                state="p", trainee=person, requirement=self.requirements[0]
+            ),
+            TrainingProgress(
+                state="f", trainee=person, requirement=self.requirements[1]
+            ),
+            TrainingProgress(
+                state="a", trainee=person, requirement=self.requirements[2]
+            ),
+            # Last requirement is left ungraded.
+            # TrainingProgress(state="p", trainee=person, requirement=requirements[3]),
         ]
         TrainingProgress.objects.bulk_create(self.progresses)
 
@@ -29,8 +38,9 @@ class TestInstructorTrainingCompletedNotBadgedCommonFunctions(TestCase):
     ) -> InstructorTrainingCompletedNotBadgedContext:
         return {
             "person": person,
-            "passed_requirements": [self.progresses[0], self.progresses[3]],
-            "missing_requirements": [self.progresses[1], self.progresses[2]],
+            "passed_requirements": [self.progresses[0]],
+            "not_passed_requirements": [self.progresses[1], self.progresses[2]],
+            "not_graded_requirements": [self.requirements[3]],
             "training_completed_date": training_completed_date,
         }
 
@@ -71,8 +81,9 @@ class TestInstructorTrainingCompletedNotBadgedCommonFunctions(TestCase):
             context,
             {
                 "person": person,
-                "passed_requirements": [self.progresses[0], self.progresses[3]],
-                "missing_requirements": [self.progresses[1], self.progresses[2]],
+                "passed_requirements": [self.progresses[0]],
+                "not_passed_requirements": [self.progresses[1], self.progresses[2]],
+                "not_graded_requirements": [self.requirements[3]],
                 "training_completed_date": training_completed_date,
             },
         )

--- a/amy/emails/tests/actions/test_instructor_training_completed_not_badged_integration.py
+++ b/amy/emails/tests/actions/test_instructor_training_completed_not_badged_integration.py
@@ -1,0 +1,312 @@
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from django.test import RequestFactory, override_settings
+from django.urls import reverse
+
+from emails.actions.instructor_training_completed_not_badged import (
+    instructor_training_completed_not_badged_strategy,
+    run_instructor_training_completed_not_badged_strategy,
+)
+from emails.models import (
+    EmailTemplate,
+    ScheduledEmail,
+    ScheduledEmailLog,
+    ScheduledEmailStatus,
+)
+from emails.signals import INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME
+from workshops.models import (
+    Event,
+    Organization,
+    Person,
+    Role,
+    Tag,
+    Task,
+    TrainingProgress,
+    TrainingRequirement,
+)
+from workshops.tests.base import TestBase
+
+
+class TestInstructorTrainingCompletedNotBadgedReceiverIntegration(TestBase):
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    def test_integration(self) -> None:
+        # Arrange
+        self._setUpRoles()
+        self._setUpTags()
+        self._setUpUsersAndLogin()
+
+        template = EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings",
+            body="Hello! Nice to meet **you**.",
+        )
+
+        ttt_organization = Organization.objects.create(
+            domain="carpentries.org", fullname="Instructor Training"
+        )
+        event = Event.objects.create(
+            slug="test-event",
+            host=Organization.objects.create(domain="example.com", fullname="Example"),
+            administrator=ttt_organization,
+            start=date.today() + timedelta(days=30),
+            end=date.today() + timedelta(days=31),
+        )
+        ttt_tag = Tag.objects.get(name="TTT")
+        event.tags.add(ttt_tag)
+
+        learner = Person.objects.create(
+            personal="Kelsi",
+            middle="",
+            family="Purdy",
+            username="purdy_kelsi",
+            email="purdy.kelsi@example.com",
+            secondary_email="notused@amy.org",
+            gender="F",
+            airport=self.airport_0_0,
+            github="purdy_kelsi",
+            twitter="purdy_kelsi",
+            url="http://kelsipurdy.com/",
+            affiliation="University of Arizona",
+            occupation="TA at Biology Department",
+            orcid="0000-0000-0000",
+            is_active=True,
+        )
+        learner_role = Role.objects.get(name="learner")
+        Task.objects.create(event=event, person=learner, role=learner_role)
+
+        training_requirement = TrainingRequirement.objects.get(name="Training")
+
+        url = reverse("trainingprogress_add")
+        payload = {
+            "trainee": learner.pk,
+            "requirement": training_requirement.pk,
+            "event": event.pk,
+            "state": "p",
+            "trainee_notes": "",
+        }
+
+        # Act
+        rv = self.client.post(url, data=payload)
+
+        # Arrange
+        self.assertEqual(rv.status_code, 302)
+        ScheduledEmail.objects.get(template=template)
+
+
+class TestInstructorTrainingCompletedNotBadgedUpdateReceiverIntegration(TestBase):
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    def test_integration(self) -> None:
+        # Arrange
+        self._setUpRoles()
+        self._setUpTags()
+        self._setUpUsersAndLogin()
+
+        signal = INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME
+        template = EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=signal,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings",
+            body="Hello! Nice to meet **you**.",
+        )
+
+        ttt_organization = Organization.objects.create(
+            domain="carpentries.org", fullname="Instructor Training"
+        )
+        event = Event.objects.create(
+            slug="test-event",
+            host=Organization.objects.create(domain="example.com", fullname="Example"),
+            administrator=ttt_organization,
+            start=date.today() + timedelta(days=30),
+            end=date.today() + timedelta(days=31),
+        )
+        ttt_tag = Tag.objects.get(name="TTT")
+        event.tags.add(ttt_tag)
+
+        learner = Person.objects.create(
+            personal="Kelsi",
+            middle="",
+            family="Purdy",
+            username="purdy_kelsi",
+            email="purdy.kelsi@example.com",
+            secondary_email="notused@amy.org",
+            gender="F",
+            airport=self.airport_0_0,
+            github="purdy_kelsi",
+            twitter="purdy_kelsi",
+            url="http://kelsipurdy.com/",
+            affiliation="University of Arizona",
+            occupation="TA at Biology Department",
+            orcid="0000-0000-0000",
+            is_active=True,
+        )
+        learner_role = Role.objects.get(name="learner")
+        Task.objects.create(event=event, person=learner, role=learner_role)
+        request = RequestFactory().get("/")
+
+        training_requirement = TrainingRequirement.objects.get(name="Training")
+        demo_requirement = TrainingRequirement.objects.get(name="Demo")
+
+        TrainingProgress.objects.create(
+            trainee=learner,
+            requirement=training_requirement,
+            event=event,
+            state="p",
+        )
+
+        with patch(
+            "emails.actions.base_action.messages_action_scheduled"
+        ) as mock_action_scheduled:
+            run_instructor_training_completed_not_badged_strategy(
+                instructor_training_completed_not_badged_strategy(learner),
+                request=request,
+                person=learner,
+                training_completed_date=event.end,
+            )
+        scheduled_email = ScheduledEmail.objects.get(template=template)
+
+        url = reverse("trainingprogress_add")
+        payload = {
+            "trainee": learner.pk,
+            "requirement": demo_requirement.pk,
+            "state": "p",
+            "trainee_notes": "",
+        }
+
+        # Act
+        rv = self.client.post(url, payload)
+
+        # Arrange
+        mock_action_scheduled.assert_called_once()
+        self.assertEqual(rv.status_code, 302)
+        scheduled_email.refresh_from_db()
+        self.assertEqual(scheduled_email.state, ScheduledEmailStatus.SCHEDULED)
+        latest_log = (
+            ScheduledEmailLog.objects.filter(scheduled_email=scheduled_email)
+            .order_by("-created_at")
+            .first()
+        )
+        assert latest_log
+        self.assertEqual(latest_log.details, f"Updated {signal}")
+
+
+class TestInstructorTrainingCompletedNotBadgedRemoveReceiverIntegration(TestBase):
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    def test_integration(self) -> None:
+        # Arrange
+        self._setUpRoles()
+        self._setUpTags()
+        self._setUpUsersAndLogin()
+
+        signal = INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME
+        template = EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=signal,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings",
+            body="Hello! Nice to meet **you**.",
+        )
+
+        ttt_organization = Organization.objects.create(
+            domain="carpentries.org", fullname="Instructor Training"
+        )
+        event = Event.objects.create(
+            slug="test-event",
+            host=Organization.objects.create(domain="example.com", fullname="Example"),
+            administrator=ttt_organization,
+            start=date.today() + timedelta(days=30),
+            end=date.today() + timedelta(days=31),
+        )
+        ttt_tag = Tag.objects.get(name="TTT")
+        event.tags.add(ttt_tag)
+
+        learner = Person.objects.create(
+            personal="Kelsi",
+            middle="",
+            family="Purdy",
+            username="purdy_kelsi",
+            email="purdy.kelsi@example.com",
+            secondary_email="notused@amy.org",
+            gender="F",
+            airport=self.airport_0_0,
+            github="purdy_kelsi",
+            twitter="purdy_kelsi",
+            url="http://kelsipurdy.com/",
+            affiliation="University of Arizona",
+            occupation="TA at Biology Department",
+            orcid="0000-0000-0000",
+            is_active=True,
+        )
+        learner_role = Role.objects.get(name="learner")
+        Task.objects.create(event=event, person=learner, role=learner_role)
+        request = RequestFactory().get("/")
+
+        training_requirement = TrainingRequirement.objects.get(name="Training")
+        get_involved_requirement = TrainingRequirement.objects.get(name="Get Involved")
+        welcome_requirement = TrainingRequirement.objects.get(name="Welcome Session")
+        demo_requirement = TrainingRequirement.objects.get(name="Demo")
+
+        TrainingProgress.objects.bulk_create(
+            [
+                TrainingProgress(
+                    trainee=learner,
+                    requirement=training_requirement,
+                    event=event,
+                    state="p",
+                ),
+                TrainingProgress(
+                    trainee=learner,
+                    requirement=get_involved_requirement,
+                    state="p",
+                ),
+                TrainingProgress(
+                    trainee=learner,
+                    requirement=welcome_requirement,
+                    state="p",
+                ),
+            ]
+        )
+
+        with patch(
+            "emails.actions.base_action.messages_action_scheduled"
+        ) as mock_action_scheduled:
+            run_instructor_training_completed_not_badged_strategy(
+                instructor_training_completed_not_badged_strategy(learner),
+                request=request,
+                person=learner,
+                training_completed_date=event.end,
+            )
+        scheduled_email = ScheduledEmail.objects.get(template=template)
+
+        url = reverse("trainingprogress_add")
+        payload = {
+            "trainee": learner.pk,
+            "requirement": demo_requirement.pk,
+            "state": "p",
+            "trainee_notes": "",
+        }
+
+        # Act
+        rv = self.client.post(url, payload)
+
+        # Arrange
+        mock_action_scheduled.assert_called_once()
+        self.assertEqual(rv.status_code, 302)
+        scheduled_email.refresh_from_db()
+        self.assertEqual(scheduled_email.state, ScheduledEmailStatus.CANCELLED)
+        latest_log = (
+            ScheduledEmailLog.objects.filter(scheduled_email=scheduled_email)
+            .order_by("-created_at")
+            .first()
+        )
+        assert latest_log
+        self.assertEqual(latest_log.details, "Email was cancelled")

--- a/amy/emails/tests/actions/test_instructor_training_completed_not_badged_strategy.py
+++ b/amy/emails/tests/actions/test_instructor_training_completed_not_badged_strategy.py
@@ -10,7 +10,7 @@ from emails.actions.instructor_training_completed_not_badged import (
     instructor_training_completed_not_badged_strategy,
     run_instructor_training_completed_not_badged_strategy,
 )
-from emails.models import EmailTemplate, ScheduledEmail
+from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailStatus
 from emails.signals import INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME
 from emails.types import StrategyEnum
 from workshops.models import (
@@ -136,6 +136,7 @@ class TestInstructorTrainingCompletedNotBadgedStrategy(TestCase):
         self,
         person: Person,
         signal: str = INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME,
+        state: ScheduledEmailStatus = ScheduledEmailStatus.SCHEDULED,
     ) -> ScheduledEmail:
         template = EmailTemplate.objects.create(
             name="Test Email Template",
@@ -152,7 +153,7 @@ class TestInstructorTrainingCompletedNotBadgedStrategy(TestCase):
             to_header=[],
             cc_header=[],
             bcc_header=[],
-            state="scheduled",
+            state=state,
             generic_relation=person,
         )
 

--- a/amy/emails/tests/actions/test_instructor_training_completed_not_badged_strategy.py
+++ b/amy/emails/tests/actions/test_instructor_training_completed_not_badged_strategy.py
@@ -1,0 +1,425 @@
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, TestCase
+
+from emails.actions.instructor_training_completed_not_badged import (
+    EmailStrategyException,
+    TrainingCompletionDateException,
+    find_training_completion_date,
+    instructor_training_completed_not_badged_strategy,
+    run_instructor_training_completed_not_badged_strategy,
+)
+from emails.models import EmailTemplate, ScheduledEmail
+from emails.signals import INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME
+from emails.types import StrategyEnum
+from workshops.models import (
+    Event,
+    Organization,
+    Person,
+    TrainingProgress,
+    TrainingRequirement,
+)
+
+
+class TestTrainingCompletionDate(TestCase):
+    def setUp(self) -> None:
+        self.person = Person.objects.create(
+            personal="Test", family="Test", email="test@example.com"
+        )
+
+    def setUpEvent(
+        self, slug: str, start: date | None = None, end: date | None = None
+    ) -> Event:
+        organization, _ = Organization.objects.get_or_create(
+            domain="test.com", defaults={"fullname": "Test"}
+        )
+        return Event.objects.create(
+            slug=slug,
+            host=organization,
+            start=start,
+            end=end,
+        )
+
+    def setUpPassedTraining(
+        self, person: Person, event: Event | None = None
+    ) -> TrainingProgress:
+        training_requirement = TrainingRequirement.objects.get(name="Training")
+        return TrainingProgress.objects.create(
+            trainee=person,
+            state="p",
+            requirement=training_requirement,
+            event=event,
+        )
+
+    def test_find_training_completion_date(self) -> None:
+        # Arrange
+        event = self.setUpEvent(
+            slug="test-event", start=date(2023, 10, 28), end=date(2023, 10, 29)
+        )
+        self.setUpPassedTraining(self.person, event)
+        # Act
+        result = find_training_completion_date(self.person)
+
+        # Assert
+        self.assertEqual(result, event.end)
+
+    def test_find_training_completion_date__no_training(self) -> None:
+        # Act & Assert
+        with self.assertRaises(TrainingProgress.DoesNotExist):
+            find_training_completion_date(self.person)
+
+    def test_find_training_completion_date__multiple_trainings(self) -> None:
+        # Arrange
+        event1 = self.setUpEvent(
+            slug="test-event1", start=date(2023, 10, 28), end=date(2023, 10, 29)
+        )
+        event2 = self.setUpEvent(
+            slug="test-event2", start=date(2023, 11, 4), end=date(2023, 11, 5)
+        )
+        self.setUpPassedTraining(self.person, event1)
+        self.setUpPassedTraining(self.person, event2)
+        # Act & Assert
+        with self.assertRaises(TrainingProgress.MultipleObjectsReturned):
+            find_training_completion_date(self.person)
+
+    def test_find_training_completion_date__no_event(self) -> None:
+        # Arrange
+        self.setUpPassedTraining(self.person)
+        # Act & Assert
+        with self.assertRaisesMessage(
+            TrainingCompletionDateException,
+            "Training progress doesn't have an event.",
+        ):
+            find_training_completion_date(self.person)
+
+    def test_find_training_completion_date__no_event_end_date(self) -> None:
+        # Arrange
+        event = self.setUpEvent(slug="test-event", start=date(2023, 10, 28))
+        self.setUpPassedTraining(self.person, event)
+        # Act & Assert
+        with self.assertRaisesMessage(
+            TrainingCompletionDateException,
+            "Training progress event doesn't have an end date.",
+        ):
+            find_training_completion_date(self.person)
+
+
+class TestInstructorTrainingCompletedNotBadgedStrategy(TestCase):
+    def setUp(self) -> None:
+        self.person = Person.objects.create(
+            personal="Test", family="Test", email="test@example.com"
+        )
+        organization = Organization.objects.create(domain="test.com", fullname="Test")
+        self.event = Event.objects.create(
+            slug="test-event",
+            host=organization,
+            start=date(2023, 10, 28),
+            end=date(2023, 10, 29),
+        )
+        self.training_requirement = TrainingRequirement.objects.get(name="Training")
+
+    def setUpPassedTrainingProgress(
+        self,
+        person: Person,
+        requirement: TrainingRequirement,
+        event: Event | None = None,
+    ) -> TrainingProgress:
+        return TrainingProgress.objects.create(
+            trainee=person,
+            state="p",
+            requirement=requirement,
+            event=event,
+        )
+
+    def setUpScheduledEmail(
+        self,
+        person: Person,
+        signal: str = INSTRUCTOR_TRAINING_COMPLETED_NOT_BADGED_SIGNAL_NAME,
+    ) -> ScheduledEmail:
+        template = EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=signal,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ name }}",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+        return ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state="scheduled",
+            generic_relation=person,
+        )
+
+    def test_strategy_create(self) -> None:
+        # Arrange
+        self.setUpPassedTrainingProgress(
+            self.person, self.training_requirement, self.event
+        )
+        # Act
+        result = instructor_training_completed_not_badged_strategy(self.person)
+        # Assert
+        self.assertEqual(result, StrategyEnum.CREATE)
+
+    def test_strategy_update(self) -> None:
+        # Arrange
+        self.setUpPassedTrainingProgress(
+            self.person, self.training_requirement, self.event
+        )
+        self.setUpScheduledEmail(self.person)
+        # Act
+        result = instructor_training_completed_not_badged_strategy(self.person)
+        # Assert
+        self.assertEqual(result, StrategyEnum.UPDATE)
+
+    def test_strategy_remove(self) -> None:
+        # Arrange
+        self.setUpScheduledEmail(self.person)
+        # Act
+        result = instructor_training_completed_not_badged_strategy(self.person)
+        # Assert
+        self.assertEqual(result, StrategyEnum.REMOVE)
+
+    def test_strategy_noop(self) -> None:
+        # Act
+        result = instructor_training_completed_not_badged_strategy(self.person)
+        # Assert
+        self.assertEqual(result, StrategyEnum.NOOP)
+
+
+class TestRunInstructorTrainingCompletedNotBadgedStrategy(TestCase):
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "instructor_training_completed_not_badged_signal",
+    )
+    def test_strategy_calls_create_signal(
+        self,
+        mock_instructor_training_completed_not_badged_signal: MagicMock,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.CREATE
+        request = RequestFactory().get("/")
+        person = Person()
+        training_completed_date = date(2023, 10, 29)
+
+        # Act
+        run_instructor_training_completed_not_badged_strategy(
+            strategy, request, person, training_completed_date
+        )
+
+        # Assert
+        mock_instructor_training_completed_not_badged_signal.send.assert_called_once_with(  # noqa: E501
+            sender=person,
+            request=request,
+            person=person,
+            training_completed_date=training_completed_date,
+        )
+
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "instructor_training_completed_not_badged_update_signal",
+    )
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "find_training_completion_date",
+    )
+    def test_strategy_calls_update_signal(
+        self,
+        mock_find_training_completion_date: MagicMock,
+        mock_instructor_training_completed_not_badged_update_signal: MagicMock,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.UPDATE
+        request = RequestFactory().get("/")
+        person = Person()
+        training_completed_date = None
+        # Mock `find_training_completion_date` is needed when
+        # `training_completed_date` is not provided.
+        mock_find_training_completion_date.return_value = date(2023, 10, 29)
+
+        # Act
+        run_instructor_training_completed_not_badged_strategy(
+            strategy, request, person, training_completed_date
+        )
+
+        # Assert
+        mock_instructor_training_completed_not_badged_update_signal.send.assert_called_once_with(  # noqa: E501
+            sender=person,
+            request=request,
+            person=person,
+            training_completed_date=mock_find_training_completion_date.return_value,
+        )
+
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "instructor_training_completed_not_badged_remove_signal",
+    )
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "find_training_completion_date",
+    )
+    def test_strategy_calls_remove_signal(
+        self,
+        mock_find_training_completion_date: MagicMock,
+        mock_instructor_training_completed_not_badged_remove_signal: MagicMock,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.REMOVE
+        request = RequestFactory().get("/")
+        person = Person()
+        training_completed_date = None
+        # Mock `find_training_completion_date` is needed when
+        # `training_completed_date` is not provided.
+        mock_find_training_completion_date.return_value = date(2023, 10, 29)
+
+        # Act
+        run_instructor_training_completed_not_badged_strategy(
+            strategy, request, person, training_completed_date
+        )
+
+        # Assert
+        mock_instructor_training_completed_not_badged_remove_signal.send.assert_called_once_with(  # noqa: E501
+            sender=person,
+            request=request,
+            person=person,
+            training_completed_date=mock_find_training_completion_date.return_value,
+        )
+
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged.logger",
+    )
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "instructor_training_completed_not_badged_signal",
+    )
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "instructor_training_completed_not_badged_update_signal",
+    )
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "instructor_training_completed_not_badged_remove_signal",
+    )
+    def test_invalid_strategy_no_signal_called(
+        self,
+        mock_instructor_training_completed_not_badged_remove_signal: MagicMock,
+        mock_instructor_training_completed_not_badged_update_signal: MagicMock,
+        mock_instructor_training_completed_not_badged_signal: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.NOOP
+        request = RequestFactory().get("/")
+        person = Person()
+        training_completed_date = date(2023, 10, 29)
+
+        # Act
+        run_instructor_training_completed_not_badged_strategy(
+            strategy, request, person, training_completed_date
+        )
+
+        # Assert
+        mock_instructor_training_completed_not_badged_signal.send.assert_not_called()
+        mock_instructor_training_completed_not_badged_update_signal.send.assert_not_called()  # noqa: E501
+        mock_instructor_training_completed_not_badged_remove_signal.send.assert_not_called()  # noqa: E501
+        mock_logger.debug.assert_called_once_with(
+            f"Strategy {strategy} for {person} is a no-op"
+        )
+
+    def test_invalid_strategy(self) -> None:
+        # Arrange
+        strategy = MagicMock()
+        request = RequestFactory().get("/")
+        person = Person()
+        training_completed_date = date(2023, 10, 29)
+
+        # Act & Assert
+        with self.assertRaisesMessage(
+            EmailStrategyException, f"Unknown strategy {strategy}"
+        ):
+            run_instructor_training_completed_not_badged_strategy(
+                strategy, request, person, training_completed_date
+            )
+
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "find_training_completion_date",
+    )
+    def test_missing_training_completed_date__multiple_training_progresses(
+        self,
+        mock_find_training_completion_date: MagicMock,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.CREATE
+        request = RequestFactory().get("/")
+        person = Person()
+        training_completed_date = None
+        mock_find_training_completion_date.side_effect = (
+            TrainingProgress.MultipleObjectsReturned
+        )
+
+        # Act & Assert
+        with self.assertRaisesMessage(
+            EmailStrategyException,
+            "Unable to determine training completion date. Person "
+            "has multiple passed training progresses.",
+        ):
+            run_instructor_training_completed_not_badged_strategy(
+                strategy, request, person, training_completed_date
+            )
+
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "find_training_completion_date",
+    )
+    def test_missing_training_completed_date__no_training_progress(
+        self,
+        mock_find_training_completion_date: MagicMock,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.CREATE
+        request = RequestFactory().get("/")
+        person = Person()
+        training_completed_date = None
+        mock_find_training_completion_date.side_effect = TrainingProgress.DoesNotExist
+
+        # Act & Assert
+        with self.assertRaisesMessage(
+            EmailStrategyException,
+            "Unable to determine training completion date. Person doesn't have "
+            "a passed training progress.",
+        ):
+            run_instructor_training_completed_not_badged_strategy(
+                strategy, request, person, training_completed_date
+            )
+
+    @patch(
+        "emails.actions.instructor_training_completed_not_badged."
+        "find_training_completion_date",
+    )
+    def test_missing_training_completed_date__issue_with_event_or_event_date(
+        self,
+        mock_find_training_completion_date: MagicMock,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.CREATE
+        request = RequestFactory().get("/")
+        person = Person()
+        training_completed_date = None
+        mock_find_training_completion_date.side_effect = TrainingCompletionDateException
+
+        # Act & Assert
+        with self.assertRaisesMessage(
+            EmailStrategyException,
+            "Unable to determine training completion date. Probably the person has "
+            "training progress not linked to an event, or the event doesn't have "
+            "an end date.",
+        ):
+            run_instructor_training_completed_not_badged_strategy(
+                strategy, request, person, training_completed_date
+            )

--- a/amy/emails/tests/actions/test_instructor_training_completed_not_badged_strategy.py
+++ b/amy/emails/tests/actions/test_instructor_training_completed_not_badged_strategy.py
@@ -192,6 +192,17 @@ class TestInstructorTrainingCompletedNotBadgedStrategy(TestCase):
         # Assert
         self.assertEqual(result, StrategyEnum.NOOP)
 
+    def test_strategy_noop_when_previous_successful_email_exists(self) -> None:
+        # Arrange
+        self.setUpPassedTrainingProgress(
+            self.person, self.training_requirement, self.event
+        )
+        self.setUpScheduledEmail(self.person, state=ScheduledEmailStatus.SUCCEEDED)
+        # Act
+        result = instructor_training_completed_not_badged_strategy(self.person)
+        # Assert
+        self.assertEqual(result, StrategyEnum.NOOP)
+
 
 class TestRunInstructorTrainingCompletedNotBadgedStrategy(TestCase):
     @patch(

--- a/amy/emails/tests/test_template_tags.py
+++ b/amy/emails/tests/test_template_tags.py
@@ -1,44 +1,7 @@
-from unittest.mock import MagicMock
-
 from django.test import TestCase
 
 from emails.models import ScheduledEmailStatus
-from emails.templatetags.emails import (
-    allowed_actions_for_status,
-    model_documentation_link,
-)
-
-
-class TestModelDocumentationLink(TestCase):
-    def test_model_documentation_link__valid_model(self) -> None:
-        # Arrange
-        # Real models are replaced with their metaclass BaseModel, so the tests don't
-        # work with real models and instead mocks are used.
-        model = MagicMock()
-        model.__class__.__name__ = "Person"
-
-        # Act
-        link = model_documentation_link(model)
-
-        # Assert
-        self.assertEqual(
-            link,
-            "https://carpentries.github.io/amy/amy_database_structure/#persons",
-        )
-
-    def test_model_documentation_link__invalid_model(self) -> None:
-        # Arrange
-        # Real models are replaced with their metaclass BaseModel, so the tests don't
-        # work with real models and instead mocks are used.
-        model = MagicMock()
-        # Badge is not in the mapping yet
-        model.__class__.__name__ = "Badge"
-
-        # Act
-        link = model_documentation_link(model)
-
-        # Assert
-        self.assertEqual(link, "")
+from emails.templatetags.emails import allowed_actions_for_status
 
 
 class TestAllowedActionsForStatusTag(TestCase):

--- a/amy/emails/tests/test_views.py
+++ b/amy/emails/tests/test_views.py
@@ -85,7 +85,7 @@ class TestEmailTemplateDetails(TestBase):
         self.assertEqual(
             rv.context["body_context_annotations"],
             {
-                "person": Person,
+                "person": repr(Person),
             },
         )
 
@@ -147,7 +147,7 @@ class TestEmailTemplateUpdateView(TestBase):
         self.assertEqual(
             rv.context["body_context_annotations"],
             {
-                "person": Person,
+                "person": repr(Person),
             },
         )
 

--- a/amy/emails/types.py
+++ b/amy/emails/types.py
@@ -100,7 +100,7 @@ class InstructorTrainingApproachingContext(TypedDict):
 class InstructorTrainingCompletedNotBadgedKwargs(TypedDict):
     request: HttpRequest
     person: Person
-    training_completed_date: date
+    training_completed_date: date | None
 
 
 class InstructorTrainingCompletedNotBadgedContext(TypedDict):

--- a/amy/emails/types.py
+++ b/amy/emails/types.py
@@ -5,7 +5,7 @@ from typing import TypedDict
 from django.http import HttpRequest
 
 from recruitment.models import InstructorRecruitmentSignup
-from workshops.models import Award, Event, Person
+from workshops.models import Award, Event, Person, TrainingProgress
 
 
 class InstructorBadgeAwardedKwargs(TypedDict):
@@ -105,6 +105,9 @@ class InstructorTrainingCompletedNotBadgedKwargs(TypedDict):
 
 class InstructorTrainingCompletedNotBadgedContext(TypedDict):
     person: Person
+    passed_requirements: list[TrainingProgress]
+    missing_requirements: list[TrainingProgress]
+    training_completed_date: date | None
 
 
 class StrategyEnum(StrEnum):

--- a/amy/emails/types.py
+++ b/amy/emails/types.py
@@ -5,7 +5,7 @@ from typing import TypedDict
 from django.http import HttpRequest
 
 from recruitment.models import InstructorRecruitmentSignup
-from workshops.models import Award, Event, Person, TrainingProgress
+from workshops.models import Award, Event, Person, TrainingProgress, TrainingRequirement
 
 
 class InstructorBadgeAwardedKwargs(TypedDict):
@@ -106,7 +106,8 @@ class InstructorTrainingCompletedNotBadgedKwargs(TypedDict):
 class InstructorTrainingCompletedNotBadgedContext(TypedDict):
     person: Person
     passed_requirements: list[TrainingProgress]
-    missing_requirements: list[TrainingProgress]
+    not_passed_requirements: list[TrainingProgress]
+    not_graded_requirements: list[TrainingRequirement]
     training_completed_date: date
 
 

--- a/amy/emails/types.py
+++ b/amy/emails/types.py
@@ -97,6 +97,16 @@ class InstructorTrainingApproachingContext(TypedDict):
     instructors: list[Person]
 
 
+class InstructorTrainingCompletedNotBadgedKwargs(TypedDict):
+    request: HttpRequest
+    person: Person
+    training_completed_date: date
+
+
+class InstructorTrainingCompletedNotBadgedContext(TypedDict):
+    person: Person
+
+
 class StrategyEnum(StrEnum):
     CREATE = "create"
     UPDATE = "update"

--- a/amy/emails/types.py
+++ b/amy/emails/types.py
@@ -100,14 +100,14 @@ class InstructorTrainingApproachingContext(TypedDict):
 class InstructorTrainingCompletedNotBadgedKwargs(TypedDict):
     request: HttpRequest
     person: Person
-    training_completed_date: date | None
+    training_completed_date: date
 
 
 class InstructorTrainingCompletedNotBadgedContext(TypedDict):
     person: Person
     passed_requirements: list[TrainingProgress]
     missing_requirements: list[TrainingProgress]
-    training_completed_date: date | None
+    training_completed_date: date
 
 
 class StrategyEnum(StrEnum):

--- a/amy/emails/utils.py
+++ b/amy/emails/utils.py
@@ -39,7 +39,8 @@ def combine_date_with_current_utc_time(date: date) -> datetime:
 
 def shift_date_and_apply_current_utc_time(date: date, offset: timedelta) -> datetime:
     """Return timezone-aware datetime object combining current time in UTC
-    with a given date shifted by offset (timedelta)."""
+    with a given date shifted by offset (timedelta).
+    Time component of the offset is discarded."""
     date_shifted = date + offset
     return combine_date_with_current_utc_time(date_shifted)
 

--- a/amy/emails/utils.py
+++ b/amy/emails/utils.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta
+from functools import partial
 import logging
 from typing import Iterable, cast
 
@@ -29,12 +30,26 @@ def immediate_action() -> datetime:
     return timezone.now() + timedelta(hours=1)
 
 
-def one_month_before(date: date) -> datetime:
-    """Timezone-aware datetime object for action scheduled one month before, uses
-    current time in UTC as time component of the returned datetime object."""
+def combine_date_with_current_utc_time(date: date) -> datetime:
+    """Return timezone-aware datetime object combining current time in UTC
+    with a given date."""
     current_time_utc = datetime.now(timezone.utc).timetz()
-    date_shifted = date - timedelta(days=30)
-    return datetime.combine(date_shifted, current_time_utc)
+    return datetime.combine(date, current_time_utc)
+
+
+def shift_date_and_apply_current_utc_time(date: date, offset: timedelta) -> datetime:
+    """Return timezone-aware datetime object combining current time in UTC
+    with a given date shifted by offset (timedelta)."""
+    date_shifted = date + offset
+    return combine_date_with_current_utc_time(date_shifted)
+
+
+one_month_before = partial(
+    shift_date_and_apply_current_utc_time, offset=-timedelta(days=30)
+)
+two_months_after = partial(
+    shift_date_and_apply_current_utc_time, offset=timedelta(days=60)
+)
 
 
 def messages_missing_recipients(request: HttpRequest, signal: str) -> None:

--- a/amy/emails/views.py
+++ b/amy/emails/views.py
@@ -63,7 +63,9 @@ class EmailTemplateDetails(OnlyForAdminsMixin, FlaggedViewMixin, AMYDetailView):
         context["body_context_annotations"] = {}
         if signal:
             context["body_context_type"] = signal.context_type
-            context["body_context_annotations"] = signal.context_type.__annotations__
+            context["body_context_annotations"] = {
+                k: repr(v) for k, v in signal.context_type.__annotations__.items()
+            }
         return context
 
 
@@ -96,7 +98,9 @@ class EmailTemplateUpdate(OnlyForAdminsMixin, FlaggedViewMixin, AMYUpdateView):
         context["body_context_annotations"] = {}
         if signal:
             context["body_context_type"] = signal.context_type
-            context["body_context_annotations"] = signal.context_type.__annotations__
+            context["body_context_annotations"] = {
+                k: repr(v) for k, v in signal.context_type.__annotations__.items()
+            }
         return context
 
 

--- a/amy/scripts/seed_emails.py
+++ b/amy/scripts/seed_emails.py
@@ -144,6 +144,24 @@ EMAIL_TEMPLATES: list[EmailTemplateDef] = [
             "Your training is one month away. Please be sure to do the following... "
         ),
     ),
+    EmailTemplateDef(
+        active=True,
+        id=UUID("17234a5e-a15e-4314-a328-783f917d6630"),
+        name="Instructor Training completed but not yet badged",
+        signal=SignalNameEnum.instructor_training_completed_not_badged,
+        from_header="instructor.training@carpentries.org",
+        reply_to_header="",
+        cc_header=["instructor.training@carpentries.org"],
+        bcc_header=[],
+        subject="Carpentries Instructor Training Deadline Approaching",
+        body=(
+            "Hi, {{ person.personal }} {{ person.family }}. "
+            "Thank you for joining the Carpentries instructor training on (date). "
+            "You have completed the following steps towards certification "
+            "(passed requirements). "
+            "Here's what you have left to do: (missing requirements)."
+        ),
+    ),
 ]
 
 

--- a/amy/templates/emails/email_template_detail.html
+++ b/amy/templates/emails/email_template_detail.html
@@ -1,5 +1,4 @@
 {% extends "base_nav.html" %}
-{% load emails %}
 
 {% block content %}
 
@@ -102,7 +101,7 @@
     <td colspan="2">
       <ul>
       {% for key, value in body_context_annotations.items %}
-      <li><code>{{ key }}</code>: {{ value|model_documentation_link|urlize }}</li>
+      <li><code>{{ key }}</code>: {{ value }}</li>
       {% endfor %}
       </ul>
     </td>

--- a/amy/templates/emails/email_template_edit.html
+++ b/amy/templates/emails/email_template_edit.html
@@ -1,7 +1,6 @@
 {% extends "base_nav.html" %}
 
 {% load crispy_forms_tags %}
-{% load emails %}
 
 {% block content %}
 
@@ -14,7 +13,7 @@
   <div class="col-12 col-lg-10">
     <ul>
     {% for key, value in body_context_annotations.items %}
-    <li><code>{{ key }}</code>: {{ value|model_documentation_link|urlize }}</li>
+    <li><code>{{ key }}</code>: {{ value }}</li>
     {% endfor %}
     </ul>
   </div>

--- a/amy/trainings/views.py
+++ b/amy/trainings/views.py
@@ -116,7 +116,7 @@ class TrainingProgressUpdate(RedirectSupportMixin, OnlyForAdminsMixin, AMYUpdate
         except EmailStrategyException as exc:
             messages.error(
                 self.request,
-                f"Error when running instructor training completed strategy. {exc}",
+                f"Error when creating or updating scheduled email. {exc}",
             )
         return super().form_valid(form)
 

--- a/amy/trainings/views.py
+++ b/amy/trainings/views.py
@@ -4,6 +4,10 @@ from django.db.models import Case, Count, F, IntegerField, Prefetch, Sum, When
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
 
+from emails.actions.instructor_training_completed_not_badged import (
+    instructor_training_completed_not_badged_strategy,
+    run_instructor_training_completed_not_badged_strategy,
+)
 from trainings.filters import TraineeFilter
 from trainings.forms import BulkAddTrainingProgressForm, TrainingProgressForm
 from trainings.utils import raise_validation_error_if_no_learner_task
@@ -74,16 +78,55 @@ class TrainingProgressCreate(
         context["form"].helper = context["form"].create_helper
         return context
 
+    def form_valid(self, form):
+        person = form.cleaned_data["trainee"]
+        event = form.cleaned_data["event"]
+        result = super().form_valid(form)
+        run_instructor_training_completed_not_badged_strategy(
+            instructor_training_completed_not_badged_strategy(person),
+            request=self.request,
+            person=person,
+            training_completed_date=event.end if event else None,
+        )
+        return result
+
 
 class TrainingProgressUpdate(RedirectSupportMixin, OnlyForAdminsMixin, AMYUpdateView):
     model = TrainingProgress
     form_class = TrainingProgressForm
     template_name = "trainings/trainingprogress_form.html"
 
+    def form_valid(self, form):
+        person = form.cleaned_data["trainee"]
+        event = form.cleaned_data["event"]
+        run_instructor_training_completed_not_badged_strategy(
+            instructor_training_completed_not_badged_strategy(person),
+            request=self.request,
+            person=person,
+            training_completed_date=event.end if event else None,
+        )
+        return super().form_valid(form)
+
 
 class TrainingProgressDelete(RedirectSupportMixin, OnlyForAdminsMixin, AMYDeleteView):
     model = TrainingProgress
     success_url = reverse_lazy("all_trainees")
+    object: TrainingProgress
+
+    def before_delete(self, *args, **kwargs):
+        """Save for use in `after_delete` method."""
+        self._person = self.object.trainee
+        self._event = self.object.event
+
+    def after_delete(self, *args, **kwargs):
+        person = self._person
+        event = self._event
+        run_instructor_training_completed_not_badged_strategy(
+            instructor_training_completed_not_badged_strategy(person),
+            request=self.request,
+            person=person,
+            training_completed_date=event.end if event else None,
+        )
 
 
 def all_trainees_queryset():
@@ -144,6 +187,14 @@ def all_trainees(request):
                     )
                     progress.full_clean()
                     progress.save()
+
+                    run_instructor_training_completed_not_badged_strategy(
+                        instructor_training_completed_not_badged_strategy(trainee),
+                        request=request,
+                        person=trainee,
+                        training_completed_date=event.end if event else None,
+                    )
+
                 except ValidationError as e:
                     unique_constraint_message = (
                         "Training progress with this Trainee "

--- a/amy/trainings/views.py
+++ b/amy/trainings/views.py
@@ -106,6 +106,7 @@ class TrainingProgressUpdate(RedirectSupportMixin, OnlyForAdminsMixin, AMYUpdate
     def form_valid(self, form):
         person = form.cleaned_data["trainee"]
         event = form.cleaned_data["event"]
+        result = super().form_valid(form)
         try:
             run_instructor_training_completed_not_badged_strategy(
                 instructor_training_completed_not_badged_strategy(person),
@@ -118,7 +119,7 @@ class TrainingProgressUpdate(RedirectSupportMixin, OnlyForAdminsMixin, AMYUpdate
                 self.request,
                 f"Error when creating or updating scheduled email. {exc}",
             )
-        return super().form_valid(form)
+        return result
 
 
 class TrainingProgressDelete(RedirectSupportMixin, OnlyForAdminsMixin, AMYDeleteView):


### PR DESCRIPTION
This fixes #2540.
Add "Instructor Training Completed but not yet badged" email.

This email will be triggered when trainee is given a pass mark on training requirement.
It will update with other training requirements being awarded, and once all requirements have been passed it will cancel.

The email is scheduled to run 2 months after the training has completed (trainee's training requirement event's end date).


From developer's standpoint there's a few small differences between this action and other emails:
1. strategy run function, `run_instructor_training_completed_not_badged_strategy`, is also responsible for getting trainee's training completion date (it may not be available when marking as "passed" other requirements than the training requirement)
2. receiver classes inheriting from `BaseAction`, `BaseActionUpdate` and `BaseActionCancel` now share the same functions (called `get_scheduled_at`, `get_context`, `get_generic_relation_object`, `get_recipients`)
3. I eliminated some repeated tests for receiver classes, since they are well-tested by tests for the base classes; I kept integration tests.