### PR TITLE
Remove nonexistent field from knowledge domain lookup

### DIFF
--- a/amy/workshops/lookups.py
+++ b/amy/workshops/lookups.py
@@ -332,20 +332,11 @@ class LanguageLookupView(LoginNotRequiredMixin, AutoResponseView):
 
 
 class KnowledgeDomainLookupView(OnlyForAdminsNoRedirectMixin, AutoResponseView):
-    def dispatch(self, request, *args, **kwargs):
-        self.subtag = "subtag" in request.GET.keys()
-        return super().dispatch(request, *args, **kwargs)
-
     def get_queryset(self):
         results = models.KnowledgeDomain.objects.all()
 
         if self.term:
-            results = results.filter(
-                Q(name__icontains=self.term) | Q(subtag__icontains=self.term)
-            )
-
-            if self.subtag:
-                return results.filter(subtag__iexact=self.term)
+            results = results.filter(Q(name__icontains=self.term))
 
         results = results.annotate(person_count=Count("person")).order_by(
             "-person_count"

--- a/amy/workshops/tests/test_lookups.py
+++ b/amy/workshops/tests/test_lookups.py
@@ -12,6 +12,7 @@ from workshops.lookups import (
     EventLookupForAwardsView,
     EventLookupView,
     GenericObjectLookupView,
+    KnowledgeDomainLookupView,
     TTTEventLookupView,
     urlpatterns,
 )
@@ -19,6 +20,7 @@ from workshops.models import (
     Award,
     Badge,
     Event,
+    KnowledgeDomain,
     Lesson,
     Person,
     Role,
@@ -54,6 +56,35 @@ class TestLookups(TestBase):
         for pattern in self.urlpatterns:
             rv = self.client.get(reverse(pattern.name))
             self.assertEqual(rv.status_code, 200, pattern.name)  # OK
+
+
+class TestKnowledgeDomainLookupView(TestBase):
+    def setUpView(self, term: str = "") -> KnowledgeDomainLookupView:
+        # path doesn't matter
+        request = RequestFactory().get("/")
+        view = KnowledgeDomainLookupView(request=request, term=term)
+        return view
+
+    def test_get_queryset_no_term(self):
+        # Arrange
+        view = self.setUpView()
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, KnowledgeDomain.objects.all(), ordered=False)
+
+    def test_get_queryset_simple_term(self):
+        # Arrange
+        term = "ed"
+        view = self.setUpView(term=term)
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(
+            queryset,
+            KnowledgeDomain.objects.filter(name__icontains=term),
+            ordered=False,
+        )
 
 
 class TestAwardLookupView(TestBase):


### PR DESCRIPTION
The `KnowledgeDomainLookupView` filters on the `subtag` field, which doesn't actually exist on the `KnowledgeDomain` model. 
(I think this might have been copied across from the equivalent view for the `Language` model.)

This lookup is only used in one view, and it doesn't get much use, so this fix can go into the next regular release.
