### PR TITLE
[Emails] Change related object to Task in Instructor Confirmed for Workshop and to Award in Instructor Badge Awarded

### DIFF
--- a/amy/api/v2/serializers.py
+++ b/amy/api/v2/serializers.py
@@ -10,6 +10,7 @@ from workshops.models import (
     Organization,
     Person,
     TagQuerySet,
+    Task,
     TrainingProgress,
     TrainingRequirement,
 )
@@ -289,6 +290,26 @@ class ScheduledEmailSerializer(serializers.ModelSerializer):
 
 class ScheduledEmailLogDetailsSerializer(serializers.Serializer):
     details = serializers.CharField(max_length=MAX_LENGTH)
+
+
+class TaskSerializer(serializers.ModelSerializer):
+    event = serializers.SlugRelatedField(read_only=True, slug_field="slug")
+    person = serializers.SlugRelatedField(read_only=True, slug_field="username")
+    role = serializers.SlugRelatedField(read_only=True, slug_field="name")
+    seat_membership = serializers.SlugRelatedField(read_only=True, slug_field="name")
+
+    class Meta:
+        model = Task
+        fields = (
+            "event",
+            "person",
+            "role",
+            "title",
+            "url",
+            "seat_membership",
+            "seat_public",
+            "seat_open_training",
+        )
 
 
 class TrainingProgressSerializer(serializers.ModelSerializer):

--- a/amy/api/v2/urls.py
+++ b/amy/api/v2/urls.py
@@ -13,6 +13,7 @@ router.register("instructorrecruitmentsignup", views.InstructorRecruitmentSignup
 router.register("membership", views.MembershipViewSet)
 router.register("person", views.PersonViewSet)
 router.register("scheduledemail", views.ScheduledEmailViewSet)
+router.register("task", views.TaskViewSet)
 router.register("trainingprogress", views.TrainingProgressViewSet)
 router.register("trainingrequirement", views.TrainingRequirementViewSet)
 router.register("selforganisedsubmission", views.SelfOrganisedSubmissionViewSet)

--- a/amy/api/v2/views.py
+++ b/amy/api/v2/views.py
@@ -18,6 +18,7 @@ from api.v2.serializers import (
     ScheduledEmailLogDetailsSerializer,
     ScheduledEmailSerializer,
     SelfOrganisedSubmissionSerializer,
+    TaskSerializer,
     TrainingProgressSerializer,
     TrainingRequirementSerializer,
 )
@@ -31,6 +32,7 @@ from workshops.models import (
     Membership,
     Organization,
     Person,
+    Task,
     TrainingProgress,
     TrainingRequirement,
 )
@@ -232,6 +234,24 @@ class ScheduledEmailViewSet(viewsets.ReadOnlyModelViewSet):
             email, serializer.validated_data["details"], request.user
         )
         return Response(self.get_serializer(locked_email).data)
+
+
+class TaskViewSet(viewsets.ReadOnlyModelViewSet):
+    authentication_classes = (
+        TokenAuthentication,
+        SessionAuthentication,
+    )
+    permission_classes = (
+        IsAuthenticated,
+        ApiAccessPermission,
+    )
+    queryset = (
+        Task.objects.select_related("person", "event", "role", "seat_membership")
+        .order_by("pk")
+        .all()
+    )
+    serializer_class = TaskSerializer
+    pagination_class = StandardResultsSetPagination
 
 
 class TrainingProgressViewSet(viewsets.ReadOnlyModelViewSet):

--- a/amy/emails/tests/actions/test_instructor_badge_awarded_cancel_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_badge_awarded_cancel_receiver.py
@@ -76,7 +76,7 @@ class TestInstructorBadgeAwardedCancelReceiver(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.award,
         )
 
         # Act
@@ -114,7 +114,7 @@ class TestInstructorBadgeAwardedCancelReceiver(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.award,
         )
 
         # Act
@@ -150,7 +150,7 @@ class TestInstructorBadgeAwardedCancelReceiver(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.award,
         )
         scheduled_email2 = ScheduledEmail.objects.create(
             template=template,
@@ -159,7 +159,7 @@ class TestInstructorBadgeAwardedCancelReceiver(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.award,
         )
 
         # Act

--- a/amy/emails/tests/actions/test_instructor_badge_awarded_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_badge_awarded_receiver.py
@@ -8,7 +8,7 @@ from emails.actions import instructor_badge_awarded_receiver
 from emails.models import EmailTemplate, ScheduledEmail
 from emails.schemas import ContextModel, ToHeaderModel
 from emails.signals import instructor_badge_awarded_signal
-from emails.utils import api_model_url
+from emails.utils import api_model_url, scalar_value_url
 from workshops.models import Award, Badge, Person
 from workshops.tests.base import TestBase
 
@@ -111,6 +111,7 @@ class TestInstructorBadgeAwardedReceiver(TestCase):
                 {
                     "person": api_model_url("person", person.pk),
                     "award": api_model_url("award", award.pk),
+                    "award_id": scalar_value_url("int", award.pk),
                 }
             ),
             scheduled_at=scheduled_at,
@@ -123,7 +124,7 @@ class TestInstructorBadgeAwardedReceiver(TestCase):
                     }  # type: ignore
                 ]
             ),
-            generic_relation_obj=person,
+            generic_relation_obj=award,
             author=None,
         )
 

--- a/amy/emails/tests/actions/test_instructor_badge_awarded_strategy.py
+++ b/amy/emails/tests/actions/test_instructor_badge_awarded_strategy.py
@@ -48,7 +48,7 @@ class TestInstructorBadgeAwardedStrategy(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=award.person,
+            generic_relation=award,
         )
 
         # Act
@@ -60,6 +60,7 @@ class TestInstructorBadgeAwardedStrategy(TestCase):
     def test_strategy_cancel(self) -> None:
         # Arrange
         # Award intentionally not created
+        award = Award.objects.create(badge=self.badge, person=self.person)
         template = EmailTemplate.objects.create(
             name="Test Email Template",
             signal=INSTRUCTOR_BADGE_AWARDED_SIGNAL_NAME,
@@ -76,11 +77,15 @@ class TestInstructorBadgeAwardedStrategy(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=award,
         )
+        award_pk = award.pk
+        award.delete()
 
         # Act
-        result = instructor_badge_awarded_strategy(award=None, person=self.person)
+        result = instructor_badge_awarded_strategy(
+            award=None, person=self.person, optional_award_pk=award_pk
+        )
 
         # Assert
         self.assertEqual(result, StrategyEnum.CANCEL)

--- a/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_cancel_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_cancel_receiver.py
@@ -84,7 +84,7 @@ class TestInstructorConfirmedForWorkshopCancelReceiver(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.task,
         )
 
         # Act
@@ -97,6 +97,7 @@ class TestInstructorConfirmedForWorkshopCancelReceiver(TestCase):
                 task=self.task,
                 person_id=self.person.pk,
                 event_id=self.event.pk,
+                task_id=self.task.pk,
                 instructor_recruitment_id=None,
                 instructor_recruitment_signup_id=None,
             )
@@ -125,7 +126,7 @@ class TestInstructorConfirmedForWorkshopCancelReceiver(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.task,
         )
 
         # Act
@@ -138,6 +139,7 @@ class TestInstructorConfirmedForWorkshopCancelReceiver(TestCase):
                 task=self.task,
                 person_id=self.person.pk,
                 event_id=self.event.pk,
+                task_id=self.task.pk,
                 instructor_recruitment_id=None,
                 instructor_recruitment_signup_id=None,
             )
@@ -164,7 +166,7 @@ class TestInstructorConfirmedForWorkshopCancelReceiver(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.task,
         )
         scheduled_email2 = ScheduledEmail.objects.create(
             template=template,
@@ -173,7 +175,7 @@ class TestInstructorConfirmedForWorkshopCancelReceiver(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.task,
         )
 
         # Act
@@ -186,6 +188,7 @@ class TestInstructorConfirmedForWorkshopCancelReceiver(TestCase):
                 task=self.task,
                 person_id=self.person.pk,
                 event_id=self.event.pk,
+                task_id=self.task.pk,
                 instructor_recruitment_id=None,
                 instructor_recruitment_signup_id=None,
             )
@@ -267,6 +270,7 @@ class TestInstructorConfirmedForWorkshopCancelIntegration(TestBase):
                 task=task,
                 person_id=task.person.pk,
                 event_id=task.event.pk,
+                task_id=task.pk,
                 instructor_recruitment_id=None,
                 instructor_recruitment_signup_id=None,
             )

--- a/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_strategy.py
+++ b/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_strategy.py
@@ -59,7 +59,7 @@ class TestInstructorConfirmedForWorkshopStrategy(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.task,
         )
 
         # Act
@@ -89,7 +89,7 @@ class TestInstructorConfirmedForWorkshopStrategy(TestCase):
             cc_header=[],
             bcc_header=[],
             state=ScheduledEmailStatus.SCHEDULED,
-            generic_relation=self.person,
+            generic_relation=self.task,
         )
 
         # Act

--- a/amy/emails/types.py
+++ b/amy/emails/types.py
@@ -27,6 +27,7 @@ class InstructorBadgeAwardedKwargs(TypedDict):
 class InstructorBadgeAwardedContext(TypedDict):
     person: Person
     award: Award | None
+    award_id: int
 
 
 class InstructorConfirmedKwargs(TypedDict):

--- a/amy/emails/types.py
+++ b/amy/emails/types.py
@@ -12,6 +12,7 @@ from workshops.models import (
     Membership,
     Organization,
     Person,
+    Task,
     TrainingProgress,
     TrainingRequirement,
 )
@@ -32,6 +33,7 @@ class InstructorConfirmedKwargs(TypedDict):
     request: HttpRequest
     person_id: int
     event_id: int
+    task_id: int
     instructor_recruitment_id: int | None
     instructor_recruitment_signup_id: int | None
 
@@ -39,6 +41,8 @@ class InstructorConfirmedKwargs(TypedDict):
 class InstructorConfirmedContext(TypedDict):
     person: Person
     event: Event
+    task: Task | None
+    task_id: int
     instructor_recruitment_signup: InstructorRecruitmentSignup | None
 
 

--- a/amy/emails/utils.py
+++ b/amy/emails/utils.py
@@ -23,6 +23,7 @@ from api.v2.serializers import (
     OrganizationSerializer,
     PersonSerializer,
     SelfOrganisedSubmissionSerializer,
+    TaskSerializer,
     TrainingProgressSerializer,
     TrainingRequirementSerializer,
 )
@@ -36,6 +37,7 @@ from workshops.models import (
     Membership,
     Organization,
     Person,
+    Task,
     TrainingProgress,
     TrainingRequirement,
 )
@@ -265,6 +267,7 @@ def map_single_api_uri_to_serialized_model(uri: str) -> dict[str, Any]:
         Membership: MembershipSerializer,
         Person: PersonSerializer,
         ScheduledEmail: ScheduledEmailSerializer,
+        Task: TaskSerializer,
         TrainingProgress: TrainingProgressSerializer,
         TrainingRequirement: TrainingRequirementSerializer,
         SelfOrganisedSubmission: SelfOrganisedSubmissionSerializer,

--- a/amy/recruitment/views.py
+++ b/amy/recruitment/views.py
@@ -431,6 +431,7 @@ class InstructorRecruitmentSignupChangeState(
             request=request,
             person_id=person.pk,
             event_id=event.pk,
+            task_id=task.pk,
             instructor_recruitment_id=signup.recruitment.pk,
             instructor_recruitment_signup_id=signup.pk,
         )

--- a/amy/templates/includes/event_details_table.html
+++ b/amy/templates/includes/event_details_table.html
@@ -81,6 +81,16 @@
     </td>
   </tr>
   <tr>
+    <th>Related scheduled emails for tasks:</th>
+    <td colspan="2">
+      {% for task in tasks %}
+      {% include "includes/related_scheduled_emails_no_empty_msg.html" with object=task %}
+      {% empty %}
+      &mdash;
+      {% endfor %}
+    </td>
+  </tr>
+  <tr>
     <th>Related scheduled emails for recruitments:</th>
     <td colspan="2">
       {% with signups=related_instructor_recruitment_signups %}

--- a/amy/templates/workshops/person.html
+++ b/amy/templates/workshops/person.html
@@ -263,6 +263,18 @@
     </td>
   </tr>
   <tr>
+    <th>Related scheduled emails for tasks:</th>
+    <td>
+      {% with tasks=person.task_set.all %}
+      {% for task in tasks %}
+      {% include "includes/related_scheduled_emails_no_empty_msg.html" with object=task %}
+      {% empty %}
+      &mdash;
+      {% endfor %}
+      {% endwith %}
+    </td>
+  </tr>
+  <tr>
     <th>Related scheduled emails for awards:</th>
     <td>
       {% with awards=person.award_set.all %}

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -719,6 +719,7 @@ class PersonUpdate(OnlyForAdminsMixin, UserPassesTestMixin, AMYUpdateView):
                 task=task,
                 person_id=self.object.pk,
                 event_id=task.event.pk,
+                task_id=task.pk,
                 instructor_recruitment_id=None,
                 instructor_recruitment_signup_id=None,
             )
@@ -1745,6 +1746,7 @@ class TaskCreate(
             task=self.object,
             person_id=self.object.person.pk,
             event_id=event.pk,
+            task_id=self.object.pk,
             instructor_recruitment_id=None,
             instructor_recruitment_signup_id=None,
         )
@@ -1831,6 +1833,7 @@ class TaskUpdate(
             task=self.object,
             person_id=self.object.person.pk,
             event_id=self.object.event.pk,
+            task_id=self.object.pk,
             instructor_recruitment_id=None,
             instructor_recruitment_signup_id=None,
         )
@@ -1852,6 +1855,7 @@ class TaskDelete(
 
     def before_delete(self, *args, **kwargs):
         self.old: Task = cast(Task, self.get_object())
+        self.old_pk = self.old.pk
         self.event = self.old.event
 
     def after_delete(self, *args, **kwargs):
@@ -1886,11 +1890,12 @@ class TaskDelete(
         )
 
         run_instructor_confirmed_for_workshop_strategy(
-            instructor_confirmed_for_workshop_strategy(self.object),
+            instructor_confirmed_for_workshop_strategy(self.object, self.old_pk),
             self.request,
             task=self.old,
             person_id=self.object.person.pk,
             event_id=self.event.pk,
+            task_id=self.old_pk,
             instructor_recruitment_id=None,
             instructor_recruitment_signup_id=None,
         )

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -2025,7 +2025,7 @@ class MockAwardDelete(OnlyForAdminsMixin, PermissionRequiredMixin, AMYDeleteView
         person = self._person
         try:
             run_instructor_badge_awarded_strategy(
-                instructor_badge_awarded_strategy(award, person),
+                instructor_badge_awarded_strategy(award, person, award_pk),
                 request=self.request,
                 person=person,
                 award_id=award_pk,


### PR DESCRIPTION
This fixes #2719 by switching related objects in some emails, which helped in some cases when some entities (Person) were related to multiple of those email types at once:

1. Instructor Confirmed for Workshop: switch from Person to Task as a related object
2. Instructor Badge Awarded: switch from Person to Award as related object