### PR TITLE
[Emails] Update trigger for the host-instructor introduction

### DIFF
--- a/amy/recruitment/tests/test_instructor_recruitment_views.py
+++ b/amy/recruitment/tests/test_instructor_recruitment_views.py
@@ -12,6 +12,7 @@ from communityroles.models import (
     CommunityRoleConfig,
     CommunityRoleInactivation,
 )
+from emails.types import StrategyEnum
 from recruitment.filters import InstructorRecruitmentFilter
 from recruitment.forms import (
     InstructorRecruitmentAddSignupForm,
@@ -983,8 +984,12 @@ class TestInstructorRecruitmentChangeState(TestBase):
         )
         self.assertEqual(result.status_code, 302)
 
-    def test_close_recruitment__success(self) -> None:
+    @mock.patch("recruitment.views.host_instructors_introduction_strategy")
+    def test_close_recruitment__success(
+        self, mock_host_instructors_introduction_strategy: mock.MagicMock
+    ) -> None:
         # Arrange
+        mock_host_instructors_introduction_strategy.return_value = StrategyEnum.NOOP
         request = RequestFactory().post("/")
         view = InstructorRecruitmentChangeState(request=request)
         view._validate_for_closing = mock.MagicMock(return_value=True)
@@ -1039,8 +1044,12 @@ class TestInstructorRecruitmentChangeState(TestBase):
         )
         self.assertEqual(result.status_code, 302)
 
-    def test_reopen_recruitment__success(self) -> None:
+    @mock.patch("recruitment.views.host_instructors_introduction_strategy")
+    def test_reopen_recruitment__success(
+        self, mock_host_instructors_introduction_strategy: mock.MagicMock
+    ) -> None:
         # Arrange
+        mock_host_instructors_introduction_strategy.return_value = StrategyEnum.NOOP
         request = RequestFactory().post("/")
         view = InstructorRecruitmentChangeState(request=request)
         view._validate_for_reopening = mock.MagicMock(return_value=True)

--- a/amy/recruitment/views.py
+++ b/amy/recruitment/views.py
@@ -17,6 +17,10 @@ from django.views.generic.edit import FormMixin, FormView
 import django_rq
 from flags.views import FlaggedViewMixin
 
+from emails.actions.host_instructors_introduction import (
+    host_instructors_introduction_strategy,
+    run_host_instructors_introduction_strategy,
+)
 from emails.signals import (
     admin_signs_instructor_up_for_workshop_signal,
     instructor_confirmed_for_workshop_signal,
@@ -522,6 +526,12 @@ class InstructorRecruitmentChangeState(
                 f"Successfully closed recruitment {self.object}.",
             )
 
+            run_host_instructors_introduction_strategy(
+                host_instructors_introduction_strategy(self.object.event),
+                self.request,
+                self.object.event,
+            )
+
         return HttpResponseRedirect(self.get_success_url())
 
     @staticmethod
@@ -542,6 +552,12 @@ class InstructorRecruitmentChangeState(
             self.object.save()
             messages.success(
                 self.request, f"Successfully re-opened recruitment {self.object}."
+            )
+
+            run_host_instructors_introduction_strategy(
+                host_instructors_introduction_strategy(self.object.event),
+                self.request,
+                self.object.event,
             )
 
         return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
When recruitment is opened or closed, the strategy for host-instructor introduction is run.

This fixes #2695.