### PR TITLE
[Chore] Unconditionally enable "ENFORCE_MEMBER_CODES" feature flag

### DIFF
--- a/amy/extforms/tests/test_training_request_form.py
+++ b/amy/extforms/tests/test_training_request_form.py
@@ -110,6 +110,7 @@ class TestTrainingRequestForm(TestBase):
             data[term.slug] = option.pk
         return data
 
+    @override_settings(FLAGS={"ENFORCE_MEMBER_CODES": [("boolean", False)]})
     def test_request_added(self):
         # Arrange
         email = self.data.get("email")
@@ -178,6 +179,7 @@ class TestTrainingRequestForm(TestBase):
             HiddenInput,
         )
 
+    @override_settings(FLAGS={"ENFORCE_MEMBER_CODES": [("boolean", False)]})
     def test_review_process_validation__open_code_nonempty(self):
         """Shouldn't pass when review_process requires *NO* member_code."""
         # Arrange

--- a/config/settings.py
+++ b/config/settings.py
@@ -688,9 +688,8 @@ FLAGS = {
         {"condition": "parameter", "value": "enable_email_module=true"},
         {"condition": "session", "value": "enable_email_module"},
     ],
+    # Always enabled.
     "ENFORCE_MEMBER_CODES": [
-        {"condition": "anonymous", "value": False, "required": True},
-        {"condition": "parameter", "value": "enforce_member_codes=true"},
-        {"condition": "session", "value": "enforce_member_codes"},
+        {"condition": "boolean", "value": True},
     ],
 }


### PR DESCRIPTION
This enables the feature flag "ENFORCE_MEMBER_CODES", which is required for testing by anonymous users.