### PR TITLE
Update autoresponses with member codes

### DIFF
--- a/amy/extforms/tests/test_training_request_form.py
+++ b/amy/extforms/tests/test_training_request_form.py
@@ -1,5 +1,6 @@
 from datetime import date, timedelta
 
+from django.conf import settings
 from django.core import mail
 from django.forms import CheckboxInput, HiddenInput
 from django.test import override_settings
@@ -13,8 +14,9 @@ from workshops.tests.base import TestBase
 
 class TestTrainingRequestForm(TestBase):
     INVALID_MEMBER_CODE_ERROR = "This code is invalid."
-    MEMBER_CODE_OVERRIDE_EMAIL_TEXT = (
-        "Continue with registration code marked as invalid"
+    MEMBER_CODE_OVERRIDE_LABEL = "Continue with registration code marked as invalid"
+    MEMBER_CODE_OVERRIDE_EMAIL_WARNING = (
+        "A member of our team will check the code and follow up with you"
     )
 
     def setUp(self):
@@ -111,6 +113,8 @@ class TestTrainingRequestForm(TestBase):
         # Arrange
         email = self.data.get("email")
         self.passCaptcha(self.data)
+        # before tests, check if the template invalid string exists
+        self.assertTrue(settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"])
 
         # Act
         rv = self.client.post(reverse("training_request"), self.data, follow=True)
@@ -126,7 +130,11 @@ class TestTrainingRequestForm(TestBase):
         self.assertEqual(msg.to, [email])
         self.assertEqual(msg.subject, TrainingRequestCreate.autoresponder_subject)
         self.assertIn("A copy of your request", msg.body)
-        self.assertNotIn(self.MEMBER_CODE_OVERRIDE_EMAIL_TEXT, msg.body)
+        self.assertNotIn(self.MEMBER_CODE_OVERRIDE_LABEL, msg.body)
+        self.assertNotIn(self.MEMBER_CODE_OVERRIDE_EMAIL_WARNING, msg.body)
+        self.assertNotIn(
+            settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"], msg.body
+        )
 
     def test_invalid_request_not_added(self):
         # Arrange
@@ -413,6 +421,8 @@ class TestTrainingRequestForm(TestBase):
         self.data["member_code"] = "valid123"
         self.data["member_code_override"] = True
         self.passCaptcha(self.data)
+        # before tests, check if the template invalid string exists
+        self.assertTrue(settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"])
 
         # Act
         rv = self.client.post(reverse("training_request"), data=self.data, follow=True)
@@ -427,7 +437,11 @@ class TestTrainingRequestForm(TestBase):
         # Test that the sender was emailed with correct content
         self.assertEqual(len(mail.outbox), 1)
         msg = mail.outbox[0]
-        self.assertNotIn(self.MEMBER_CODE_OVERRIDE_EMAIL_TEXT, msg.body)
+        self.assertNotIn(self.MEMBER_CODE_OVERRIDE_LABEL, msg.body)
+        self.assertNotIn(self.MEMBER_CODE_OVERRIDE_EMAIL_WARNING, msg.body)
+        self.assertNotIn(
+            settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"], msg.body
+        )
 
     def test_member_code_validation__code_invalid_override_full_request(self):
         """Sent email should include the member_code_override field if used."""
@@ -436,6 +450,8 @@ class TestTrainingRequestForm(TestBase):
         self.data["member_code"] = "invalid"
         self.data["member_code_override"] = True
         self.passCaptcha(self.data)
+        # before tests, check if the template invalid string exists
+        self.assertTrue(settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"])
 
         # Act
         rv = self.client.post(reverse("training_request"), data=self.data, follow=True)
@@ -450,4 +466,8 @@ class TestTrainingRequestForm(TestBase):
         # Test that the sender was emailed with correct content
         self.assertEqual(len(mail.outbox), 1)
         msg = mail.outbox[0]
-        self.assertIn(self.MEMBER_CODE_OVERRIDE_EMAIL_TEXT, msg.body)
+        self.assertIn(self.MEMBER_CODE_OVERRIDE_LABEL, msg.body)
+        self.assertIn(self.MEMBER_CODE_OVERRIDE_EMAIL_WARNING, msg.body)
+        self.assertNotIn(
+            settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"], msg.body
+        )

--- a/amy/templates/includes/trainingrequest_details.html
+++ b/amy/templates/includes/trainingrequest_details.html
@@ -26,8 +26,10 @@
         <td>{{ object.get_review_process_display|default:"&mdash;" }}</td></tr>
     <tr><th>Registration Code:</th>
         <td>{{ object.member_code|default:"&mdash;" }}</td></tr>
+{% if admin or object.member_code_override %}
     <tr><th>Continue with registration code marked as invalid:</th>
         <td>{{ object.member_code_override|yesno }}</td></tr>
+{% endif %}
     <tr><th>Personal name:</th>
         <td>{{ object.personal }}</td></tr>
     <tr><th>Middle name:</th>

--- a/amy/templates/mailing/training_request.html
+++ b/amy/templates/mailing/training_request.html
@@ -50,5 +50,15 @@ In the meantime, please get involved!
     The Carpentries Instructor Training Team
 </p>
 
+<hr>
+
+A copy of your request is included below for your reference.
+
+{% if object.member_code_override %}
+<p>
+    <strong>Warning:</strong> Your registration code "{object.member_code}" seems to be invalid.
+    A member of our team will check the code and follow up with you if there are any problems that require your attention.
+</p>
+{% endif %}
 
 {% include "includes/trainingrequest_details.html" with admin=False object=object %}

--- a/amy/templates/mailing/training_request.html
+++ b/amy/templates/mailing/training_request.html
@@ -56,8 +56,7 @@ A copy of your request is included below for your reference.
 
 {% if object.member_code_override %}
 <p>
-    <strong>Warning:</strong> Your registration code "{object.member_code}" seems to be invalid.
-    A member of our team will check the code and follow up with you if there are any problems that require your attention.
+    <strong>Warning:</strong> Your registration code "{{object.member_code}}" seems to be invalid. This may be due to a typo, an expired code, a code that has not yet been activated, or a code with no training seats remaining. A member of our team will check the code and follow up with you if there are any problems that require your attention.
 </p>
 {% endif %}
 

--- a/amy/templates/mailing/training_request.html
+++ b/amy/templates/mailing/training_request.html
@@ -16,7 +16,7 @@
 
 
 <p>
-    We receive hundreds of applications, and we cannot provide no-cost training for every applicant. Please, don't let that discourage you! We'd like to help you bring workshops and instructor training to your organisation. In the meantime, please get involved!
+    We receive hundreds of applications, and we cannot provide no-cost training for every applicant. Please, don't let that discourage you! We'd like to help you bring workshops and instructor training to your organisation.
 </p>
 
 In the meantime, please get involved!

--- a/amy/templates/mailing/training_request.txt
+++ b/amy/templates/mailing/training_request.txt
@@ -27,6 +27,11 @@ The Carpentries Instructor Training Team
 
 A copy of your request is included below for your reference.
 
+{% if object.member_code_override %}
+**Warning:** Your registration code "{object.member_code}" seems to be invalid.
+A member of our team will check the code and follow up with you if there are any problems that require your attention.
+{% endif %}
+
 Submission date: {{ object.created_at }}
 Application Type: {{ object.get_review_process_display|default:"---" }}
 Registration Code: {{ object.member_code|default:"&mdash;" }}

--- a/amy/templates/mailing/training_request.txt
+++ b/amy/templates/mailing/training_request.txt
@@ -7,7 +7,7 @@ Open Training applications are placed in an application queue to be considered f
 
 If you have a specific need to be trained sooner (e.g. an upcoming workshop) please let us know. Multiple applicants from a single institution generally will not be invited at once, but may be accepted individually over time. To more rapidly build an Instructor community at your institution, consider becoming a Member. For more information see: https://carpentries.org/membership/ or get in touch with memberships@carpentries.org to learn more about how we can help you make the case at your organisation.
 
-We receive hundreds of applications, and we cannot provide no-cost training for every applicant. Please, don't let that discourage you! We'd like to help you bring workshops and instructor training to your organisation. In the meantime, please get involved!
+We receive hundreds of applications, and we cannot provide no-cost training for every applicant. Please, don't let that discourage you! We'd like to help you bring workshops and instructor training to your organisation.
 
 In the meantime, please get involved!
 Join our discussion email list: https://carpentries.topicbox.com/groups/discuss
@@ -30,6 +30,9 @@ A copy of your request is included below for your reference.
 Submission date: {{ object.created_at }}
 Application Type: {{ object.get_review_process_display|default:"---" }}
 Registration Code: {{ object.member_code|default:"&mdash;" }}
+{% if object.member_code_override %}
+Continue with registration code marked as invalid: {{object.member_code_override|yesno}}
+{% endif %}
 Person: {{object.personal}} {{object.middle}} {{object.family}} &lt;{{object.email}}&gt;
 Github: {{ object.github|default:"---" }}
 Occupation: {{ object.get_occupation_display }} {{ object.occupation_other }}

--- a/amy/templates/mailing/training_request.txt
+++ b/amy/templates/mailing/training_request.txt
@@ -28,8 +28,7 @@ The Carpentries Instructor Training Team
 A copy of your request is included below for your reference.
 
 {% if object.member_code_override %}
-**Warning:** Your registration code "{object.member_code}" seems to be invalid.
-A member of our team will check the code and follow up with you if there are any problems that require your attention.
+**Warning:** Your registration code "{{object.member_code}}" seems to be invalid. This may be due to a typo, an expired code, a code that has not yet been activated, or a code with no training seats remaining. A member of our team will check the code and follow up with you if there are any problems that require your attention.
 {% endif %}
 
 Submission date: {{ object.created_at }}

--- a/amy/templates/mailing/workshoprequest.txt
+++ b/amy/templates/mailing/workshoprequest.txt
@@ -32,6 +32,7 @@ instructors in such short time.
 Submission date: {{ object.created_at }}
 Person: {{ object.personal }} {{ object.family }} &lt;{{ object.email }}&gt;
 Institution: {% if object.institution %}{{ object.institution }}{% else %}{{ object.institution_other_name }}{% endif %}{% if object.institution_department %}, {{ object.institution_department }}{% endif %}
+Member registration code: {{ object.member_code|default:"&mdash;" }}
 Workshop location: {{ object.location }}
 Country: {{ object.country.name }}
 Requested workshop types: {% for type in object.requested_workshop_types.all %}{{ type }}{% if not forloop.last %}, {% endif %}{% endfor %}


### PR DESCRIPTION
- adds `member_code` field to the WRF autoresponse
- adds `member_code_override` field to the TR autoresponse if it is set to `True` (i.e. if it wasn't used, don't include it as it may not have been displayed at all)
- adds a warning to the TR autoresponse if `member_code_override=True` (i.e. if the member code is invalid)