### PR TITLE
[Recruitment] Disallow multiple signups for the same person

### DIFF
--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django_countries.fields import CountryField
 
+from communityroles.models import CommunityRole
 from recruitment.models import InstructorRecruitment, InstructorRecruitmentSignup
 from trainings.models import Involvement
 from workshops.fields import (
@@ -327,6 +328,15 @@ class SignupForRecruitmentForm(forms.ModelForm):
 
     def clean(self):
         super().clean()
+
+        try:
+            (
+                CommunityRole.objects.active().get(  # type: ignore
+                    person=self.person, config__name="instructor"
+                )
+            )
+        except CommunityRole.DoesNotExist:
+            raise ValidationError("You don't have an active Instructor Community Role")
 
         # Check if user has any instructor roles for events taking place at the same
         # time of this event.

--- a/amy/dashboard/forms.py
+++ b/amy/dashboard/forms.py
@@ -338,6 +338,12 @@ class SignupForRecruitmentForm(forms.ModelForm):
         except CommunityRole.DoesNotExist:
             raise ValidationError("You don't have an active Instructor Community Role")
 
+        signups_exist = self.recruitment.signups.filter(  # type: ignore
+            person=self.person
+        ).exists()
+        if signups_exist:
+            raise ValidationError("You are already signed up for this recruitment")
+
         # Check if user has any instructor roles for events taking place at the same
         # time of this event.
         event: Event = self.recruitment.event

--- a/amy/dashboard/tests/test_forms.py
+++ b/amy/dashboard/tests/test_forms.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from django.test import TestCase
 
+from communityroles.models import CommunityRole, CommunityRoleConfig
 from dashboard.forms import GetInvolvedForm, SignupForRecruitmentForm
 from recruitment.models import InstructorRecruitment
 from trainings.models import Involvement
@@ -53,6 +54,17 @@ class TestSignupForRecruitmentForm(TestCase):
         person = Person.objects.create(
             personal="Test", family="User", email="test@user.com"
         )
+        config = CommunityRoleConfig.objects.create(
+            name="instructor",
+            display_name="Instructor",
+            link_to_award=False,
+            link_to_membership=False,
+            additional_url=False,
+        )
+        CommunityRole.objects.create(
+            config=config,
+            person=person,
+        )
         event = Event.objects.create(slug="test-event", host=host)  # no dates
         recruitment = InstructorRecruitment.objects.create(status="o", event=event)
         data = {}
@@ -68,6 +80,17 @@ class TestSignupForRecruitmentForm(TestCase):
         host = Organization.objects.create(domain="test.com", fullname="Test")
         person = Person.objects.create(
             personal="Test", family="User", email="test@user.com"
+        )
+        config = CommunityRoleConfig.objects.create(
+            name="instructor",
+            display_name="Instructor",
+            link_to_award=False,
+            link_to_membership=False,
+            additional_url=False,
+        )
+        CommunityRole.objects.create(
+            config=config,
+            person=person,
         )
         event = Event.objects.create(
             slug="test-event", host=host, start=date(2022, 2, 19), end=date(2022, 2, 20)
@@ -86,6 +109,17 @@ class TestSignupForRecruitmentForm(TestCase):
         host = Organization.objects.create(domain="test.com", fullname="Test")
         person = Person.objects.create(
             personal="Test", family="User", email="test@user.com"
+        )
+        config = CommunityRoleConfig.objects.create(
+            name="instructor",
+            display_name="Instructor",
+            link_to_award=False,
+            link_to_membership=False,
+            additional_url=False,
+        )
+        CommunityRole.objects.create(
+            config=config,
+            person=person,
         )
         event = Event.objects.create(
             slug="test-event", host=host, start=date(2022, 2, 19), end=date(2022, 2, 20)

--- a/amy/dashboard/tests/test_instructor_recruitment_views.py
+++ b/amy/dashboard/tests/test_instructor_recruitment_views.py
@@ -484,6 +484,18 @@ class TestSignupForRecruitment(TestCase):
         )
         recruitment = InstructorRecruitment.objects.create(status="o", event=event)
 
+        config = CommunityRoleConfig.objects.create(
+            name="instructor",
+            display_name="Instructor",
+            link_to_award=False,
+            link_to_membership=False,
+            additional_url=False,
+        )
+        CommunityRole.objects.create(
+            config=config,
+            person=person,
+        )
+
         request = RequestFactory().post("/")
         request.user = person
         view = SignupForRecruitment(

--- a/amy/recruitment/forms.py
+++ b/amy/recruitment/forms.py
@@ -30,6 +30,10 @@ class InstructorRecruitmentAddSignupForm(forms.ModelForm):
         model = InstructorRecruitmentSignup
         fields = ("person", "notes")
 
+    def __init__(self, *args, **kwargs):
+        self._recruitment = kwargs.pop("recruitment", None)
+        super().__init__(*args, **kwargs)
+
     def clean_person(self) -> None:
         person = self.cleaned_data["person"]
 
@@ -43,6 +47,16 @@ class InstructorRecruitmentAddSignupForm(forms.ModelForm):
             raise ValidationError(
                 f"Person {person} does not have an active Instructor Community Role"
             )
+
+        if (
+            self._recruitment
+            and self._recruitment.signups.filter(person=person).exists()
+        ):
+            raise ValidationError(
+                f"Person {person} is already signed up for this recruitment"
+            )
+
+        return person
 
 
 class InstructorRecruitmentSignupUpdateForm(forms.ModelForm):

--- a/amy/recruitment/forms.py
+++ b/amy/recruitment/forms.py
@@ -34,8 +34,11 @@ class InstructorRecruitmentAddSignupForm(forms.ModelForm):
         person = self.cleaned_data["person"]
 
         try:
-            CommunityRole.objects.get(person=person, config__name="instructor")
-            return person
+            (
+                CommunityRole.objects.active().get(  # type: ignore
+                    person=person, config__name="instructor"
+                )
+            )
         except CommunityRole.DoesNotExist:
             raise ValidationError(
                 f"Person {person} does not have an active Instructor Community Role"

--- a/amy/recruitment/tests/test_forms.py
+++ b/amy/recruitment/tests/test_forms.py
@@ -1,11 +1,7 @@
 from django.db.utils import IntegrityError
 from django.test import TestCase
 
-from communityroles.models import (
-    CommunityRole,
-    CommunityRoleConfig,
-    CommunityRoleInactivation,
-)
+from communityroles.models import CommunityRole, CommunityRoleConfig
 from recruitment.forms import (
     InstructorRecruitmentAddSignupForm,
     InstructorRecruitmentChangeStateForm,
@@ -57,11 +53,9 @@ class TestInstructorRecruitmentAddSignupForm(TestCase):
             link_to_membership=False,
             additional_url=False,
         )
-        inactivation = CommunityRoleInactivation.objects.create(name="inactivation")
         CommunityRole.objects.create(
             config=config,
             person=person,
-            inactivation=inactivation,
         )
         return person
 

--- a/amy/recruitment/tests/test_instructor_recruitment_views.py
+++ b/amy/recruitment/tests/test_instructor_recruitment_views.py
@@ -7,11 +7,7 @@ from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from communityroles.models import (
-    CommunityRole,
-    CommunityRoleConfig,
-    CommunityRoleInactivation,
-)
+from communityroles.models import CommunityRole, CommunityRoleConfig
 from emails.types import StrategyEnum
 from recruitment.filters import InstructorRecruitmentFilter
 from recruitment.forms import (
@@ -585,11 +581,9 @@ class TestInstructorRecruitmentAddSignup(TestBase):
             link_to_membership=False,
             additional_url=False,
         )
-        inactivation = CommunityRoleInactivation.objects.create(name="inactivation")
         CommunityRole.objects.create(
             config=config,
             person=person,
-            inactivation=inactivation,
         )
         notes = "Lorem ipsum"
         data = {"person": person.pk, "notes": notes}

--- a/amy/recruitment/views.py
+++ b/amy/recruitment/views.py
@@ -1,6 +1,6 @@
 from datetime import date
 import logging
-from typing import Callable
+from typing import Any, Callable
 from urllib.parse import unquote
 
 from django.contrib import messages
@@ -325,6 +325,11 @@ class InstructorRecruitmentAddSignup(
 
     def get_success_message(self, cleaned_data: dict[str, str]) -> str:
         return f"Added {cleaned_data['person']} to {self.object}"
+
+    def get_form_kwargs(self) -> dict[str, Any]:
+        kwargs = super().get_form_kwargs()
+        kwargs["recruitment"] = self.object
+        return kwargs
 
     def form_valid(self, form: InstructorRecruitmentAddSignupForm) -> HttpResponse:
         signup: InstructorRecruitmentSignup = form.save(commit=False)


### PR DESCRIPTION
This fixes #2495 by disallowing multiple signups (both from admin and from the instructor) in open recruitments. Indirectly this also resolves an issue of multiple confirmation emails sent out in the new email system.