### PR TITLE
[Emails] List related scheduled emails

### DIFF
--- a/amy/emails/templatetags/emails.py
+++ b/amy/emails/templatetags/emails.py
@@ -1,6 +1,12 @@
 from django import template
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Model, QuerySet
 
-from emails.models import ScheduledEmailStatus, ScheduledEmailStatusActions
+from emails.models import (
+    ScheduledEmail,
+    ScheduledEmailStatus,
+    ScheduledEmailStatusActions,
+)
 
 register = template.Library()
 
@@ -12,3 +18,12 @@ def allowed_actions_for_status(status: ScheduledEmailStatus) -> list[str]:
         for key, statuses in ScheduledEmailStatusActions.items()
         if status in statuses
     ]
+
+
+@register.simple_tag
+def get_related_scheduled_emails(obj: Model) -> QuerySet[ScheduledEmail]:
+    content_type = ContentType.objects.get_for_model(obj.__class__)
+    return ScheduledEmail.objects.filter(
+        generic_relation_content_type=content_type,
+        generic_relation_pk=obj.pk,
+    ).order_by("-created_at")

--- a/amy/templates/fiscal/membership.html
+++ b/amy/templates/fiscal/membership.html
@@ -200,6 +200,12 @@
   </tr>
   <tr><th>Emergency contact:</th>
       <td colspan="2">{% if membership.emergency_contact %}<pre>{{ membership.emergency_contact }}</pre>{% else %}&mdash;{% endif %}</td></tr>
+  <tr>
+    <th>Related scheduled emails:</th>
+    <td>
+      {% include "includes/related_scheduled_emails.html" with object=membership %}
+    </td>
+  </tr>
 </table>
 
 <div class="clearfix">

--- a/amy/templates/includes/event_details_table.html
+++ b/amy/templates/includes/event_details_table.html
@@ -89,4 +89,10 @@
         {% endif %}
       {% endwith %}
     </td></tr>
+  <tr>
+    <th>Related scheduled emails:</th>
+    <td>
+      {% include "includes/related_scheduled_emails.html" with object=event %}
+    </td>
+  </tr>
 </table>

--- a/amy/templates/includes/instructorrecruitment.html
+++ b/amy/templates/includes/instructorrecruitment.html
@@ -21,6 +21,7 @@
         ></i>
       </th>
       <th>Action</th>
+      <th>Related scheduled emails</th>
     </tr>
   </thead>
   <tbody>
@@ -88,10 +89,13 @@
         </form>
         <a href="{% url 'instructorrecruitmentsignup_edit' signup.pk %}" class="btn btn-sm btn-primary">Edit</a>
       </td>
+      <td>
+        {% include "includes/related_scheduled_emails.html" with object=signup %}
+      </td>
     </tr>
     {% empty %}
     <tr>
-      <td colspan=9><em>No applications yet.</em></td>
+      <td colspan=11><em>No applications yet.</em></td>
     </tr>
     {% endfor %}
   </tbody>

--- a/amy/templates/includes/related_scheduled_emails.html
+++ b/amy/templates/includes/related_scheduled_emails.html
@@ -1,0 +1,12 @@
+{% load emails %}
+
+{% get_related_scheduled_emails object as related_scheduled_emails %}
+{% if related_scheduled_emails %}
+<ul>
+  {% for email in related_scheduled_emails %}
+  <li><a href="{{ email.get_absolute_url }}">{{ email.subject }} | {{ email.pk }} | {{ email.get_state_display }}</a></li>
+  {% endfor %}
+</ul>
+{% else %}
+No related scheduled emails.
+{% endif %}

--- a/amy/templates/includes/related_scheduled_emails_no_empty_msg.html
+++ b/amy/templates/includes/related_scheduled_emails_no_empty_msg.html
@@ -1,0 +1,10 @@
+{% load emails %}
+
+{% get_related_scheduled_emails object as related_scheduled_emails %}
+{% if related_scheduled_emails %}
+<ul>
+  {% for email in related_scheduled_emails %}
+  <li><a href="{{ email.get_absolute_url }}">{{ email.subject }} | {{ email.pk }} | {{ email.get_state_display }}</a></li>
+  {% endfor %}
+</ul>
+{% endif %}

--- a/amy/templates/recruitment/instructorrecruitment_list.html
+++ b/amy/templates/recruitment/instructorrecruitment_list.html
@@ -39,6 +39,10 @@
         <td><i class="fas fa-user-cog"></i></td>
         <td>{% if object.assigned_to %}Assigned to: <a href="{{ object.assigned_to.get_absolute_url }}">{{ object.assigned_to.full_name }}</a>{% else %}Unassigned{% endif %}</td>
       </tr>
+      <tr>
+        <td></td>
+        <td><a href="{{ object.get_absolute_url }}">See details</a></td>
+      </tr>
     </table>
   </p>
   <div class="card recruitment-notes">

--- a/amy/templates/workshops/person.html
+++ b/amy/templates/workshops/person.html
@@ -256,6 +256,12 @@
       {% endwith %}
     </td>
   </tr>
+  <tr>
+    <th>Related scheduled emails:</th>
+    <td>
+      {% include "includes/related_scheduled_emails.html" with object=person %}
+    </td>
+  </tr>
 </table>
 
 <div class="edit-object">

--- a/amy/templates/workshops/person.html
+++ b/amy/templates/workshops/person.html
@@ -262,6 +262,18 @@
       {% include "includes/related_scheduled_emails.html" with object=person %}
     </td>
   </tr>
+  <tr>
+    <th>Related scheduled emails for awards:</th>
+    <td>
+      {% with awards=person.award_set.all %}
+      {% for award in awards %}
+      {% include "includes/related_scheduled_emails_no_empty_msg.html" with object=award %}
+      {% empty%}
+      &mdash;
+      {% endfor %}
+      {% endwith %}
+    </td>
+  </tr>
 </table>
 
 <div class="edit-object">

--- a/config/settings.py
+++ b/config/settings.py
@@ -46,7 +46,7 @@ env = environ.Env(
     ),
     AMY_SITE_BANNER=(str, "local"),  # should be "local", "testing", or "production"
     # Feature flags
-    AMY_INSTRUCTOR_RECRUITMENT_ENABLED=(bool, False),
+    AMY_INSTRUCTOR_RECRUITMENT_ENABLED=(bool, True),
 )
 
 # OS environment variables take precedence over variables from .env


### PR DESCRIPTION
This fixes #2622 by providing a template to list related scheduled emails. This template was used in Person, Event and Membership models.