### PR TITLE
Automatically assign learner TTT task membership based on code in training application

### DIFF
--- a/amy/extrequests/forms.py
+++ b/amy/extrequests/forms.py
@@ -177,8 +177,8 @@ class BulkMatchTrainingRequestForm(forms.Form):
         super().clean()
 
         event = self.cleaned_data["event"]
-        member_site = self.cleaned_data["seat_membership"]
-        member_site_auto_assign = self.cleaned_data["seat_membership_auto_assign"]
+        seat_membership = self.cleaned_data["seat_membership"]
+        seat_membership_auto_assign = self.cleaned_data["seat_membership_auto_assign"]
         open_training = self.cleaned_data["seat_open_training"]
 
         if any(r.person is None for r in self.cleaned_data.get("requests", [])):
@@ -189,13 +189,13 @@ class BulkMatchTrainingRequestForm(forms.Form):
                 "and match with a trainee."
             )
 
-        if (member_site or member_site_auto_assign) and open_training:
+        if (seat_membership or seat_membership_auto_assign) and open_training:
             raise ValidationError(
                 "Cannot simultaneously match as open training and use "
                 "a Membership instructor training seat."
             )
 
-        if member_site and member_site_auto_assign:
+        if seat_membership and seat_membership_auto_assign:
             raise ValidationError(
                 "Cannot simultaneously use seats from selected membership "
                 "and use seats based on registration code."

--- a/amy/extrequests/forms.py
+++ b/amy/extrequests/forms.py
@@ -125,6 +125,13 @@ class BulkMatchTrainingRequestForm(forms.Form):
         widget=ModelSelect2Widget(data_view="membership-lookup"),
     )
 
+    seat_membership_auto_assign = forms.BooleanField(
+        label="Automatically match seats to memberships",
+        help_text="Assigned users will take instructor seats based on the "
+        "registration code they entered.",
+        required=False,
+    )
+
     seat_public = forms.TypedChoiceField(
         coerce=lambda x: x == "True",
         choices=Task.SEAT_PUBLIC_CHOICES,
@@ -147,6 +154,7 @@ class BulkMatchTrainingRequestForm(forms.Form):
     helper.layout = Layout(
         "event",
         "seat_membership",
+        "seat_membership_auto_assign",
         "seat_public",
         "seat_open_training",
     )
@@ -170,6 +178,7 @@ class BulkMatchTrainingRequestForm(forms.Form):
 
         event = self.cleaned_data["event"]
         member_site = self.cleaned_data["seat_membership"]
+        member_site_auto_assign = self.cleaned_data["seat_membership_auto_assign"]
         open_training = self.cleaned_data["seat_open_training"]
 
         if any(r.person is None for r in self.cleaned_data.get("requests", [])):
@@ -180,10 +189,16 @@ class BulkMatchTrainingRequestForm(forms.Form):
                 "and match with a trainee."
             )
 
-        if member_site and open_training:
+        if (member_site or member_site_auto_assign) and open_training:
             raise ValidationError(
                 "Cannot simultaneously match as open training and use "
                 "a Membership instructor training seat."
+            )
+
+        if member_site and member_site_auto_assign:
+            raise ValidationError(
+                "Cannot simultaneously use seats from selected membership "
+                "and use seats based on registration code."
             )
 
         if open_training and not event.open_TTT_applications:

--- a/amy/extrequests/tests/test_training_request.py
+++ b/amy/extrequests/tests/test_training_request.py
@@ -683,7 +683,7 @@ class TestTrainingRequestsListView(TestBase):
         self.assertContains(
             rv,
             "Request does not include a member registration "
-            "code, so cannot be matched to a seat.",
+            "code, so cannot be matched to a membership seat.",
         )
 
 

--- a/amy/extrequests/tests/test_training_request.py
+++ b/amy/extrequests/tests/test_training_request.py
@@ -658,8 +658,11 @@ class TestTrainingRequestsListView(TestBase):
             "requests": [req1.pk, req2.pk, req3.pk, self.first_req.pk],
             "seat_public": "True",
         }
+
+        # Act
         rv = self.client.post(reverse("all_trainingrequests"), data, follow=True)
 
+        # Assert
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.resolver_match.view_name, "all_trainingrequests")
         self.assertNotContains(

--- a/amy/extrequests/utils.py
+++ b/amy/extrequests/utils.py
@@ -83,8 +83,6 @@ def get_membership_warnings_after_match(
 ) -> list[str]:
     warnings = []
 
-    today = date.today()
-
     remaining = (
         membership.public_instructor_training_seats_remaining
         if seat_public
@@ -97,7 +95,7 @@ def get_membership_warnings_after_match(
         )
 
     # check if membership is active
-    if not (membership.agreement_start <= today <= membership.agreement_end):
+    if not (membership.agreement_start <= date.today() <= membership.agreement_end):
         warnings.append(
             f'Membership "{membership}" is not active.',
         )

--- a/amy/extrequests/utils.py
+++ b/amy/extrequests/utils.py
@@ -103,9 +103,9 @@ def get_membership_warnings_after_match(
     # show warning if training falls out of agreement dates
     if (
         event.start
-        and event.start < membership.agreement_start
+        and not (membership.agreement_start <= event.start <= membership.agreement_end)
         or event.end
-        and event.end > membership.agreement_end
+        and not (membership.agreement_start <= event.end <= membership.agreement_end)
     ):
         warnings.append(
             f'Training "{event}" has start or end date outside '

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -568,14 +568,14 @@ def all_trainingrequests(request):
             role = Role.objects.get(name="learner")
 
             # Perform bulk match using one of two methods
-            requests = match_form.cleaned_data["requests"]
+            training_requests = match_form.cleaned_data["requests"]
             errors = []
             warnings = []
 
             # Method 1: Auto assign membership
             # membership is different for each seat (and may not be None)
             if membership_auto_assign:
-                for r in requests:
+                for r in training_requests:
                     # find which membership to use
                     # if membership can't be determined, skip this request
                     if membership_auto_assign:
@@ -611,7 +611,7 @@ def all_trainingrequests(request):
             # membership is same for all seats (and may be None)
             else:
                 # perform matches
-                for r in request:
+                for r in training_requests:
                     accept_training_request_and_match_to_event(
                         request=r,
                         event=event,

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -577,9 +577,7 @@ def all_trainingrequests(request):
                             "code, so cannot be matched to a seat."
                         )
                         continue
-                    membership_to_use = get_membership_from_code_if_exists(
-                        r.member_code
-                    )
+                    membership_to_use = get_membership_or_none_from_code(r.member_code)
                     if not membership_to_use:
                         errors.append(
                             f"{r}: No membership found for registration code "

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -579,7 +579,9 @@ def all_trainingrequests(request):
                         )
                         continue
                     try:
-                        Membership.objects.get(registration_code=r.member_code)
+                        membership_to_use = Membership.objects.get(
+                            registration_code=r.member_code
+                        )
                     except Membership.DoesNotExist:
                         errors.append(
                             f"{r}: No membership found for registration code "

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -63,6 +63,7 @@ from workshops.forms import (
 from workshops.models import (
     Event,
     Language,
+    Membership,
     Organization,
     Person,
     Role,
@@ -577,8 +578,9 @@ def all_trainingrequests(request):
                             "code, so cannot be matched to a seat."
                         )
                         continue
-                    membership_to_use = get_membership_or_none_from_code(r.member_code)
-                    if not membership_to_use:
+                    try:
+                        Membership.objects.get(registration_code=r.member_code)
+                    except Membership.DoesNotExist:
                         errors.append(
                             f"{r}: No membership found for registration code "
                             f'"{r.member_code}".'
@@ -603,6 +605,8 @@ def all_trainingrequests(request):
                     ),
                 )
 
+                # if membership is different for each request,
+                # collect warnings after each request is processed
                 if membership_auto_assign:
                     warnings += [
                         f"{r}: {w}"
@@ -613,6 +617,8 @@ def all_trainingrequests(request):
                         )
                     ]
 
+            # if membership is the same for all matches,
+            # collect warnings after all requests are processed
             if membership:
                 warnings = get_membership_warnings_after_match(
                     membership=membership, seat_public=seat_public, event=event

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -627,9 +627,10 @@ def all_trainingrequests(request):
                     messages.error(request, msg)
                 changed_count = len(match_form.cleaned_data["requests"]) - len(errors)
                 info_msg = (
-                    f"Accepted and matched {changed_count} request(s), "
+                    f"Accepted and matched {changed_count} "
+                    f'{"person" if changed_count==1 else "people"} to training, '
                     f"which raised {len(warnings)} warning(s). "
-                    f"{len(errors)} requests(s) were skipped due to errors."
+                    f"{len(errors)} request(s) were skipped due to errors."
                 )
                 messages.info(request, info_msg)
             else:

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -578,14 +578,13 @@ def all_trainingrequests(request):
                 for r in training_requests:
                     # find which membership to use
                     # if membership can't be determined, skip this request
-                    if membership_auto_assign:
-                        try:
-                            membership_to_use = (
-                                get_membership_from_training_request_or_raise_error(r)
-                            )
-                        except (ValueError, Membership.DoesNotExist) as e:
-                            errors.append(str(e))
-                            continue
+                    try:
+                        membership_to_use = (
+                            get_membership_from_training_request_or_raise_error(r)
+                        )
+                    except (ValueError, Membership.DoesNotExist) as e:
+                        errors.append(str(e))
+                        continue
 
                     # perform match
                     accept_training_request_and_match_to_event(
@@ -627,6 +626,7 @@ def all_trainingrequests(request):
                         membership=membership, seat_public=seat_public, event=event
                     )
 
+            # Matching is complete, display messages
             for msg in warnings:
                 messages.warning(request, msg)
             for msg in errors:

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -628,9 +628,9 @@ def all_trainingrequests(request):
 
             for msg in warnings:
                 messages.warning(request, msg)
+            for msg in errors:
+                messages.error(request, msg)
             if errors:
-                for msg in errors:
-                    messages.error(request, msg)
                 changed_count = len(match_form.cleaned_data["requests"]) - len(errors)
                 info_msg = (
                     f"Accepted and matched {changed_count} "

--- a/amy/static/task_form.js
+++ b/amy/static/task_form.js
@@ -21,7 +21,6 @@ jQuery(function () {
         person = data.id;
     });
     $("#id_task-role").on("change", (e) => {
-        console.log(e.target.value);
         role = e.target.value
     });
     $("#id_task-event").on("select2:select", (e) => {

--- a/amy/static/task_form.js
+++ b/amy/static/task_form.js
@@ -1,0 +1,31 @@
+jQuery(function () {
+    let person, role, event;
+    $("#id_task-seat_membership").select2({
+        ajax: {
+            data: (params) => {
+                const query = {
+                    person: person,
+                    role: role,
+                    event: event,
+                    // `field_id` is required on backend by django-select2 views
+                    field_id: $("#id_task-seat_membership").data("field_id"),
+                    ...params,
+                };
+                return query;
+            },
+        },
+    });
+    // update variables when a selection is made
+    $("#id_task-person").on("select2:select", (e) => {
+        const data = e.params.data;
+        person = data.id;
+    });
+    $("#id_task-role").on("change", (e) => {
+        console.log(e.target.value);
+        role = e.target.value
+    });
+    $("#id_task-event").on("select2:select", (e) => {
+        const data = e.params.data;
+        event = data.id;
+    });
+});

--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -642,7 +642,7 @@ class TaskForm(WidgetOverrideMixin, forms.ModelForm):
         required=False,
         queryset=Membership.objects.all(),
         widget=ModelSelect2Widget(
-            data_view="membership-lookup",
+            data_view="membership-lookup-for-tasks",
             attrs=SELECT2_SIDEBAR,
         ),
     )
@@ -668,6 +668,9 @@ class TaskForm(WidgetOverrideMixin, forms.ModelForm):
             ),
             "seat_public": forms.RadioSelect(),
         }
+
+    class Media:
+        js = ("task_form.js",)
 
     def __init__(self, *args, **kwargs):
         form_tag = kwargs.pop("form_tag", True)

--- a/amy/workshops/lookups.py
+++ b/amy/workshops/lookups.py
@@ -211,7 +211,7 @@ class MembershipLookupForTasksView(MembershipLookupView):
             and ttt_tag in models.Event.objects.get(id=event).tags.all()
         ):
             training_requests = models.TrainingRequest.objects.filter(person__id=person)
-            member_codes = training_requests.values_list("group_name")
+            member_codes = training_requests.values_list("member_code")
             results = results.filter(registration_code__in=member_codes)
 
         return results

--- a/amy/workshops/lookups.py
+++ b/amy/workshops/lookups.py
@@ -193,6 +193,30 @@ class MembershipLookupView(OnlyForAdminsNoRedirectMixin, AutoResponseView):
         return results
 
 
+class MembershipLookupForTasksView(MembershipLookupView):
+    def get_queryset(self):
+        results = super().get_queryset()
+
+        # if this is a TTT learner task,
+        # find the membership from the associated training request
+        person = self.request.GET.get("person")
+        role = self.request.GET.get("role")
+        event = self.request.GET.get("event")
+        ttt_tag = models.Tag.objects.get(name="TTT")
+        if (
+            person
+            and role
+            and event
+            and models.Role.objects.get(id=role).name == "learner"
+            and ttt_tag in models.Event.objects.get(id=event).tags.all()
+        ):
+            training_requests = models.TrainingRequest.objects.filter(person__id=person)
+            member_codes = training_requests.values_list("group_name")
+            results = results.filter(registration_code__in=member_codes)
+
+        return results
+
+
 class MemberRoleLookupView(OnlyForAdminsNoRedirectMixin, AutoResponseView):
     def get_queryset(self):
         q = models.MemberRole.objects.all()
@@ -476,6 +500,11 @@ urlpatterns = [
         name="administrator-org-lookup",
     ),
     path("memberships/", MembershipLookupView.as_view(), name="membership-lookup"),
+    path(
+        "memberships_for_tasks/",
+        MembershipLookupForTasksView.as_view(),
+        name="membership-lookup-for-tasks",
+    ),
     path("member-roles/", MemberRoleLookupView.as_view(), name="memberrole-lookup"),
     path(
         "membership-person-roles/",

--- a/amy/workshops/tests/test_lookups.py
+++ b/amy/workshops/tests/test_lookups.py
@@ -485,10 +485,10 @@ class TestMembershipLookupForTasksView(TestMembershipLookupView):
 
         # create some training requests
         TrainingRequest.objects.create(
-            person=self.blackwidow, group_name=self.membership_alpha.registration_code
+            person=self.blackwidow, member_code=self.membership_alpha.registration_code
         )
         TrainingRequest.objects.create(
-            person=self.blackwidow, group_name=self.membership_beta.registration_code
+            person=self.blackwidow, member_code=self.membership_beta.registration_code
         )
 
     def setUpView(

--- a/amy/workshops/tests/test_lookups.py
+++ b/amy/workshops/tests/test_lookups.py
@@ -582,7 +582,7 @@ class TestMembershipLookupForTasksView(TestMembershipLookupView):
         )
 
     def test_get_queryset_person_and_learner_role_and_ttt_event_and_term(self):
-        """Person, role, and event combined should change results."""
+        """Person, role, event, and term combined should change results."""
         # Arrange
         term = "alpha"
         view = self.setUpView(

--- a/amy/workshops/tests/test_lookups.py
+++ b/amy/workshops/tests/test_lookups.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Optional
 
 from django.contrib.contenttypes.models import ContentType
@@ -13,6 +14,8 @@ from workshops.lookups import (
     EventLookupView,
     GenericObjectLookupView,
     KnowledgeDomainLookupView,
+    MembershipLookupForTasksView,
+    MembershipLookupView,
     TTTEventLookupView,
     urlpatterns,
 )
@@ -22,10 +25,12 @@ from workshops.models import (
     Event,
     KnowledgeDomain,
     Lesson,
+    Membership,
     Person,
     Role,
     Tag,
     TrainingProgress,
+    TrainingRequest,
     TrainingRequirement,
 )
 from workshops.tests.base import (
@@ -382,6 +387,214 @@ class TestTTTEventLookupView(TestBase):
             queryset,
             [self.event],
         )
+
+
+class TestMembershipLookupView(TestBase):
+    def setUp(self):
+        super().setUp()
+        self._setUpRoles()
+        self._setUpTags()
+
+        self.membership_alpha = Membership.objects.create(
+            name="Alpha Organization",
+            variant="bronze",
+            agreement_start=date(2023, 8, 15),
+            agreement_end=date(2024, 8, 14),
+            contribution_type="financial",
+            registration_code="alpha44",
+        )
+        self.membership_beta = Membership.objects.create(
+            name="Beta Organization Unique",
+            variant="bronze",
+            agreement_start=date(2023, 9, 15),
+            agreement_end=date(2024, 9, 14),
+            contribution_type="financial",
+            registration_code="beta55",
+        )
+        self.membership_gamma = Membership.objects.create(
+            name="Gamma Organization",
+            variant="silver",
+            agreement_start=date(2023, 10, 15),
+            agreement_end=date(2023, 11, 14),
+            contribution_type="financial",
+            registration_code="gamma66",
+        )
+
+    def setUpView(self, term: str = "") -> MembershipLookupView:
+        # path doesn't matter
+        request = RequestFactory().get("/")
+        view = MembershipLookupView(request=request, term=term)
+        return view
+
+    def test_get_queryset_no_term(self):
+        # Arrange
+        view = self.setUpView()
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, Membership.objects.all(), ordered=False)
+
+    def test_get_queryset_term__date(self):
+        # Arrange
+        term = "2023-08-30"
+        view = self.setUpView(term=term)
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, [self.membership_alpha], ordered=False)
+
+    def test_get_queryset_term__organization_name(self):
+        # Arrange
+        term = "alpha"
+        view = self.setUpView(term=term)
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, [self.membership_alpha], ordered=False)
+
+    def test_get_queryset_term__membership_name(self):
+        # Arrange
+        term = "unique"
+        view = self.setUpView(term=term)
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, [self.membership_beta], ordered=False)
+
+    def test_get_queryset_term__variant(self):
+        # Arrange
+        term = "bronze"
+        view = self.setUpView(term=term)
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(
+            queryset, [self.membership_alpha, self.membership_beta], ordered=False
+        )
+
+
+class TestMembershipLookupForTasksView(TestMembershipLookupView):
+    def setUp(self):
+        super().setUp()
+
+        self.role = Role.objects.get(name="learner")
+
+        self.event = Event.objects.create(slug="test-event", host=self.org_alpha)
+        self.ttt_event = Event.objects.create(slug="test-ttt", host=self.org_alpha)
+        self.ttt_event.tags.add(Tag.objects.get(name="TTT"))
+
+        # create some training requests
+        TrainingRequest.objects.create(
+            person=self.blackwidow, group_name=self.membership_alpha.registration_code
+        )
+        TrainingRequest.objects.create(
+            person=self.blackwidow, group_name=self.membership_beta.registration_code
+        )
+
+    def setUpView(
+        self,
+        term: str = "",
+        person: Optional[int] = None,
+        role: Optional[int] = None,
+        event: Optional[int] = None,
+    ) -> MembershipLookupForTasksView:
+        # path doesn't matter
+        request = RequestFactory().get(
+            f"/?person={person if person else ''}"
+            f"&role={role if role else ''}"
+            f"&event={event if event else ''}"
+        )
+        view = MembershipLookupForTasksView(request=request, term=term)
+        return view
+
+    def test_get_queryset_no_args(self):
+        # Arrange
+        view = self.setUpView()
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, Membership.objects.all(), ordered=False)
+
+    def test_get_queryset_person(self):
+        """Person alone should not change results."""
+        # Arrange
+        view = self.setUpView(person=self.blackwidow.pk)
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, Membership.objects.all(), ordered=False)
+
+    def test_get_queryset_role(self):
+        """Role alone should not change results."""
+        # Arrange
+        view = self.setUpView(role=self.role.pk)
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, Membership.objects.all(), ordered=False)
+
+    def test_get_queryset_event(self):
+        """Event alone should not change results."""
+        # Arrange
+        view = self.setUpView(event=self.ttt_event.pk)
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, Membership.objects.all(), ordered=False)
+
+    def test_get_queryset_person_and_non_learner_role_and_ttt_event(self):
+        """Any query with a non-learner role should not change results."""
+        # Arrange
+        view = self.setUpView(
+            person=self.blackwidow.pk,
+            role=Role.objects.get(name="instructor").pk,
+            event=self.ttt_event.pk,
+        )
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, Membership.objects.all(), ordered=False)
+
+    def test_get_queryset_person_and_learner_role_and_non_ttt_event(self):
+        """Any query with a non-TTT event should not change results."""
+        # Arrange
+        view = self.setUpView(
+            person=self.blackwidow.pk,
+            role=self.role.pk,
+            event=self.event.pk,
+        )
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, Membership.objects.all(), ordered=False)
+
+    def test_get_queryset_person_and_learner_role_and_ttt_event(self):
+        """Person, role, and event combined should change results."""
+        # Arrange
+        view = self.setUpView(
+            person=self.blackwidow.pk, role=self.role.pk, event=self.ttt_event.pk
+        )
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(
+            queryset, [self.membership_alpha, self.membership_beta], ordered=False
+        )
+
+    def test_get_queryset_person_and_learner_role_and_ttt_event_and_term(self):
+        """Person, role, and event combined should change results."""
+        # Arrange
+        term = "alpha"
+        view = self.setUpView(
+            term=term,
+            person=self.blackwidow.pk,
+            role=self.role.pk,
+            event=self.ttt_event.pk,
+        )
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertQuerysetEqual(queryset, [self.membership_alpha], ordered=False)
 
 
 class TestGenericObjectLookupView(TestBase):

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -9,5 +9,5 @@ Table of contents:
 3. [Model versioning](./model_versioning.md)
 4. [Templates hierarchy](./template_hierarchy.md)
 5. [Views hierarchy](./views_hierarchy.md)
-6. [Server infrastructure](./server_infrastructure.md)
-7. [Design patterns reference](./design_patterns.md)
+6. [Design patterns reference](./design_patterns.md)
+7. [Server infrastructure](./server_infrastructure.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,56 +1,56 @@
 site_name: AMY documentation
 repo_url: https://github.com/carpentries/amy/
-edit_uri: 'edit/develop/docs/'
+edit_uri: "edit/develop/docs/"
 
 extra_javascript:
-    - 'js/navigation.js'
+    - "js/navigation.js"
 
 theme:
     name: material
     collapse_navigation: true
 
 nav:
-    - 'Home': 'index.md'
-    - 'For Carpentries Community members':
-        - 'AMY Community Users Guide': 'users_guide/community_index.md'
-    - 'For AMY Administrators':
-        - 'Users Guide': 'users_guide/admin_index.md'
-        - 'Database Structure': 'amy_database_structure.md'
-    - 'For AMY Developers':
-        - 'Design': 'design/index.md'
-        - 'Application design': 'design/application_design.md'
-        - 'Database models': 'design/database_models.md'
-        - 'Model versioning': 'design/model_versioning.md'
-        - 'Templates': 'design/template_hierarchy.md'
-        - 'Views': 'design/views_hierarchy.md'
-        - 'Server Infrastructure': 'design/server_infrastructure.md'
-        - 'Database backups': 'design/database_backups.md'
-        - 'Accessibility Testing': 'accessibility_testing.md'
-        - 'Deploying AMY':
-                - 'Procedures': 'procedures.md'
-                - 'CI/CD': 'design/cicd.md'
-                - 'Releases': './releases/README.md'
-                - 'Release-Specific Manual Deployment Steps': 'manual_deployment_steps.md'
-        - 'Projects':
-          - 'Projects': './design/projects/README.md'
-          - 'Automated emails': './design/projects/2019_automated_emails.md'
-          - 'Memberships': './design/projects/2021_memberships.md'
-          - 'Consents': './design/projects/2021_consents.md'
-          - 'Profile Archival': './design/projects/2021_profile_archival.md'
-          - 'Community Roles': './design/projects/2021_community_roles.md'
-          - 'Instructor Selection': './design/projects/2021_instructor_selection.md'
-          - 'Single Instructor Badge': './design/projects/2021_single_instructor_badge.md'
-        - 'Feature flags': 'design/feature_flags.md'
-    - 'About The Carpentries':
-        - 'The Carpentries': 'https://carpentries.org'
-        - 'Data Carpentry': 'https://datacarpentry.org/'
-        - 'Library Carpentry': 'https://librarycarpentry.org/'
-        - 'Software Carpentry': 'https://software-carpentry.org/'
-        - 'AMY': 'https://amy.carpentries.org'
-
+    - "Home": "index.md"
+    - "For Carpentries Community members":
+          - "AMY Community Users Guide": "users_guide/community_index.md"
+    - "For AMY Administrators":
+          - "Users Guide": "users_guide/admin_index.md"
+          - "Database Structure": "amy_database_structure.md"
+    - "For AMY Developers":
+          - "Design": "design/index.md"
+          - "Application design": "design/application_design.md"
+          - "Database models": "design/database_models.md"
+          - "Model versioning": "design/model_versioning.md"
+          - "Templates": "design/template_hierarchy.md"
+          - "Views": "design/views_hierarchy.md"
+          - "Design Pattern Reference": "design/design_patterns.md"
+          - "Server Infrastructure": "design/server_infrastructure.md"
+          - "Database backups": "design/database_backups.md"
+          - "Accessibility Testing": "accessibility_testing.md"
+          - "Deploying AMY":
+                - "Procedures": "procedures.md"
+                - "CI/CD": "design/cicd.md"
+                - "Releases": "./releases/README.md"
+                - "Release-Specific Manual Deployment Steps": "manual_deployment_steps.md"
+          - "Projects":
+                - "Projects": "./design/projects/README.md"
+                - "Automated emails": "./design/projects/2019_automated_emails.md"
+                - "Memberships": "./design/projects/2021_memberships.md"
+                - "Consents": "./design/projects/2021_consents.md"
+                - "Profile Archival": "./design/projects/2021_profile_archival.md"
+                - "Community Roles": "./design/projects/2021_community_roles.md"
+                - "Instructor Selection": "./design/projects/2021_instructor_selection.md"
+                - "Single Instructor Badge": "./design/projects/2021_single_instructor_badge.md"
+          - "Feature flags": "design/feature_flags.md"
+    - "About The Carpentries":
+          - "The Carpentries": "https://carpentries.org"
+          - "Data Carpentry": "https://datacarpentry.org/"
+          - "Library Carpentry": "https://librarycarpentry.org/"
+          - "Software Carpentry": "https://software-carpentry.org/"
+          - "AMY": "https://amy.carpentries.org"
 
 markdown_extensions:
-  - toc:
-      permalink: True
+    - toc:
+          permalink: True
 
 extra_css: [extra.css]


### PR DESCRIPTION
Depends on #2553 so marking as draft until that is merged.

This PR adds two features:

1. on the 'Add task' page, helps the user find the active membership when assigning a learner task (which uses a new lookup)
2. on the 'All trainees' page, adds a checkbox to auto-assign membership seats based on member codes used. This will raise errors for requests that did not provide a code or that provided an invalid code. 

Screenshots:
![New Task form with person, role, and event fields filled, and only one displayed option for the membership](https://github.com/carpentries/amy/assets/20683271/6932b5f9-462c-41d8-ab18-28cb57311951)
![Match form showing new checkbox "Automatically match seats to memberships" with help text "Assigned users will take instructor seats based on the registration code they entered."](https://github.com/carpentries/amy/assets/20683271/5e248007-e995-461a-8eca-4a1bec11d4fd)
![All trainees page showing warnings, errors, and info message after bulk matching trainees with the auto-assign membership feature. The warnings indicate that a membership is inactive at the time of the training, the errors indicate that some requests did not include valid codes, and the info message says "Accepted and matched 3 people to training, which raised 6 warning(s). 3 request(s) were skipped due to errors."](https://github.com/carpentries/amy/assets/20683271/514d522d-d30a-4c42-9046-28e7fbccac87)
Note that I get lots of extra warnings raised on my dev instance because the membership dates are randomised, but they're the same warnings as you may see currently when you match trainees through this page. It's only the errors that are new.