### PR TITLE
[#1992] Rename Host->Host Site, Sponsor->Organiser

### DIFF
--- a/amy/templates/dashboard/admin_dashboard.html
+++ b/amy/templates/dashboard/admin_dashboard.html
@@ -49,7 +49,7 @@
         <th>Dates</th>
         <th>Location</th>
         <th>URL</th>
-        <th>Host</th>
+        <th>Host Site</th>
       </tr>
       {% for event in unpublished_events %}
       <tr>

--- a/amy/templates/includes/event_details_table.html
+++ b/amy/templates/includes/event_details_table.html
@@ -8,8 +8,8 @@
   <tr><th>Completed:</th><td colspan="2">{{ event.completed|yesno }}</td></tr>
   <tr class="{% if event.start > event.end %}table-danger{% endif %}"><th>Start date:</th><td colspan="2">{{ event.start|default:"&mdash;" }}</td></tr>
   <tr class="{% if event.start > event.end %}table-danger{% endif %}"><th>End date: </th><td colspan="2">{{ event.end|default:"&mdash;" }}</td></tr>
-  <tr><th>Host:</th><td colspan="2"><a href="{% url 'organization_details' event.host.domain_quoted %}">{{ event.host }}</a></td></tr>
-  <tr><th>Sponsor:</th><td colspan="2">{% if event.sponsor %}<a href="{{ event.sponsor.get_absolute_url }}">{{ event.sponsor }}</a>{% else %}&mdash;{% endif %}</td></tr>
+  <tr><th>Host Site:</th><td colspan="2"><a href="{% url 'organization_details' event.host.domain_quoted %}">{{ event.host }}</a></td></tr>
+  <tr><th>Organiser:</th><td colspan="2">{% if event.sponsor %}<a href="{{ event.sponsor.get_absolute_url }}">{{ event.sponsor }}</a>{% else %}&mdash;{% endif %}</td></tr>
   <tr><th>Membership:</th><td colspan="2">{% if event.membership %}<a href="{{ event.membership.get_absolute_url }}">{{ event.membership }}</a>{% else %}&mdash;{% endif %}</td></tr>
   <tr><th>Administrator:</th><td colspan="2">{% if event.administrator %}<a href="{{ event.administrator.get_absolute_url }}">{{ event.administrator }}</a>{% else %}&mdash;{% endif %}</td></tr>
   <tr><th>Is this workshop public?<br><small>Public workshops will show up in public Carpentries feeds.</small></th><td colspan="2">{{ event.get_public_status_display|default:"&mdash;" }}</td></tr>

--- a/amy/templates/workshops/all_events.html
+++ b/amy/templates/workshops/all_events.html
@@ -18,7 +18,7 @@
         <th>Tags</th>
         <th>URL</th>
         <th>Instructors</th>
-        <th>Host</th>
+        <th>Host Site</th>
         <th>Dates</th>
         <th>Completed</th>
         <th class="additional-links"></th>

--- a/amy/templates/workshops/events_merge.html
+++ b/amy/templates/workshops/events_merge.html
@@ -49,10 +49,16 @@
     <th>{% include "includes/merge_radio.html" with field=form.end %}</th>
   </tr>
   <tr>
-    <th scope="row">Host</th>
+    <th scope="row">Host Site</th>
     <td><a href="{{ obj_a.host.get_absolute_url }}">{{ obj_a.host }}</a></td>
     <td><a href="{{ obj_b.host.get_absolute_url }}">{{ obj_b.host }}</a></td>
     <th>{% include "includes/merge_radio.html" with field=form.host %}</th>
+  </tr>
+  <tr>
+    <th scope="row">Organiser</th>
+    <td><a href="{{ obj_a.sponsor.get_absolute_url }}">{{ obj_a.sponsor }}</a></td>
+    <td><a href="{{ obj_b.sponsor.get_absolute_url }}">{{ obj_b.sponsor }}</a></td>
+    <th>{% include "includes/merge_radio.html" with field=form.sponsor %}</th>
   </tr>
   <tr>
     <th scope="row">Administrator</th>

--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -372,6 +372,23 @@ class BulkUploadCSVForm(forms.Form):
 
 
 class EventForm(forms.ModelForm):
+    host = forms.ModelChoiceField(
+        label="Host Site",
+        required=True,
+        help_text=Event._meta.get_field("host").help_text,
+        queryset=Organization.objects.all(),
+        widget=ModelSelect2Widget(data_view="organization-lookup"),
+    )
+
+    sponsor = forms.ModelChoiceField(
+        label="Organiser",
+        required=True,
+        help_text=Event._meta.get_field("sponsor").help_text
+        + " Previously called 'Sponsor'.",
+        queryset=Organization.objects.all(),
+        widget=ModelSelect2Widget(data_view="organization-lookup"),
+    )
+
     administrator = forms.ModelChoiceField(
         label="Administrator",
         required=True,
@@ -450,8 +467,6 @@ class EventForm(forms.ModelForm):
             "comment",
         ]
         widgets = {
-            "host": ModelSelect2Widget(data_view="organization-lookup"),
-            "sponsor": ModelSelect2Widget(data_view="organization-lookup"),
             "membership": ModelSelect2Widget(data_view="membership-lookup"),
             "manual_attendance": TextInput,
             "latitude": TextInput,
@@ -1146,8 +1161,12 @@ class EventsMergeForm(forms.Form):
     )
     start = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
     end = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
-    host = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
-    sponsor = forms.ChoiceField(choices=TWO, initial=DEFAULT, widget=forms.RadioSelect)
+    host = forms.ChoiceField(
+        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect, label="Host Site"
+    )
+    sponsor = forms.ChoiceField(
+        choices=TWO, initial=DEFAULT, widget=forms.RadioSelect, label="Organiser"
+    )
     administrator = forms.ChoiceField(
         choices=TWO,
         initial=DEFAULT,


### PR DESCRIPTION
No migration created since the rename is only in forms and some templates.

This fixes #1992.