### PR TITLE
[Emails] Limit instructor confirmed for workshop email

### DIFF
--- a/amy/emails/actions/instructor_confirmed_for_workshop.py
+++ b/amy/emails/actions/instructor_confirmed_for_workshop.py
@@ -41,15 +41,23 @@ def instructor_confirmed_for_workshop_strategy(task: Task) -> StrategyEnum:
     carpentries_tags = task.event.tags.filter(
         name__in=TagQuerySet.CARPENTRIES_TAG_NAMES
     ).exclude(name__in=TagQuerySet.NON_CARPENTRIES_TAG_NAMES)
+    centrally_organised = (
+        task.event.administrator and task.event.administrator.domain != "self-organized"
+    )
 
     log_condition_elements(
         instructor_role=instructor_role,
         person_email_exists=person_email_exists,
         carpentries_tags=carpentries_tags,
+        centrally_organised=centrally_organised,
     )
 
     email_should_exist = (
-        task.pk and instructor_role and person_email_exists and carpentries_tags
+        task.pk
+        and instructor_role
+        and person_email_exists
+        and carpentries_tags
+        and centrally_organised
     )
     logger.debug(f"{email_should_exist=}")
 

--- a/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_strategy.py
+++ b/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_strategy.py
@@ -18,7 +18,11 @@ class TestInstructorConfirmedForWorkshopStrategy(TestCase):
     def setUp(self) -> None:
         host = Organization.objects.create(domain="test.com", fullname="Test")
         self.event = Event.objects.create(
-            slug="test-event", host=host, start=date(2024, 8, 5), end=date(2024, 8, 5)
+            slug="test-event",
+            host=host,
+            administrator=host,
+            start=date(2024, 8, 5),
+            end=date(2024, 8, 5),
         )
         swc_tag = Tag.objects.create(name="SWC")
         self.event.tags.set([swc_tag])


### PR DESCRIPTION
This email is now only sent to centrally-organised workshops.


This fixes #2717.