### PR TITLE
rm line about rm'ing old db

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ directory) with tags `amy:latest` and `amy:LAST_COMMIT`.
     pipenv run make dev_database
     ~~~
 
-    **Note**:  this command requires removing (by hand) the old database file.
-
 1. Run database migrations:
 
     ~~~~


### PR DESCRIPTION
There is a legacy line in the README about removing the old database file. This is a holdover from when we were using SQLite.