### PR TITLE
Never hide training requests with invalid code when filtering

### DIFF
--- a/amy/extrequests/filters.py
+++ b/amy/extrequests/filters.py
@@ -68,7 +68,7 @@ class TrainingRequestFilter(AMYFilterSet):
 
     invalid_member_code = django_filters.BooleanFilter(
         label="Member code marked as invalid",
-        field_name="member_code_override",
+        method="filter_member_code_override",
         widget=widgets.CheckboxInput,
     )
 
@@ -155,6 +155,15 @@ class TrainingRequestFilter(AMYFilterSet):
     def filter_non_null_manual_score(self, queryset, name, manual_score):
         if manual_score:
             return queryset.filter(score_manual__isnull=False)
+        return queryset
+
+    def filter_member_code_override(
+        self, queryset: QuerySet, name: str, only_overrides: bool
+    ) -> QuerySet:
+        """If checked, only show requests where the member code has been
+        marked as invalid. Otherwise, show all requests."""
+        if only_overrides:
+            return queryset.filter(member_code_override=True)
         return queryset
 
 

--- a/amy/extrequests/filters.py
+++ b/amy/extrequests/filters.py
@@ -90,6 +90,7 @@ class TrainingRequestFilter(AMYFilterSet):
         fields = [
             "search",
             "member_code",
+            "invalid_member_code",
             "state",
             "matched",
             "affiliation",

--- a/amy/extrequests/tests/test_filters.py
+++ b/amy/extrequests/tests/test_filters.py
@@ -274,7 +274,7 @@ class TestTrainingRequestFilter(TestBase):
         # Assert
         self.assertQuerysetEqual(result, [self.request_blackwidow])
 
-    def test_filter_invalid_member_code(self):
+    def test_filter_invalid_member_code__true(self):
         # Arrange
         filter_name = "invalid_member_code"
         value = True
@@ -284,6 +284,17 @@ class TestTrainingRequestFilter(TestBase):
 
         # Assert
         self.assertQuerysetEqual(result, [self.request_blackwidow])
+
+    def test_filter_invalid_member_code__false(self):
+        # Arrange
+        filter_name = "invalid_member_code"
+        value = False
+
+        # Act
+        result = self.filterset.filters[filter_name].filter(self.qs, value)
+
+        # Assert
+        self.assertQuerysetEqual(result, TrainingRequest.objects.all())
 
     def test_filter_affiliation(self):
         # Arrange


### PR DESCRIPTION
Currently the `member_code_override` `BooleanFilter`, when unchecked, will only display training requests where the override hasn't been used.
It would make more sense that when the filter is unchecked, _all_ requests should be shown, regardless of override usage.