### PR TITLE
[Emails] Update Tag condition for some email actions

### DIFF
--- a/amy/emails/actions/ask_for_website.py
+++ b/amy/emails/actions/ask_for_website.py
@@ -24,7 +24,7 @@ from emails.utils import (
     one_month_before,
     scalar_value_none,
 )
-from workshops.models import Event, Task
+from workshops.models import Event, TagQuerySet, Task
 
 logger = logging.getLogger("amy")
 
@@ -39,6 +39,9 @@ def ask_for_website_strategy(event: Event) -> StrategyEnum:
     has_instructors = (
         Task.objects.filter(event=event, role__name="instructor").count() >= 1
     )
+    carpentries_tags = event.tags.filter(
+        name__in=TagQuerySet.CARPENTRIES_TAG_NAMES
+    ).exclude(name__in=TagQuerySet.NON_CARPENTRIES_TAG_NAMES)
 
     log_condition_elements(
         start_date_in_future=start_date_in_future,
@@ -46,6 +49,7 @@ def ask_for_website_strategy(event: Event) -> StrategyEnum:
         has_administrator=has_administrator,
         no_url=no_url,
         has_instructors=has_instructors,
+        carpentries_tags=carpentries_tags,
     )
 
     email_should_exist = (
@@ -54,6 +58,7 @@ def ask_for_website_strategy(event: Event) -> StrategyEnum:
         and has_administrator
         and no_url
         and has_instructors
+        and carpentries_tags
     )
     logger.debug(f"{email_should_exist=}")
 

--- a/amy/emails/actions/host_instructors_introduction.py
+++ b/amy/emails/actions/host_instructors_introduction.py
@@ -29,7 +29,7 @@ from emails.utils import (
     scalar_value_none,
 )
 from recruitment.models import InstructorRecruitment
-from workshops.models import Event, Task
+from workshops.models import Event, TagQuerySet, Task
 
 logger = logging.getLogger("amy")
 
@@ -51,6 +51,9 @@ def host_instructors_introduction_strategy(event: Event) -> StrategyEnum:
     at_least_2_instructors = (
         Task.objects.filter(role__name="instructor", event=event).count() >= 2
     )
+    carpentries_tags = event.tags.filter(
+        name__in=TagQuerySet.CARPENTRIES_TAG_NAMES
+    ).exclude(name__in=TagQuerySet.NON_CARPENTRIES_TAG_NAMES)
 
     log_condition_elements(
         not_self_organised=not_self_organised,
@@ -59,6 +62,7 @@ def host_instructors_introduction_strategy(event: Event) -> StrategyEnum:
         active=active,
         host=host,
         at_least_2_instructors=at_least_2_instructors,
+        carpentries_tags=carpentries_tags,
     )
 
     email_should_exist = (
@@ -68,6 +72,7 @@ def host_instructors_introduction_strategy(event: Event) -> StrategyEnum:
         and host
         and at_least_2_instructors
         and no_open_recruitment
+        and carpentries_tags
     )
     logger.debug(f"{email_should_exist=}")
 

--- a/amy/emails/actions/recruit_helpers.py
+++ b/amy/emails/actions/recruit_helpers.py
@@ -24,7 +24,7 @@ from emails.utils import (
     scalar_value_none,
     shift_date_and_apply_current_utc_time,
 )
-from workshops.models import Event, Task
+from workshops.models import Event, TagQuerySet, Task
 
 logger = logging.getLogger("amy")
 
@@ -44,6 +44,9 @@ def recruit_helpers_strategy(event: Event) -> StrategyEnum:
         Task.objects.filter(role__name="instructor", event=event).count() >= 1
     )
     no_helpers = Task.objects.filter(role__name="helper", event=event).count() == 0
+    carpentries_tags = event.tags.filter(
+        name__in=TagQuerySet.CARPENTRIES_TAG_NAMES
+    ).exclude(name__in=TagQuerySet.NON_CARPENTRIES_TAG_NAMES)
 
     log_condition_elements(
         not_self_organised=not_self_organised,
@@ -52,6 +55,7 @@ def recruit_helpers_strategy(event: Event) -> StrategyEnum:
         at_least_1_host=at_least_1_host,
         at_least_1_instructor=at_least_1_instructor,
         no_helpers=no_helpers,
+        carpentries_tags=carpentries_tags,
     )
 
     email_should_exist = (
@@ -61,6 +65,7 @@ def recruit_helpers_strategy(event: Event) -> StrategyEnum:
         and at_least_1_host
         and at_least_1_instructor
         and no_helpers
+        and carpentries_tags
     )
     logger.debug(f"{email_should_exist=}")
 

--- a/amy/emails/tests/actions/test_ask_for_website_cancel_receiver.py
+++ b/amy/emails/tests/actions/test_ask_for_website_cancel_receiver.py
@@ -11,7 +11,7 @@ from emails.actions.ask_for_website import (
 )
 from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailStatus
 from emails.signals import ASK_FOR_WEBSITE_SIGNAL_NAME, ask_for_website_cancel_signal
-from workshops.models import Event, Organization, Person, Role, Task
+from workshops.models import Event, Organization, Person, Role, Tag, Task
 from workshops.tests.base import TestBase
 
 
@@ -222,6 +222,7 @@ class TestAskForWebsiteCancelIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
+        event.tags.set([Tag.objects.get(name="SWC")])
 
         instructor1 = Person.objects.create(
             personal="Kelsi",

--- a/amy/emails/tests/actions/test_ask_for_website_receiver.py
+++ b/amy/emails/tests/actions/test_ask_for_website_receiver.py
@@ -210,8 +210,7 @@ class TestAskForWebsiteReceiverIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        ttt_tag = Tag.objects.get(name="TTT")
-        event.tags.add(ttt_tag)
+        event.tags.set([Tag.objects.get(name="SWC")])
 
         instructor1 = Person.objects.create(
             personal="Kelsi",

--- a/amy/emails/tests/actions/test_ask_for_website_strategy.py
+++ b/amy/emails/tests/actions/test_ask_for_website_strategy.py
@@ -11,7 +11,7 @@ from emails.actions.exceptions import EmailStrategyException
 from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailStatus
 from emails.signals import ASK_FOR_WEBSITE_SIGNAL_NAME
 from emails.types import StrategyEnum
-from workshops.models import Event, Organization, Person, Role, Task
+from workshops.models import Event, Organization, Person, Role, Tag, Task
 
 
 class TestAskForWebsiteStrategy(TestCase):
@@ -19,12 +19,14 @@ class TestAskForWebsiteStrategy(TestCase):
         self.ttt_organization = Organization.objects.create(
             domain="carpentries.org", fullname="Instructor Training"
         )
+        swc_tag = Tag.objects.create(name="SWC")
         self.event = Event.objects.create(
             slug="test-event",
             host=Organization.objects.create(domain="example.com", fullname="Example"),
             administrator=self.ttt_organization,
             start=date.today() + timedelta(days=30),
         )
+        self.event.tags.set([swc_tag])
 
         self.instructor_role = Role.objects.create(name="instructor")
         self.instructor1 = Person.objects.create(

--- a/amy/emails/tests/actions/test_ask_for_website_update_receiver.py
+++ b/amy/emails/tests/actions/test_ask_for_website_update_receiver.py
@@ -301,8 +301,8 @@ class TestAskForWebsiteUpdateIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        ttt_tag = Tag.objects.get(name="TTT")
-        event.tags.add(ttt_tag)
+        swc_tag = Tag.objects.get(name="SWC")
+        event.tags.add(swc_tag)
 
         instructor1 = Person.objects.create(
             personal="Kelsi",
@@ -342,7 +342,7 @@ class TestAskForWebsiteUpdateIntegration(TestBase):
             "sponsor": event.host.pk,
             "administrator": event.administrator.pk,  # type: ignore
             "start": date.today() + timedelta(days=60),
-            "tags": [ttt_tag.pk],
+            "tags": [swc_tag.pk],
         }
 
         # Act

--- a/amy/emails/tests/actions/test_host_instructors_introduction_cancel_receiver.py
+++ b/amy/emails/tests/actions/test_host_instructors_introduction_cancel_receiver.py
@@ -242,8 +242,7 @@ class TestHostInstructorsIntroductionCancelIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        ttt_tag = Tag.objects.get(name="TTT")
-        event.tags.add(ttt_tag)
+        event.tags.set([Tag.objects.get(name="SWC")])
 
         instructor1 = Person.objects.create(
             personal="Kelsi",

--- a/amy/emails/tests/actions/test_host_instructors_introduction_receiver.py
+++ b/amy/emails/tests/actions/test_host_instructors_introduction_receiver.py
@@ -240,8 +240,7 @@ class TestHostInstructorsIntroductionReceiverIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        ttt_tag = Tag.objects.get(name="TTT")
-        event.tags.add(ttt_tag)
+        event.tags.set([Tag.objects.get(name="SWC")])
 
         instructor1 = Person.objects.create(
             personal="Kelsi",

--- a/amy/emails/tests/actions/test_host_instructors_introduction_strategy.py
+++ b/amy/emails/tests/actions/test_host_instructors_introduction_strategy.py
@@ -25,8 +25,8 @@ class TestHostInstructorsIntroductionStrategy(TestCase):
             administrator=self.ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        self.ttt_tag = Tag.objects.create(name="TTT")
-        self.event.tags.add(self.ttt_tag)
+        swc_tag = Tag.objects.create(name="SWC")
+        self.event.tags.set([swc_tag])
 
         self.instructor_role = Role.objects.create(name="instructor")
         self.instructor1 = Person.objects.create(

--- a/amy/emails/tests/actions/test_host_instructors_introduction_update_receiver.py
+++ b/amy/emails/tests/actions/test_host_instructors_introduction_update_receiver.py
@@ -334,8 +334,8 @@ class TestHostInstructorsIntroductionUpdateIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        ttt_tag = Tag.objects.get(name="TTT")
-        event.tags.add(ttt_tag)
+        swc_tag = Tag.objects.get(name="SWC")
+        event.tags.set([swc_tag])
 
         instructor1 = Person.objects.create(
             personal="Kelsi",
@@ -402,7 +402,7 @@ class TestHostInstructorsIntroductionUpdateIntegration(TestBase):
             "sponsor": event.host.pk,
             "administrator": event.administrator.pk,  # type: ignore
             "start": date.today() + timedelta(days=60),
-            "tags": [ttt_tag.pk],
+            "tags": [swc_tag.pk],
         }
 
         # Act

--- a/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_cancel_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_cancel_receiver.py
@@ -14,11 +14,11 @@ from emails.signals import (
     INSTRUCTOR_CONFIRMED_FOR_WORKSHOP_SIGNAL_NAME,
     instructor_confirmed_for_workshop_cancel_signal,
 )
-from workshops.models import Event, Organization, Person, Role, Task
+from workshops.models import Event, Organization, Person, Role, Tag, Task
 from workshops.tests.base import TestBase
 
 
-class TestInstructorBadgeAwardedCancelReceiver(TestCase):
+class TestInstructorConfirmedForWorkshopCancelReceiver(TestCase):
     def setUp(self) -> None:
         host = Organization.objects.create(domain="test.com", fullname="Test")
         self.event = Event.objects.create(
@@ -205,7 +205,7 @@ class TestInstructorBadgeAwardedCancelReceiver(TestCase):
         )
 
 
-class TestInstructorBadgeAwardedCancelIntegration(TestBase):
+class TestInstructorConfirmedForWorkshopCancelIntegration(TestBase):
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
     def test_integration(self) -> None:
         # Arrange
@@ -235,6 +235,7 @@ class TestInstructorBadgeAwardedCancelIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
+        event.tags.set([Tag.objects.get(name="SWC")])
 
         instructor = Person.objects.create(
             personal="Kelsi",

--- a/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_strategy.py
+++ b/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_strategy.py
@@ -11,7 +11,7 @@ from emails.actions.instructor_confirmed_for_workshop import (
 from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailStatus
 from emails.signals import INSTRUCTOR_CONFIRMED_FOR_WORKSHOP_SIGNAL_NAME
 from emails.types import StrategyEnum
-from workshops.models import Event, Organization, Person, Role, Task
+from workshops.models import Event, Organization, Person, Role, Tag, Task
 
 
 class TestInstructorConfirmedForWorkshopStrategy(TestCase):
@@ -20,6 +20,8 @@ class TestInstructorConfirmedForWorkshopStrategy(TestCase):
         self.event = Event.objects.create(
             slug="test-event", host=host, start=date(2024, 8, 5), end=date(2024, 8, 5)
         )
+        swc_tag = Tag.objects.create(name="SWC")
+        self.event.tags.set([swc_tag])
         self.person = Person.objects.create(email="test@example.org")
         instructor = Role.objects.create(name="instructor")
         self.task = Task.objects.create(

--- a/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_update_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_update_receiver.py
@@ -17,7 +17,7 @@ from emails.signals import (
 )
 from emails.utils import api_model_url, scalar_value_none
 from workshops.forms import PersonForm
-from workshops.models import Event, Organization, Person, Role, Task
+from workshops.models import Event, Organization, Person, Role, Tag, Task
 from workshops.tests.base import TestBase
 
 
@@ -316,6 +316,7 @@ class TestInstructorConfirmedForWorkshopUpdateIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
+        event.tags.set([Tag.objects.get(name="SWC")])
 
         instructor = Person.objects.create(
             personal="Kelsi",

--- a/amy/emails/tests/actions/test_recruit_helpers_cancel_receiver.py
+++ b/amy/emails/tests/actions/test_recruit_helpers_cancel_receiver.py
@@ -15,7 +15,7 @@ from workshops.models import Event, Organization, Person, Role, Tag, Task
 from workshops.tests.base import TestBase
 
 
-class TestHostInstructorsIntroductionCancelReceiver(TestCase):
+class TestRecruitHelpersCancelReceiver(TestCase):
     def setUp(self) -> None:
         self.ttt_organization = Organization.objects.create(
             domain="carpentries.org", fullname="Instructor Training"
@@ -202,7 +202,7 @@ class TestHostInstructorsIntroductionCancelReceiver(TestCase):
         )
 
 
-class TestInstructorTrainingApproachingCancelIntegration(TestBase):
+class TestRecruitHelpersCancelIntegration(TestBase):
     @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
     def test_integration(self) -> None:
         # Arrange
@@ -229,8 +229,7 @@ class TestInstructorTrainingApproachingCancelIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        ttt_tag = Tag.objects.get(name="TTT")
-        event.tags.add(ttt_tag)
+        event.tags.set([Tag.objects.get(name="SWC")])
 
         instructor = Person.objects.create(
             personal="Kelsi",

--- a/amy/emails/tests/actions/test_recruit_helpers_receiver.py
+++ b/amy/emails/tests/actions/test_recruit_helpers_receiver.py
@@ -222,8 +222,7 @@ class TestRecruitHelpersReceiverIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        ttt_tag = Tag.objects.get(name="TTT")
-        event.tags.add(ttt_tag)
+        event.tags.set([Tag.objects.get(name="SWC")])
 
         instructor = Person.objects.create(
             personal="Kelsi",

--- a/amy/emails/tests/actions/test_recruit_helpers_strategy.py
+++ b/amy/emails/tests/actions/test_recruit_helpers_strategy.py
@@ -25,8 +25,8 @@ class TestRecruitHelpersStrategy(TestCase):
             administrator=self.ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        self.ttt_tag = Tag.objects.create(name="TTT")
-        self.event.tags.add(self.ttt_tag)
+        swc_tag = Tag.objects.create(name="SWC")
+        self.event.tags.add(swc_tag)
 
         self.instructor_role = Role.objects.create(name="instructor")
         self.instructor = Person.objects.create(

--- a/amy/emails/tests/actions/test_recruit_helpers_update_receiver.py
+++ b/amy/emails/tests/actions/test_recruit_helpers_update_receiver.py
@@ -313,8 +313,8 @@ class TestRecruitHelpersUpdateIntegration(TestBase):
             administrator=ttt_organization,
             start=date.today() + timedelta(days=30),
         )
-        ttt_tag = Tag.objects.get(name="TTT")
-        event.tags.add(ttt_tag)
+        swc_tag = Tag.objects.get(name="SWC")
+        event.tags.set([swc_tag])
 
         instructor1 = Person.objects.create(
             personal="Kelsi",
@@ -373,7 +373,7 @@ class TestRecruitHelpersUpdateIntegration(TestBase):
             "sponsor": event.host.pk,
             "administrator": event.administrator.pk,  # type: ignore
             "start": date.today() + timedelta(days=60),
-            "tags": [ttt_tag.pk],
+            "tags": [swc_tag.pk],
         }
 
         # Act

--- a/amy/workshops/models.py
+++ b/amy/workshops/models.py
@@ -1076,6 +1076,7 @@ class Person(
 
 class TagQuerySet(QuerySet):
     CARPENTRIES_TAG_NAMES = ["SWC", "DC", "LC"]
+    NON_CARPENTRIES_TAG_NAMES = ["TTT", "Circuits", "CLDT"]
     MAIN_TAG_NAMES = ["SWC", "DC", "LC", "TTT", "ITT", "WiSE"]
 
     def main_tags(self):


### PR DESCRIPTION
AskForWebsite, HostInstructorsIntroduction, InstructorConfirmedForWorkshop and RecruitHelpers now should run only for events tagged SWC/DC/LC, and not run for anything tagged TTT/Circuits/CLDT.

This fixes #2697.