### PR TITLE
[Emails] Rendering emails - switch to API serializers to fix error

### DIFF
--- a/amy/api/v2/tests/test_scheduled_emails_api.py
+++ b/amy/api/v2/tests/test_scheduled_emails_api.py
@@ -74,8 +74,8 @@ class TestScheduledEmailsAPI(SuperuserMixin, TestCase):
                     {
                         "api_uri": api_model_url("person", self.harry.pk),
                         "property": "email",
-                    }
-                ]  # type: ignore
+                    }  # type: ignore
+                ]
             ),
             generic_relation_obj=generic_relation_obj,
             author=author,

--- a/amy/emails/tests/test_views.py
+++ b/amy/emails/tests/test_views.py
@@ -5,6 +5,7 @@ from django.test import RequestFactory, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+from api.v2.serializers import PersonSerializer
 from emails.models import (
     EmailTemplate,
     ScheduledEmail,
@@ -349,7 +350,7 @@ class TestScheduledEmailDetails(TestBase):
             rv.context["rendered_context"],
             {
                 "a_list": [1, 2],
-                "hermione": self.hermione,
+                "hermione": PersonSerializer(self.hermione).data,
                 "personal": "Harry",
                 "family": "Potter",
             },

--- a/amy/emails/views.py
+++ b/amy/emails/views.py
@@ -164,14 +164,14 @@ class ScheduledEmailDetails(OnlyForAdminsMixin, FlaggedViewMixin, AMYDetailView)
             context["rendered_body"] = markdownify(
                 jinjanify(engine, self.object.body, body_context)
             )
-        except TemplateError as exc:
+        except (TemplateError, AttributeError, ValueError, TypeError) as exc:
             context["rendered_body"] = markdownify(f"Unable to render template: {exc}")
 
         try:
             context["rendered_subject"] = jinjanify(
                 engine, self.object.subject, body_context
             )
-        except TemplateError as exc:
+        except (TemplateError, AttributeError, ValueError, TypeError) as exc:
             context["rendered_subject"] = f"Unable to render template: {exc}"
 
         try:

--- a/amy/emails/views.py
+++ b/amy/emails/views.py
@@ -180,7 +180,6 @@ class ScheduledEmailDetails(OnlyForAdminsMixin, FlaggedViewMixin, AMYDetailView)
             )
             context["rendered_to_header_context"] = to_header_context
         except ValueError as exc:
-            to_header_context = {}
             context["rendered_to_header_context"] = f"Unable to render context: {exc}"
 
         context["status_explanation"] = ScheduledEmailStatusExplanation[


### PR DESCRIPTION
This fixes #2694.

The error was caused by accessing event.tags object from the email template; for the worker this object was going to be a list of strings, whereas in the code this was a manager, which needed a different (special) handling. Fix involved serializing the event as the API does it.
