### PR TITLE
[Emails] Cleanup feature flags

### DIFF
--- a/amy/dashboard/tests/test_instructor_recruitment_views.py
+++ b/amy/dashboard/tests/test_instructor_recruitment_views.py
@@ -22,7 +22,7 @@ from workshops.models import Event, Organization, Person, Role, Tag, Task
 
 
 class TestUpcomingTeachingOpportunitiesList(TestCase):
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    @override_settings(FLAGS={"INSTRUCTOR_RECRUITMENT": [("boolean", True)]})
     def test_view_enabled__no_community_role(self):
         # Arrange
         request = RequestFactory().get("/")
@@ -32,9 +32,9 @@ class TestUpcomingTeachingOpportunitiesList(TestCase):
         # Act
         view = UpcomingTeachingOpportunitiesList(request=request)
         # Assert
-        self.assertEqual(view.get_view_enabled(), False)
+        self.assertEqual(view.get_view_enabled(request), False)
 
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    @override_settings(FLAGS={"INSTRUCTOR_RECRUITMENT": [("boolean", True)]})
     def test_view_enabled__community_role_inactive(self):
         # Arrange
         request = RequestFactory().get("/")
@@ -59,9 +59,9 @@ class TestUpcomingTeachingOpportunitiesList(TestCase):
         view = UpcomingTeachingOpportunitiesList(request=request)
         # Assert
         self.assertEqual(role.is_active(), False)
-        self.assertEqual(view.get_view_enabled(), False)
+        self.assertEqual(view.get_view_enabled(request), False)
 
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    @override_settings(FLAGS={"INSTRUCTOR_RECRUITMENT": [("boolean", True)]})
     def test_view_enabled__community_role_active(self):
         # Arrange
         request = RequestFactory().get("/")
@@ -84,7 +84,7 @@ class TestUpcomingTeachingOpportunitiesList(TestCase):
         view = UpcomingTeachingOpportunitiesList(request=request)
         # Assert
         self.assertEqual(role.is_active(), True)
-        self.assertEqual(view.get_view_enabled(), True)
+        self.assertEqual(view.get_view_enabled(request), True)
 
     def test_get_queryset(self):
         # Arrange
@@ -201,7 +201,7 @@ class TestUpcomingTeachingOpportunitiesList(TestCase):
 
 
 class TestSignupForRecruitment(TestCase):
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    @override_settings(FLAGS={"INSTRUCTOR_RECRUITMENT": [("boolean", True)]})
     def test_view_enabled__no_community_role(self):
         # Arrange
         request = RequestFactory().get("/")
@@ -211,9 +211,9 @@ class TestSignupForRecruitment(TestCase):
         # Act
         view = SignupForRecruitment(request=request)
         # Assert
-        self.assertEqual(view.get_view_enabled(), False)
+        self.assertEqual(view.get_view_enabled(request), False)
 
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    @override_settings(FLAGS={"INSTRUCTOR_RECRUITMENT": [("boolean", True)]})
     def test_view_enabled__community_role_inactive(self):
         # Arrange
         request = RequestFactory().get("/")
@@ -238,9 +238,9 @@ class TestSignupForRecruitment(TestCase):
         view = SignupForRecruitment(request=request)
         # Assert
         self.assertEqual(role.is_active(), False)
-        self.assertEqual(view.get_view_enabled(), False)
+        self.assertEqual(view.get_view_enabled(request), False)
 
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    @override_settings(FLAGS={"INSTRUCTOR_RECRUITMENT": [("boolean", True)]})
     def test_view_enabled__community_role_active(self):
         # Arrange
         request = RequestFactory().get("/")
@@ -263,7 +263,7 @@ class TestSignupForRecruitment(TestCase):
         view = SignupForRecruitment(request=request)
         # Assert
         self.assertEqual(role.is_active(), True)
-        self.assertEqual(view.get_view_enabled(), True)
+        self.assertEqual(view.get_view_enabled(request), True)
 
     def test_get_context_data(self):
         # Arrange
@@ -505,7 +505,7 @@ class TestSignupForRecruitment(TestCase):
 
 
 class TestResignFromRecruitment(TestCase):
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    @override_settings(FLAGS={"INSTRUCTOR_RECRUITMENT": [("boolean", True)]})
     def test_view_enabled__no_community_role(self):
         # Arrange
         request = RequestFactory().post("/")
@@ -515,9 +515,9 @@ class TestResignFromRecruitment(TestCase):
         # Act
         view = ResignFromRecruitment(request=request)
         # Assert
-        self.assertEqual(view.get_view_enabled(), False)
+        self.assertEqual(view.get_view_enabled(request), False)
 
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    @override_settings(FLAGS={"INSTRUCTOR_RECRUITMENT": [("boolean", True)]})
     def test_view_enabled__community_role_inactive(self):
         # Arrange
         request = RequestFactory().post("/")
@@ -542,9 +542,9 @@ class TestResignFromRecruitment(TestCase):
         view = ResignFromRecruitment(request=request)
         # Assert
         self.assertEqual(role.is_active(), False)
-        self.assertEqual(view.get_view_enabled(), False)
+        self.assertEqual(view.get_view_enabled(request), False)
 
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
+    @override_settings(FLAGS={"INSTRUCTOR_RECRUITMENT": [("boolean", True)]})
     def test_view_enabled__community_role_active(self):
         # Arrange
         request = RequestFactory().post("/")
@@ -567,7 +567,7 @@ class TestResignFromRecruitment(TestCase):
         view = ResignFromRecruitment(request=request)
         # Assert
         self.assertEqual(role.is_active(), True)
-        self.assertEqual(view.get_view_enabled(), True)
+        self.assertEqual(view.get_view_enabled(request), True)
 
     def test_get_queryset(self):
         # Arrange

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -336,7 +336,7 @@ class GetInvolvedDeleteView(LoginRequiredMixin, AMYDeleteView):
 
 
 class UpcomingTeachingOpportunitiesList(
-    LoginRequiredMixin, FlaggedViewMixin, AMYListView
+    LoginRequiredMixin, FlaggedViewMixin, ConditionallyEnabledMixin, AMYListView
 ):
     flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = "recruitment.view_instructorrecruitment"
@@ -375,12 +375,12 @@ class UpcomingTeachingOpportunitiesList(
         )
         return super().get_queryset()
 
-    def get_view_enabled(self) -> bool:
+    def get_view_enabled(self, request) -> bool:
         try:
             role = CommunityRole.objects.get(
                 person=self.request.user, config__name="instructor"
             )
-            return role.is_active() and super().get_view_enabled()
+            return role.is_active()
         except CommunityRole.DoesNotExist:
             return False
 
@@ -414,6 +414,7 @@ class UpcomingTeachingOpportunitiesList(
 class SignupForRecruitment(
     LoginRequiredMixin,
     FlaggedViewMixin,
+    ConditionallyEnabledMixin,
     AMYCreateAndFetchObjectView,
 ):
     flag_name = "INSTRUCTOR_RECRUITMENT"
@@ -432,12 +433,12 @@ class SignupForRecruitment(
     form_class = SignupForRecruitmentForm
     template_name = "dashboard/signup_for_recruitment.html"
 
-    def get_view_enabled(self) -> bool:
+    def get_view_enabled(self, request) -> bool:
         try:
             role = CommunityRole.objects.get(
                 person=self.request.user, config__name="instructor"
             )
-            return role.is_active() and super().get_view_enabled()
+            return role.is_active()
         except CommunityRole.DoesNotExist:
             return False
 
@@ -530,6 +531,7 @@ class SignupForRecruitment(
 class ResignFromRecruitment(
     LoginRequiredMixin,
     FlaggedViewMixin,
+    ConditionallyEnabledMixin,
     SingleObjectMixin,
     View,
 ):
@@ -556,12 +558,12 @@ class ResignFromRecruitment(
         redirect_url = self.get_redirect_url()
         return redirect(redirect_url)
 
-    def get_view_enabled(self) -> bool:
+    def get_view_enabled(self, request) -> bool:
         try:
             role = CommunityRole.objects.get(
                 person=self.request.user, config__name="instructor"
             )
-            return role.is_active() and super().get_view_enabled()
+            return role.is_active()
         except CommunityRole.DoesNotExist:
             return False
 

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -24,6 +24,7 @@ from django.views.generic import TemplateView, View
 from django.views.generic.detail import SingleObjectMixin
 from django_comments.models import Comment
 from flags.sources import get_flags
+from flags.views import FlaggedViewMixin
 
 from communityroles.models import CommunityRole
 from consents.forms import TermBySlugsForm
@@ -41,13 +42,11 @@ from emails.signals import instructor_signs_up_for_workshop_signal
 from extrequests.base_views import AMYCreateAndFetchObjectView
 from fiscal.models import MembershipTask
 from recruitment.models import InstructorRecruitment, InstructorRecruitmentSignup
-from recruitment.views import RecruitmentEnabledMixin
 from workshops.base_views import (
     AMYCreateView,
     AMYDeleteView,
     AMYListView,
     AMYUpdateView,
-    ConditionallyEnabledMixin,
 )
 from workshops.models import (
     Airport,
@@ -335,8 +334,9 @@ class GetInvolvedDeleteView(LoginRequiredMixin, AMYDeleteView):
 
 
 class UpcomingTeachingOpportunitiesList(
-    LoginRequiredMixin, RecruitmentEnabledMixin, ConditionallyEnabledMixin, AMYListView
+    LoginRequiredMixin, FlaggedViewMixin, AMYListView
 ):
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = "recruitment.view_instructorrecruitment"
     title = "Upcoming Teaching Opportunities"
     template_name = "dashboard/upcoming_teaching_opportunities.html"
@@ -411,10 +411,10 @@ class UpcomingTeachingOpportunitiesList(
 
 class SignupForRecruitment(
     LoginRequiredMixin,
-    RecruitmentEnabledMixin,
-    ConditionallyEnabledMixin,
+    FlaggedViewMixin,
     AMYCreateAndFetchObjectView,
 ):
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = [
         "recruitment.view_instructorrecruitment",
         "recruitment.add_instructorrecruitmentsignup",
@@ -527,11 +527,11 @@ class SignupForRecruitment(
 
 class ResignFromRecruitment(
     LoginRequiredMixin,
-    RecruitmentEnabledMixin,
-    ConditionallyEnabledMixin,
+    FlaggedViewMixin,
     SingleObjectMixin,
     View,
 ):
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = [
         "recruitment.view_instructorrecruitmentsignup",
         "recruitment.delete_instructorrecruitmentsignup",

--- a/amy/dashboard/views.py
+++ b/amy/dashboard/views.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 import re
 from urllib.parse import unquote
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import (
@@ -47,6 +48,7 @@ from workshops.base_views import (
     AMYDeleteView,
     AMYListView,
     AMYUpdateView,
+    ConditionallyEnabledMixin,
 )
 from workshops.models import (
     Airport,
@@ -744,8 +746,13 @@ def search(request):
 # ------------------------------------------------------------
 
 
-class AllFeatureFlags(LoginRequiredMixin, TemplateView):
+class AllFeatureFlags(ConditionallyEnabledMixin, LoginRequiredMixin, TemplateView):
     template_name = "dashboard/all_feature_flags.html"
+
+    def get_view_enabled(self, request) -> bool:
+        return bool(
+            settings.PROD_ENVIRONMENT and request.user.is_superuser
+        ) or not bool(settings.PROD_ENVIRONMENT)
 
     def get(self, request: HttpRequest, *args, **kwargs):
         self.request = request

--- a/amy/emails/tests/actions/test_admin_signs_instructor_up_for_workshop.py
+++ b/amy/emails/tests/actions/test_admin_signs_instructor_up_for_workshop.py
@@ -222,8 +222,12 @@ class TestAdminSignsInstructorUpForWorkshopReceiver(TestCase):
 
 
 class TestAdminSignsInstructorUpForWorkshopReceiverIntegration(TestBase):
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
-    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @override_settings(
+        FLAGS={
+            "INSTRUCTOR_RECRUITMENT": [("boolean", True)],
+            "EMAIL_MODULE": [("boolean", True)],
+        }
+    )
     @patch("django.contrib.messages.views.messages")
     @patch("emails.actions.base_action.messages_action_scheduled")
     def test_integration(

--- a/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_receiver.py
@@ -224,8 +224,12 @@ class TestInstructorConfirmedForWorkshopReceiver(TestCase):
 
 
 class TestInstructorConfirmedForWorkshopReceiverIntegration(TestBase):
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
-    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @override_settings(
+        FLAGS={
+            "INSTRUCTOR_RECRUITMENT": [("boolean", True)],
+            "EMAIL_MODULE": [("boolean", True)],
+        }
+    )
     @patch("django.contrib.messages.views.messages")
     @patch("emails.actions.base_action.messages_action_scheduled")
     def test_integration(

--- a/amy/emails/tests/actions/test_instructor_declined_from_workshop.py
+++ b/amy/emails/tests/actions/test_instructor_declined_from_workshop.py
@@ -222,8 +222,12 @@ class TestInstructorDeclinedFromWorkshopReceiver(TestCase):
 
 
 class TestInstructorDeclinedFromWorkshopReceiverIntegration(TestBase):
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
-    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @override_settings(
+        FLAGS={
+            "INSTRUCTOR_RECRUITMENT": [("boolean", True)],
+            "EMAIL_MODULE": [("boolean", True)],
+        }
+    )
     @patch("django.contrib.messages.views.messages")
     @patch("emails.actions.base_action.messages_action_scheduled")
     def test_integration(

--- a/amy/emails/tests/actions/test_instructor_signs_up_for_workshop.py
+++ b/amy/emails/tests/actions/test_instructor_signs_up_for_workshop.py
@@ -222,8 +222,12 @@ class TestInstructorSignsUpForWorkshopReceiver(TestCase):
 
 
 class TestInstructorSignsUpForWorkshopReceiverIntegration(TestBase):
-    @override_settings(INSTRUCTOR_RECRUITMENT_ENABLED=True)
-    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @override_settings(
+        FLAGS={
+            "INSTRUCTOR_RECRUITMENT": [("boolean", True)],
+            "EMAIL_MODULE": [("boolean", True)],
+        }
+    )
     @patch("django.contrib.messages.views.messages")
     @patch("emails.actions.base_action.messages_action_scheduled")
     def test_integration(

--- a/amy/recruitment/templatetags/instructorrecruitment.py
+++ b/amy/recruitment/templatetags/instructorrecruitment.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 from typing import Sequence, Union
 
 from django import template
-from django.conf import settings
 
 from recruitment.models import (
     InstructorRecruitment,
@@ -12,14 +11,6 @@ from recruitment.models import (
 from workshops.models import Event
 
 register = template.Library()
-
-
-@register.simple_tag
-def is_instructor_recruitment_enabled() -> bool:
-    try:
-        return bool(settings.INSTRUCTOR_RECRUITMENT_ENABLED)
-    except AttributeError:
-        return False
 
 
 @register.simple_tag

--- a/amy/recruitment/tests/test_template_tags.py
+++ b/amy/recruitment/tests/test_template_tags.py
@@ -1,7 +1,6 @@
 from datetime import date
 
-from django.conf import settings
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from recruitment.models import (
     InstructorRecruitment,
@@ -12,25 +11,12 @@ from recruitment.templatetags.instructorrecruitment import (
     get_event_conflicts,
     get_events_nearby,
     get_signup_conflicts,
-    is_instructor_recruitment_enabled,
     priority_label,
 )
 from workshops.models import Event
 
 
 class TestInstructorRecruitmentTemplateTags(TestCase):
-    def test_feature_flag_enabled(self) -> None:
-        with self.settings(INSTRUCTOR_RECRUITMENT_ENABLED=False):
-            self.assertEqual(is_instructor_recruitment_enabled(), False)
-        with self.settings(INSTRUCTOR_RECRUITMENT_ENABLED=True):
-            self.assertEqual(is_instructor_recruitment_enabled(), True)
-
-    @override_settings()
-    def test_feature_flag_removed(self) -> None:
-        del settings.INSTRUCTOR_RECRUITMENT_ENABLED
-
-        self.assertEqual(is_instructor_recruitment_enabled(), False)
-
     def test_get_event_conflicts(self) -> None:
         # Arrange
         event1 = Event(

--- a/amy/recruitment/views.py
+++ b/amy/recruitment/views.py
@@ -3,7 +3,6 @@ import logging
 from typing import Callable
 from urllib.parse import unquote
 
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
@@ -16,6 +15,7 @@ from django.urls import reverse
 from django.views.generic import View
 from django.views.generic.edit import FormMixin, FormView
 import django_rq
+from flags.views import FlaggedViewMixin
 
 from emails.signals import (
     admin_signs_instructor_up_for_workshop_signal,
@@ -35,7 +35,6 @@ from workshops.base_views import (
     AMYDetailView,
     AMYListView,
     AMYUpdateView,
-    ConditionallyEnabledMixin,
     RedirectSupportMixin,
 )
 from workshops.models import Event, Person, Role, Task
@@ -53,14 +52,8 @@ redis_connection = django_rq.get_connection("default")
 # InstructorRecruitment related views
 
 
-class RecruitmentEnabledMixin:
-    def get_view_enabled(self) -> bool:
-        return settings.INSTRUCTOR_RECRUITMENT_ENABLED is True
-
-
-class InstructorRecruitmentList(
-    OnlyForAdminsMixin, RecruitmentEnabledMixin, ConditionallyEnabledMixin, AMYListView
-):
+class InstructorRecruitmentList(OnlyForAdminsMixin, FlaggedViewMixin, AMYListView):
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = "recruitment.view_instructorrecruitment"
     title = "Recruitment processes"
     filter_class = InstructorRecruitmentFilter
@@ -154,10 +147,10 @@ class InstructorRecruitmentCreate(
     OnlyForAdminsMixin,
     PermissionRequiredMixin,
     RedirectSupportMixin,
-    RecruitmentEnabledMixin,
-    ConditionallyEnabledMixin,
+    FlaggedViewMixin,
     AMYCreateView,
 ):
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = "recruitment.add_instructorrecruitment"
     model = InstructorRecruitment
     template_name = "recruitment/instructorrecruitment_add.html"
@@ -233,10 +226,10 @@ class InstructorRecruitmentCreate(
 
 class InstructorRecruitmentDetails(
     OnlyForAdminsMixin,
-    RecruitmentEnabledMixin,
-    ConditionallyEnabledMixin,
+    FlaggedViewMixin,
     AMYDetailView,
 ):
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = "recruitment.view_instructorrecruitment"
     queryset = (
         InstructorRecruitment.objects.annotate_with_priority()
@@ -296,14 +289,14 @@ class InstructorRecruitmentDetails(
 
 class InstructorRecruitmentAddSignup(
     OnlyForAdminsMixin,
-    RecruitmentEnabledMixin,
-    ConditionallyEnabledMixin,
+    FlaggedViewMixin,
     SuccessMessageMixin,
     PermissionRequiredMixin,
     FormView,
 ):
     """POST requests for adding new signup for an existing recruitment."""
 
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = [
         "recruitment.change_instructorrecruitment",
         "recruitment.view_instructorrecruitmentsignup",
@@ -358,14 +351,14 @@ class InstructorRecruitmentAddSignup(
 
 class InstructorRecruitmentSignupChangeState(
     OnlyForAdminsMixin,
-    RecruitmentEnabledMixin,
-    ConditionallyEnabledMixin,
+    FlaggedViewMixin,
     FormMixin,
     PermissionRequiredMixin,
     View,
 ):
     """POST requests for editing (confirming or declining) the instructor signup."""
 
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = "recruitment.change_instructorrecruitmentsignup"
     form_class = InstructorRecruitmentSignupChangeStateForm
 
@@ -477,14 +470,14 @@ class InstructorRecruitmentSignupChangeState(
 
 class InstructorRecruitmentChangeState(
     OnlyForAdminsMixin,
-    RecruitmentEnabledMixin,
-    ConditionallyEnabledMixin,
+    FlaggedViewMixin,
     FormMixin,
     PermissionRequiredMixin,
     View,
 ):
     """POST requests for editing (e.g. closing) the instructor recruitment."""
 
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     form_class = InstructorRecruitmentChangeStateForm
     permission_required = "recruitment.change_instructorrecruitment"
 
@@ -585,10 +578,10 @@ class InstructorRecruitmentSignupUpdate(
     OnlyForAdminsMixin,
     PermissionRequiredMixin,
     RedirectSupportMixin,
-    RecruitmentEnabledMixin,
-    ConditionallyEnabledMixin,
+    FlaggedViewMixin,
     AMYUpdateView,
 ):
+    flag_name = "INSTRUCTOR_RECRUITMENT"
     permission_required = "recruitment.change_instructorrecruitmentsignup"
     form_class = InstructorRecruitmentSignupUpdateForm
     model = InstructorRecruitmentSignup

--- a/amy/templates/dashboard/all_feature_flags.html
+++ b/amy/templates/dashboard/all_feature_flags.html
@@ -26,10 +26,16 @@
       <td>
         {% flag_enabled flag.name as state %}{{ state|yesno|title }}.
         {% first_parameter_condition flag as parameter %}
-        {% if not state %}
+        {% can_change_state flag as can_change_flag_state %}
+
+        {% if state is False and can_change_flag_state %}
           <a href="?{{ parameter.value|parameter_strip_value }}=true">Enable.</a>
-        {% else %}
+        {% elif state is True and can_change_flag_state %}
           <a href="?{{ parameter.value|parameter_strip_value }}=false">Disable.</a>
+        {% elif state is False and not can_change_flag_state %}
+          Cannot enable.
+        {% elif state is True and not can_change_flag_state %}
+          Cannot disable.
         {% endif %}
       </td>
     </tr>

--- a/amy/templates/dashboard/instructor_dashboard.html
+++ b/amy/templates/dashboard/instructor_dashboard.html
@@ -6,11 +6,11 @@
 {% load communityroles %}
 {% load crispy_forms_tags %}
 {% load dates %}
-{% load instructorrecruitment %}
+{% load feature_flags %}
 
 {% block content %}
 
-{% is_instructor_recruitment_enabled as INSTRUCTOR_RECRUITMENT_ENABLED %}
+{% flag_enabled 'INSTRUCTOR_RECRUITMENT' as INSTRUCTOR_RECRUITMENT_ENABLED %}
 {% get_community_role user role_name="instructor" as INSTRUCTOR_COMMUNITY_ROLE %}
 {% if INSTRUCTOR_RECRUITMENT_ENABLED and INSTRUCTOR_COMMUNITY_ROLE.is_active %}
 <a href="{% url 'upcoming-teaching-opportunities' %}" class="btn btn-primary btn-lg my-3">View upcoming teaching opportunities with The Carpentries</a>

--- a/amy/templates/navigation_instructor_dashboard.html
+++ b/amy/templates/navigation_instructor_dashboard.html
@@ -1,6 +1,6 @@
 {% load navigation %}
 {% load communityroles %}
-{% load instructorrecruitment %}
+{% load feature_flags %}
 {% block navbar %}
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <a class="navbar-brand" href="{% url 'admin-dashboard' %}">AMY</a>
@@ -17,7 +17,7 @@
           {% navbar_element "Update data" "autoupdate_profile" %}
           {% navbar_element "Training progress" "training-progress" %}
 
-          {% is_instructor_recruitment_enabled as INSTRUCTOR_RECRUITMENT_ENABLED %}
+          {% flag_enabled 'INSTRUCTOR_RECRUITMENT' as INSTRUCTOR_RECRUITMENT_ENABLED %}
           {% get_community_role user role_name="instructor" as INSTRUCTOR_COMMUNITY_ROLE %}
           {% if INSTRUCTOR_RECRUITMENT_ENABLED and INSTRUCTOR_COMMUNITY_ROLE.is_active %}
             {% navbar_element "Upcoming Teaching Opportunities" "upcoming-teaching-opportunities" %}

--- a/amy/templates/workshops/event.html
+++ b/amy/templates/workshops/event.html
@@ -5,7 +5,7 @@
 {% load revisions %}
 {% load tags %}
 {% load dates %}
-{% load instructorrecruitment %}
+{% load feature_flags %}
 {% load consents %}
 
 {% block title %}
@@ -26,7 +26,7 @@
     </div>
     <div class="col-lg-6">
       {% comment %} Only show Instructor Selection summary in centrally-organised events. Exclude TTT events, too. {% endcomment %}
-      {% is_instructor_recruitment_enabled as INSTRUCTOR_RECRUITMENT_ENABLED %}
+      {% flag_enabled 'INSTRUCTOR_RECRUITMENT' as INSTRUCTOR_RECRUITMENT_ENABLED %}
       {% if INSTRUCTOR_RECRUITMENT_ENABLED %}
         {% if "TTT" not in event.tags.strings and event.administrator.domain != "self-organized" %}
           {% include "includes/instructor_selection_summary.html" with event=event stats=recruitment_stats %}

--- a/amy/workshops/base_views.py
+++ b/amy/workshops/base_views.py
@@ -450,11 +450,11 @@ class ConditionallyEnabledMixin:
 
     view_enabled: Optional[bool] = None
 
-    def get_view_enabled(self) -> bool:
+    def get_view_enabled(self, request) -> bool:
         return self.view_enabled is True
 
     def dispatch(self, request, *args, **kwargs):
-        if self.get_view_enabled() is not True:
+        if self.get_view_enabled(request) is not True:
             raise Http404("Page not found")
 
         return super().dispatch(request, *args, **kwargs)

--- a/amy/workshops/templatetags/feature_flag_conditions.py
+++ b/amy/workshops/templatetags/feature_flag_conditions.py
@@ -9,6 +9,11 @@ def first_parameter_condition(flag: Flag) -> Condition | None:
     return next((c for c in flag.conditions if c.condition == "parameter"), None)
 
 
+@register.simple_tag
+def can_change_state(flag: Flag) -> bool:
+    return any(c.condition == "parameter" for c in flag.conditions)
+
+
 @register.filter
 def parameter_strip_value(url: str) -> str:
     try:

--- a/amy/workshops/tests/test_base_views.py
+++ b/amy/workshops/tests/test_base_views.py
@@ -31,7 +31,7 @@ class TestConditionallyEnabledView(TestCase):
     def test_disabled_view_through_method(self):
         # Arrange
         class View(ConditionallyEnabledMixin, FakeView):
-            def get_view_enabled(self) -> bool:
+            def get_view_enabled(self, request) -> bool:
                 return False
 
         view = View()
@@ -60,7 +60,7 @@ class TestConditionallyEnabledView(TestCase):
     def test_enabled_view_through_method(self):
         # Arrange
         class View(ConditionallyEnabledMixin, FakeView):
-            def get_view_enabled(self) -> bool:
+            def get_view_enabled(self, request) -> bool:
                 return True
 
         view = View()

--- a/amy/workshops/tests/test_template_tags.py
+++ b/amy/workshops/tests/test_template_tags.py
@@ -2,13 +2,14 @@ from django.test import TestCase
 from flags.sources import Condition, Flag
 
 from workshops.templatetags.feature_flag_conditions import (
+    can_change_state,
     first_parameter_condition,
     parameter_strip_value,
 )
 
 
 class TestFeatureFlagConditions(TestCase):
-    def test_first_parameter_condition(self):
+    def test_first_parameter_condition(self) -> None:
         # Arrange
         condition1 = Condition(condition="session", value="test")
         condition2 = Condition(condition="parameter", value="test")
@@ -19,7 +20,7 @@ class TestFeatureFlagConditions(TestCase):
         # Assert
         self.assertEqual(result, condition2)
 
-    def test_first_parameter_condition__not_found(self):
+    def test_first_parameter_condition__not_found(self) -> None:
         # Arrange
         condition1 = Condition(condition="session", value="test")
         condition2 = Condition(condition="user", value="test")
@@ -30,7 +31,21 @@ class TestFeatureFlagConditions(TestCase):
         # Assert
         self.assertIsNone(result)
 
-    def test_url_parameter_strip_value(self):
+    def test_can_change_state(self) -> None:
+        # Arrange
+        condition1 = Condition(condition="session", value="test")
+        condition2 = Condition(condition="parameter", value="test")
+        condition3 = Condition(condition="boolean", value=True)
+        flag1 = Flag(name="TEST_FLAG1", conditions=[condition1, condition2, condition3])
+        flag2 = Flag(name="TEST_FLAG2", conditions=[condition3])
+        # Act
+        result1 = can_change_state(flag1)
+        result2 = can_change_state(flag2)
+        # Assert
+        self.assertTrue(result1)
+        self.assertFalse(result2)
+
+    def test_parameter_strip_value(self) -> None:
         # Arrange
         url = "https://example.com/?test=1asdf"
         # Act
@@ -38,7 +53,7 @@ class TestFeatureFlagConditions(TestCase):
         # Assert
         self.assertEqual(result, "https://example.com/?test")
 
-    def test_url_parameter_strip_value__missing_rhs(self):
+    def test_parameter_strip_value__missing_rhs(self) -> None:
         # Arrange
         url = "test"
         # Act

--- a/config/settings.py
+++ b/config/settings.py
@@ -674,6 +674,8 @@ if SITE_BANNER_STYLE not in ("local", "testing", "production"):
         "SITE_BANNER_STYLE accepts only one of 'local', 'testing', 'production'."
     )
 
+PROD_ENVIRONMENT = bool(SITE_BANNER_STYLE == "production")
+
 # Feature Flags
 # -----------------------------------------------------------------------------
 # These flags are used to enable/disable features in AMY.

--- a/config/settings.py
+++ b/config/settings.py
@@ -696,18 +696,14 @@ PROD_ENVIRONMENT = bool(SITE_BANNER_STYLE == "production")
 #  }
 # ------------
 FLAGS = {
-    # Enables instructor recruitment views; this should be enabled in all environments.
+    # Enable instructor recruitment views.
     "INSTRUCTOR_RECRUITMENT": [
         {"condition": "boolean", "value": True},
     ],
     # ------------
-    # Enables the new email module. It's only for logged-in users and it has to be
-    # enabled through `?enable_email_module` GET parameter or the same parameter stored
-    # in request session.
+    # Enable the new email module.
     "EMAIL_MODULE": [
-        {"condition": "anonymous", "value": False, "required": True},
-        {"condition": "parameter", "value": "enable_email_module=true"},
-        {"condition": "session", "value": "enable_email_module"},
+        {"condition": "boolean", "value": True},
     ],
     # Always enabled.
     "ENFORCE_MEMBER_CODES": [

--- a/config/settings.py
+++ b/config/settings.py
@@ -46,8 +46,6 @@ env = environ.Env(
         "https://workshop-reports.carpentries.org/?key={hash}&slug={slug}",
     ),
     AMY_SITE_BANNER=(str, "local"),  # should be "local", "testing", or "production"
-    # Feature flags
-    AMY_INSTRUCTOR_RECRUITMENT_ENABLED=(bool, True),
 )
 
 # OS environment variables take precedence over variables from .env
@@ -666,11 +664,6 @@ if not DEBUG and not (REPORTS_SALT_FRONT and REPORTS_SALT_BACK):
 
 REPORTS_LINK = env("AMY_REPORTS_LINK")
 
-# Instructor Recruitment Process
-# -----------------------------------------------------------------------------
-# Settings for Instructor Recruitment project
-INSTRUCTOR_RECRUITMENT_ENABLED = env("AMY_INSTRUCTOR_RECRUITMENT_ENABLED")
-
 # Site banner style
 # -----------------------------------------------------------------------------
 # This should show a special banner on all sites so that users are aware of
@@ -702,8 +695,9 @@ if SITE_BANNER_STYLE not in ("local", "testing", "production"):
 # ------------
 FLAGS = {
     # Enables instructor recruitment views; this should be enabled in all environments.
-    # The flag itself was not migrated from envvar to django-flags mechanism.
-    # "INSTRUCTOR_RECRUITMENT": [{"condition": "boolean", "value": True}],
+    "INSTRUCTOR_RECRUITMENT": [
+        {"condition": "boolean", "value": True},
+    ],
     # ------------
     # Enables the new email module. It's only for logged-in users and it has to be
     # enabled through `?enable_email_module` GET parameter or the same parameter stored

--- a/config/settings.py
+++ b/config/settings.py
@@ -685,13 +685,13 @@ if SITE_BANNER_STYLE not in ("local", "testing", "production"):
 # Disabling the feature flag should be done by setting the URL parameter to `=false`.
 # There should also be included a session condition. For example:
 #
-#     FLAGS = {
-#         "EMAIL_MODULE": [
-#             {"condition": "anonymous", "value": False, "required": True},
-#             {"condition": "parameter", "value": "enable_email_module=true"},
-#             {"condition": "session", "value": "enable_email_module"},
-#         ],
-#     }
+#  FLAGS = {
+#      "SOME_MODULE": [
+#          {"condition": "anonymous", "value": False, "required": True},
+#          {"condition": "parameter", "value": "enable_some_module=true"},  # CHANGE ME
+#          {"condition": "session", "value": "enable_some_module"},  # CHANGE ME
+#      ],
+#  }
 # ------------
 FLAGS = {
     # Enables instructor recruitment views; this should be enabled in all environments.


### PR DESCRIPTION
This fixes #2687.
This fixes #2524.

1. Email module feature flag is enabled.
2. Feature Flags view is enabled in production only for admin users.
3. Small improvements for managing feature flags in UI.
4. Old feature, Instructor Recruitment, was switched to feature flags system (and always enabled).