### PR TITLE
[Emails] Link to other related scheduled emails

### DIFF
--- a/amy/templates/emails/email_template_list.html
+++ b/amy/templates/emails/email_template_list.html
@@ -12,7 +12,6 @@
 {% if email_templates %}
     <table class="table table-striped">
       <tr>
-        <th>ID</th>
         <th>Name</th>
         <th>Active</th>
         <th>Signal</th>
@@ -25,8 +24,7 @@
       </tr>
     {% for template in email_templates %}
       <tr>
-        <td><a href="{{ template.get_absolute_url }}">{{ template.id }}</a></td>
-        <td>{{ template.name }}</td>
+        <td><a href="{{ template.get_absolute_url }}">{{ template.name }}</a></td>
         <td>{{ template.active|yesno }}</td>
         <td><code>{{ template.signal }}</code></td>
         <td>{{ template.from_header }}</td>

--- a/amy/templates/includes/event_details_table.html
+++ b/amy/templates/includes/event_details_table.html
@@ -91,8 +91,20 @@
     </td></tr>
   <tr>
     <th>Related scheduled emails:</th>
-    <td>
+    <td colspan="2">
       {% include "includes/related_scheduled_emails.html" with object=event %}
+    </td>
+  </tr>
+  <tr>
+    <th>Related scheduled emails for recruitments:</th>
+    <td colspan="2">
+      {% with signups=related_instructor_recruitment_signups %}
+      {% for signup in signups %}
+      {% include "includes/related_scheduled_emails_no_empty_msg.html" with object=signup %}
+      {% empty %}
+      &mdash;
+      {% endfor %}
+      {% endwith %}
     </td>
   </tr>
 </table>

--- a/amy/templates/workshops/person.html
+++ b/amy/templates/workshops/person.html
@@ -268,7 +268,19 @@
       {% with awards=person.award_set.all %}
       {% for award in awards %}
       {% include "includes/related_scheduled_emails_no_empty_msg.html" with object=award %}
-      {% empty%}
+      {% empty %}
+      &mdash;
+      {% endfor %}
+      {% endwith %}
+    </td>
+  </tr>
+  <tr>
+    <th>Related scheduled emails for recruitments:</th>
+    <td>
+      {% with signups=person.instructorrecruitmentsignup_set.all %}
+      {% for signup in signups %}
+      {% include "includes/related_scheduled_emails_no_empty_msg.html" with object=signup %}
+      {% empty %}
       &mdash;
       {% endfor %}
       {% endwith %}

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -81,6 +81,7 @@ from emails.actions.recruit_helpers import (
 )
 from emails.signals import persons_merged_signal
 from fiscal.models import MembershipTask
+from recruitment.models import InstructorRecruitmentSignup
 from workshops.base_views import (
     AMYCreateView,
     AMYDeleteView,
@@ -1087,6 +1088,12 @@ def event_details(request, slug):
     admin_lookup_form.helper = BootstrapHelper(
         form_action=reverse("event_assign", args=[slug]), add_cancel_button=False
     )
+    if hasattr(event, "instructorrecruitment"):
+        instructor_recruitment_signups = InstructorRecruitmentSignup.objects.filter(
+            recruitment=event.instructorrecruitment
+        )
+    else:
+        instructor_recruitment_signups = []
 
     context = {
         "title": "Event {0}".format(event),
@@ -1109,6 +1116,7 @@ def event_details(request, slug):
             "longitude": event.longitude,
         },
         "recruitment_stats": recruitment_stats,
+        "related_instructor_recruitment_signups": instructor_recruitment_signups,
     }
     return render(request, "workshops/event.html", context)
 


### PR DESCRIPTION
This fixes #2696. New links were introduced to event and person details page.