### PR TITLE
[Emails] Complex strategy for instructor declined for workshop

### DIFF
--- a/amy/emails/actions/__init__.py
+++ b/amy/emails/actions/__init__.py
@@ -14,10 +14,14 @@ from emails.actions.host_instructors_introduction import (
 )
 from emails.actions.instructor_badge_awarded import instructor_badge_awarded_receiver
 from emails.actions.instructor_confirmed_for_workshop import (
+    instructor_confirmed_for_workshop_cancel_receiver,
     instructor_confirmed_for_workshop_receiver,
+    instructor_confirmed_for_workshop_update_receiver,
 )
 from emails.actions.instructor_declined_from_workshop import (
+    instructor_declined_from_workshop_cancel_receiver,
     instructor_declined_from_workshop_receiver,
+    instructor_declined_from_workshop_update_receiver,
 )
 from emails.actions.instructor_signs_up_for_workshop import (
     instructor_signs_up_for_workshop_receiver,

--- a/amy/emails/actions/instructor_declined_from_workshop.py
+++ b/amy/emails/actions/instructor_declined_from_workshop.py
@@ -1,79 +1,293 @@
 from datetime import datetime
+import logging
 
+from django.contrib.contenttypes.models import ContentType
+from django.http import HttpRequest
+from django.utils import timezone
 from typing_extensions import Unpack
 
-from emails.actions.base_action import BaseAction
+from emails.actions.base_action import BaseAction, BaseActionCancel, BaseActionUpdate
+from emails.actions.base_strategy import run_strategy
+from emails.models import ScheduledEmail, ScheduledEmailStatus
 from emails.schemas import ContextModel, ToHeaderModel
-from emails.signals import instructor_declined_from_workshop_signal
-from emails.types import InstructorDeclinedContext, InstructorDeclinedKwargs
-from emails.utils import api_model_url, immediate_action
+from emails.signals import (
+    INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+    Signal,
+    instructor_declined_from_workshop_cancel_signal,
+    instructor_declined_from_workshop_signal,
+    instructor_declined_from_workshop_update_signal,
+)
+from emails.types import (
+    InstructorDeclinedContext,
+    InstructorDeclinedKwargs,
+    StrategyEnum,
+)
+from emails.utils import api_model_url, immediate_action, log_condition_elements
 from recruitment.models import InstructorRecruitmentSignup
-from workshops.models import Event, Person
+from workshops.models import Event, Person, TagQuerySet
+
+logger = logging.getLogger("amy")
+
+
+def instructor_declined_from_workshop_strategy(
+    signup: InstructorRecruitmentSignup,
+) -> StrategyEnum:
+    logger.info(f"Running InstructorDeclinedFromWorkshop strategy for {signup=}")
+
+    signup_is_declined = signup.state == "d"
+    person_email_exists = bool(signup.person.email)
+    event = signup.recruitment.event
+    carpentries_tags = event.tags.filter(
+        name__in=TagQuerySet.CARPENTRIES_TAG_NAMES
+    ).exclude(name__in=TagQuerySet.NON_CARPENTRIES_TAG_NAMES)
+    centrally_organised = (
+        event.administrator and event.administrator.domain != "self-organized"
+    )
+    start_date_in_future = event.start and event.start >= timezone.now().date()
+
+    log_condition_elements(
+        signup=signup,
+        signup_pk=signup.pk,
+        signup_is_declined=signup_is_declined,
+        event=event,
+        person_email_exists=person_email_exists,
+        carpentries_tags=carpentries_tags,
+        centrally_organised=centrally_organised,
+        start_date_in_future=start_date_in_future,
+    )
+
+    email_should_exist = (
+        signup_is_declined
+        and person_email_exists
+        and carpentries_tags
+        and centrally_organised
+        and start_date_in_future
+    )
+    logger.debug(f"{email_should_exist=}")
+
+    ct = ContentType.objects.get_for_model(InstructorRecruitmentSignup)
+    email_exists = ScheduledEmail.objects.filter(
+        generic_relation_content_type=ct,
+        generic_relation_pk=signup.pk,
+        template__signal=INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+        state=ScheduledEmailStatus.SCHEDULED,
+    ).exists()
+    logger.debug(f"{email_exists=}")
+
+    if not email_exists and email_should_exist:
+        result = StrategyEnum.CREATE
+    elif email_exists and not email_should_exist:
+        result = StrategyEnum.CANCEL
+    elif email_exists and email_should_exist:
+        result = StrategyEnum.UPDATE
+    else:
+        result = StrategyEnum.NOOP
+
+    logger.debug(f"InstructorDeclinedFromWorkshop strategy {result = }")
+    return result
+
+
+def run_instructor_declined_from_workshop_strategy(
+    strategy: StrategyEnum,
+    request: HttpRequest,
+    signup: InstructorRecruitmentSignup,
+    **kwargs,
+) -> None:
+    signal_mapping: dict[StrategyEnum, Signal | None] = {
+        StrategyEnum.CREATE: instructor_declined_from_workshop_signal,
+        StrategyEnum.UPDATE: instructor_declined_from_workshop_update_signal,
+        StrategyEnum.CANCEL: instructor_declined_from_workshop_cancel_signal,
+        StrategyEnum.NOOP: None,
+    }
+    return run_strategy(
+        strategy,
+        signal_mapping,
+        request,
+        sender=signup,
+        signup=signup,
+        **kwargs,
+    )
+
+
+def get_scheduled_at(**kwargs: Unpack[InstructorDeclinedKwargs]) -> datetime:
+    return immediate_action()
+
+
+def get_context(
+    **kwargs: Unpack[InstructorDeclinedKwargs],
+) -> InstructorDeclinedContext:
+    person = Person.objects.get(pk=kwargs["person_id"])
+    event = Event.objects.get(pk=kwargs["event_id"])
+    instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
+        pk=kwargs["instructor_recruitment_signup_id"]
+    )
+    return {
+        "person": person,
+        "event": event,
+        "instructor_recruitment_signup": instructor_recruitment_signup,
+    }
+
+
+def get_context_json(context: InstructorDeclinedContext) -> ContextModel:
+    return ContextModel(
+        {
+            "person": api_model_url("person", context["person"].pk),
+            "event": api_model_url("event", context["event"].pk),
+            "instructor_recruitment_signup": api_model_url(
+                "instructorrecruitmentsignup",
+                context["instructor_recruitment_signup"].pk,
+            ),
+        },
+    )
+
+
+def get_generic_relation_object(
+    context: InstructorDeclinedContext,
+    **kwargs: Unpack[InstructorDeclinedKwargs],
+) -> InstructorRecruitmentSignup:
+    return context["instructor_recruitment_signup"]
+
+
+def get_recipients(
+    context: InstructorDeclinedContext,
+    **kwargs: Unpack[InstructorDeclinedKwargs],
+) -> list[str]:
+    person = context["person"]
+    return [person.email] if person.email else []
+
+
+def get_recipients_context_json(
+    context: InstructorDeclinedContext,
+    **kwargs: Unpack[InstructorDeclinedKwargs],
+) -> ToHeaderModel:
+    return ToHeaderModel(
+        [
+            {
+                "api_uri": api_model_url("person", context["person"].pk),
+                "property": "email",
+            },  # type: ignore
+        ],
+    )
 
 
 class InstructorDeclinedFromWorkshopReceiver(BaseAction):
     signal = instructor_declined_from_workshop_signal.signal_name
 
     def get_scheduled_at(self, **kwargs: Unpack[InstructorDeclinedKwargs]) -> datetime:
-        return immediate_action()
+        return get_scheduled_at(**kwargs)
 
     def get_context(
         self, **kwargs: Unpack[InstructorDeclinedKwargs]
     ) -> InstructorDeclinedContext:
-        person = Person.objects.get(pk=kwargs["person_id"])
-        event = Event.objects.get(pk=kwargs["event_id"])
-        instructor_recruitment_signup = InstructorRecruitmentSignup.objects.get(
-            pk=kwargs["instructor_recruitment_signup_id"]
-        )
-        return {
-            "person": person,
-            "event": event,
-            "instructor_recruitment_signup": instructor_recruitment_signup,
-        }
+        return get_context(**kwargs)
 
     def get_context_json(self, context: InstructorDeclinedContext) -> ContextModel:
-        return ContextModel(
-            {
-                "person": api_model_url("person", context["person"].pk),
-                "event": api_model_url("event", context["event"].pk),
-                "instructor_recruitment_signup": api_model_url(
-                    "instructorrecruitmentsignup",
-                    context["instructor_recruitment_signup"].pk,
-                ),
-            },
-        )
+        return get_context_json(context)
 
     def get_generic_relation_object(
         self,
         context: InstructorDeclinedContext,
         **kwargs: Unpack[InstructorDeclinedKwargs],
     ) -> InstructorRecruitmentSignup:
-        return context["instructor_recruitment_signup"]
+        return get_generic_relation_object(context, **kwargs)
 
     def get_recipients(
         self,
         context: InstructorDeclinedContext,
         **kwargs: Unpack[InstructorDeclinedKwargs],
     ) -> list[str]:
-        person = context["person"]
-        return [person.email] if person.email else []
+        return get_recipients(context, **kwargs)
 
     def get_recipients_context_json(
         self,
         context: InstructorDeclinedContext,
         **kwargs: Unpack[InstructorDeclinedKwargs],
     ) -> ToHeaderModel:
-        return ToHeaderModel(
-            [
-                {
-                    "api_uri": api_model_url("person", context["person"].pk),
-                    "property": "email",
-                },  # type: ignore
-            ],
-        )
+        return get_recipients_context_json(context, **kwargs)
+
+
+class InstructorDeclinedFromWorkshopUpdateReceiver(BaseActionUpdate):
+    signal = instructor_declined_from_workshop_signal.signal_name
+
+    def get_scheduled_at(self, **kwargs: Unpack[InstructorDeclinedKwargs]) -> datetime:
+        return get_scheduled_at(**kwargs)
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorDeclinedKwargs]
+    ) -> InstructorDeclinedContext:
+        return get_context(**kwargs)
+
+    def get_context_json(self, context: InstructorDeclinedContext) -> ContextModel:
+        return get_context_json(context)
+
+    def get_generic_relation_object(
+        self,
+        context: InstructorDeclinedContext,
+        **kwargs: Unpack[InstructorDeclinedKwargs],
+    ) -> InstructorRecruitmentSignup:
+        return get_generic_relation_object(context, **kwargs)
+
+    def get_recipients(
+        self,
+        context: InstructorDeclinedContext,
+        **kwargs: Unpack[InstructorDeclinedKwargs],
+    ) -> list[str]:
+        return get_recipients(context, **kwargs)
+
+    def get_recipients_context_json(
+        self,
+        context: InstructorDeclinedContext,
+        **kwargs: Unpack[InstructorDeclinedKwargs],
+    ) -> ToHeaderModel:
+        return get_recipients_context_json(context, **kwargs)
+
+
+class InstructorDeclinedFromWorkshopCancelReceiver(BaseActionCancel):
+    signal = instructor_declined_from_workshop_signal.signal_name
+
+    def get_context(
+        self, **kwargs: Unpack[InstructorDeclinedKwargs]
+    ) -> InstructorDeclinedContext:
+        return get_context(**kwargs)
+
+    def get_context_json(self, context: InstructorDeclinedContext) -> ContextModel:
+        return get_context_json(context)
+
+    def get_generic_relation_object(
+        self,
+        context: InstructorDeclinedContext,
+        **kwargs: Unpack[InstructorDeclinedKwargs],
+    ) -> InstructorRecruitmentSignup:
+        return get_generic_relation_object(context, **kwargs)
+
+    def get_recipients(
+        self,
+        context: InstructorDeclinedContext,
+        **kwargs: Unpack[InstructorDeclinedKwargs],
+    ) -> list[str]:
+        return get_recipients(context, **kwargs)
+
+    def get_recipients_context_json(
+        self,
+        context: InstructorDeclinedContext,
+        **kwargs: Unpack[InstructorDeclinedKwargs],
+    ) -> ToHeaderModel:
+        return get_recipients_context_json(context, **kwargs)
 
 
 instructor_declined_from_workshop_receiver = InstructorDeclinedFromWorkshopReceiver()
 instructor_declined_from_workshop_signal.connect(
     instructor_declined_from_workshop_receiver
+)
+instructor_declined_from_workshop_update_receiver = (
+    InstructorDeclinedFromWorkshopUpdateReceiver()
+)
+instructor_declined_from_workshop_update_signal.connect(
+    instructor_declined_from_workshop_update_receiver
+)
+instructor_declined_from_workshop_cancel_receiver = (
+    InstructorDeclinedFromWorkshopCancelReceiver()
+)
+instructor_declined_from_workshop_cancel_signal.connect(
+    instructor_declined_from_workshop_cancel_receiver
 )

--- a/amy/emails/signals.py
+++ b/amy/emails/signals.py
@@ -82,9 +82,14 @@ INSTRUCTOR_CONFIRMED_FOR_WORKSHOP_SIGNAL_NAME = "instructor_confirmed_for_worksh
     SignalNameEnum.instructor_confirmed_for_workshop,
     InstructorConfirmedContext,
 )
-instructor_declined_from_workshop_signal = Signal(
-    signal_name=SignalNameEnum.instructor_declined_from_workshop,
-    context_type=InstructorDeclinedContext,
+INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME = "instructor_declined_from_workshop"
+(
+    instructor_declined_from_workshop_signal,
+    instructor_declined_from_workshop_update_signal,
+    instructor_declined_from_workshop_cancel_signal,
+) = triple_signals(
+    SignalNameEnum.instructor_declined_from_workshop,
+    InstructorDeclinedContext,
 )
 instructor_signs_up_for_workshop_signal = Signal(
     signal_name=SignalNameEnum.instructor_signs_up_for_workshop,

--- a/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_confirmed_for_workshop_receiver.py
@@ -13,7 +13,7 @@ from emails.schemas import ContextModel, ToHeaderModel
 from emails.signals import instructor_confirmed_for_workshop_signal
 from emails.utils import api_model_url, scalar_value_url
 from recruitment.models import InstructorRecruitment, InstructorRecruitmentSignup
-from workshops.models import Event, Organization, Person, Role, Task
+from workshops.models import Event, Organization, Person, Role, Tag, Task
 from workshops.tests.base import TestBase
 
 
@@ -249,6 +249,8 @@ class TestInstructorConfirmedForWorkshopReceiverIntegration(TestBase):
     ) -> None:
         # Arrange
         self._setUpRoles()
+        self._setUpTags()
+        self._setUpAdministrators()
         host = Organization.objects.create(domain="test.com", fullname="Test")
         person = Person.objects.create_user(  # type: ignore
             username="test_test",
@@ -269,8 +271,13 @@ class TestInstructorConfirmedForWorkshopReceiverIntegration(TestBase):
             person=person,
         )
         event = Event.objects.create(
-            slug="test-event", host=host, start=date(2023, 7, 22), end=date(2023, 7, 23)
+            slug="test-event",
+            host=host,
+            start=date.today() + timedelta(days=7),
+            end=date.today() + timedelta(days=8),
+            administrator=Organization.objects.get(domain="software-carpentry.org"),
         )
+        event.tags.add(Tag.objects.get(name="SWC"))
         recruitment = InstructorRecruitment.objects.create(status="o", event=event)
         signup = InstructorRecruitmentSignup.objects.create(
             recruitment=recruitment, person=person

--- a/amy/emails/tests/actions/test_instructor_declined_from_workshop_cancel_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_declined_from_workshop_cancel_receiver.py
@@ -1,0 +1,293 @@
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import MagicMock, call, patch
+
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import reverse
+
+from communityroles.models import CommunityRole, CommunityRoleConfig
+from emails.actions.instructor_declined_from_workshop import (
+    instructor_declined_from_workshop_cancel_receiver,
+    instructor_declined_from_workshop_strategy,
+    run_instructor_declined_from_workshop_strategy,
+)
+from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailStatus
+from emails.signals import (
+    INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+    instructor_declined_from_workshop_cancel_signal,
+)
+from recruitment.models import InstructorRecruitment, InstructorRecruitmentSignup
+from workshops.models import Event, Organization, Person, Role, Tag, Task
+from workshops.tests.base import TestBase
+
+
+class TestInstructorDeclinedFromWorkshopCancelReceiver(TestCase):
+    def setUp(self) -> None:
+        host = Organization.objects.create(domain="test.com", fullname="Test")
+        self.event = Event.objects.create(
+            slug="test-event", host=host, start=date(2024, 8, 5), end=date(2024, 8, 5)
+        )
+        self.person = Person.objects.create(email="test@example.org")
+        instructor = Role.objects.create(name="instructor")
+        self.task = Task.objects.create(
+            role=instructor, person=self.person, event=self.event
+        )
+        self.recruitment = InstructorRecruitment.objects.create(
+            event=self.event, notes="Test notes"
+        )
+        self.signup = InstructorRecruitmentSignup.objects.create(
+            recruitment=self.recruitment, person=self.person
+        )
+
+    def setUpEmailTemplate(self) -> EmailTemplate:
+        return EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ name }}",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+
+    @patch("emails.actions.base_action.logger")
+    def test_disabled_when_no_feature_flag(self, mock_logger: MagicMock) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        with self.settings(FLAGS={"EMAIL_MODULE": [("boolean", False)]}):
+            # Act
+            instructor_declined_from_workshop_cancel_receiver(None, request=request)
+            # Assert
+            mock_logger.debug.assert_called_once_with(
+                "EMAIL_MODULE feature flag not set, skipping "
+                "instructor_declined_from_workshop_cancel"
+            )
+
+    def test_receiver_connected_to_signal(self) -> None:
+        # Arrange
+        original_receivers = instructor_declined_from_workshop_cancel_signal.receivers[
+            :
+        ]
+
+        # Act
+        # attempt to connect the receiver
+        instructor_declined_from_workshop_cancel_signal.connect(
+            instructor_declined_from_workshop_cancel_receiver
+        )
+        new_receivers = instructor_declined_from_workshop_cancel_signal.receivers[:]
+
+        # Assert
+        # the same receiver list means this receiver has already been connected
+        self.assertEqual(original_receivers, new_receivers)
+
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    def test_action_triggered(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+
+        template = self.setUpEmailTemplate()
+        scheduled_email = ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+
+        # Act
+        with patch(
+            "emails.actions.base_action.messages_action_cancelled"
+        ) as mock_messages_action_cancelled:
+            instructor_declined_from_workshop_cancel_signal.send(
+                sender=self.signup,
+                request=request,
+                person_id=self.person.pk,
+                event_id=self.event.pk,
+                instructor_recruitment_id=self.recruitment.pk,
+                instructor_recruitment_signup_id=self.signup.pk,
+            )
+
+        # Assert
+        scheduled_email = ScheduledEmail.objects.get(template=template)
+        mock_messages_action_cancelled.assert_called_once_with(
+            request,
+            INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+            scheduled_email,
+        )
+
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @patch("emails.actions.base_action.messages_action_cancelled")
+    def test_email_cancelled(
+        self,
+        mock_messages_action_cancelled: MagicMock,
+    ) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        template = self.setUpEmailTemplate()
+        scheduled_email = ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+
+        # Act
+        with patch(
+            "emails.actions.base_action.EmailController.cancel_email"
+        ) as mock_cancel_email:
+            instructor_declined_from_workshop_cancel_signal.send(
+                sender=self.signup,
+                request=request,
+                person_id=self.person.pk,
+                event_id=self.event.pk,
+                instructor_recruitment_id=self.recruitment.pk,
+                instructor_recruitment_signup_id=self.signup.pk,
+            )
+
+        # Assert
+        mock_cancel_email.assert_called_once_with(
+            scheduled_email=scheduled_email,
+            author=None,
+        )
+
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @patch("emails.actions.base_action.messages_action_cancelled")
+    def test_multiple_emails_cancelled(
+        self,
+        mock_messages_action_cancelled: MagicMock,
+    ) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        template = self.setUpEmailTemplate()
+        scheduled_email1 = ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+        scheduled_email2 = ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+
+        # Act
+        with patch(
+            "emails.actions.base_action.EmailController.cancel_email"
+        ) as mock_cancel_email:
+            instructor_declined_from_workshop_cancel_signal.send(
+                sender=self.signup,
+                request=request,
+                person_id=self.person.pk,
+                event_id=self.event.pk,
+                instructor_recruitment_id=self.recruitment.pk,
+                instructor_recruitment_signup_id=self.signup.pk,
+            )
+
+        # Assert
+        mock_cancel_email.assert_has_calls(
+            [
+                call(
+                    scheduled_email=scheduled_email1,
+                    author=None,
+                ),
+                call(
+                    scheduled_email=scheduled_email2,
+                    author=None,
+                ),
+            ]
+        )
+
+
+class TestInstructorDeclinedFromWorkshopCancelIntegration(TestBase):
+    @override_settings(
+        FLAGS={
+            "INSTRUCTOR_RECRUITMENT": [("boolean", True)],
+            "EMAIL_MODULE": [("boolean", True)],
+        }
+    )
+    def test_integration(self) -> None:
+        # Arrange
+        self._setUpRoles()
+        self._setUpTags()
+        self._setUpAdministrators()
+        self._setUpUsersAndLogin()
+        host = Organization.objects.create(domain="test.com", fullname="Test")
+        person = Person.objects.create_user(  # type: ignore
+            username="test_test",
+            personal="Test",
+            family="User",
+            email="test@user.com",
+            password="test",
+        )
+        config = CommunityRoleConfig.objects.create(
+            name="instructor",
+            display_name="Instructor",
+            link_to_award=False,
+            link_to_membership=False,
+            additional_url=False,
+        )
+        CommunityRole.objects.create(
+            config=config,
+            person=person,
+        )
+        event = Event.objects.create(
+            slug="test-event",
+            host=host,
+            start=date.today() + timedelta(days=7),
+            end=date.today() + timedelta(days=8),
+            administrator=Organization.objects.get(domain="software-carpentry.org"),
+        )
+        event.tags.add(Tag.objects.get(name="SWC"))
+        recruitment = InstructorRecruitment.objects.create(status="o", event=event)
+        signup = InstructorRecruitmentSignup.objects.create(
+            recruitment=recruitment, person=person, state="d"
+        )
+
+        template = EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ person.personal }}",
+            body="Hello, {{ person.personal }}! Nice to meet **you**.",
+        )
+
+        request = RequestFactory().get("/")
+        with patch(
+            "emails.actions.base_action.messages_action_scheduled"
+        ) as mock_action_scheduled:
+            run_instructor_declined_from_workshop_strategy(
+                instructor_declined_from_workshop_strategy(signup),
+                request,
+                signup=signup,
+                person_id=person.pk,
+                event_id=event.pk,
+                instructor_recruitment_id=recruitment.pk,
+                instructor_recruitment_signup_id=signup.pk,
+            )
+        scheduled_email = ScheduledEmail.objects.get(template=template)
+
+        url = reverse("instructorrecruitmentsignup_changestate", args=[signup.pk])
+        payload = {"action": "confirm"}
+
+        # Act
+        rv = self.client.post(url, payload)
+
+        # Assert
+        mock_action_scheduled.assert_called_once()
+        self.assertEqual(rv.status_code, 302)
+        scheduled_email.refresh_from_db()
+        self.assertEqual(scheduled_email.state, ScheduledEmailStatus.CANCELLED)

--- a/amy/emails/tests/actions/test_instructor_declined_from_workshop_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_declined_from_workshop_receiver.py
@@ -8,7 +8,10 @@ from communityroles.models import CommunityRole, CommunityRoleConfig
 from emails.actions import instructor_declined_from_workshop_receiver
 from emails.models import EmailTemplate, ScheduledEmail
 from emails.schemas import ContextModel, ToHeaderModel
-from emails.signals import instructor_declined_from_workshop_signal
+from emails.signals import (
+    INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+    instructor_declined_from_workshop_signal,
+)
 from emails.utils import api_model_url
 from recruitment.models import InstructorRecruitment, InstructorRecruitmentSignup
 from workshops.models import Event, Organization, Person, Tag
@@ -228,9 +231,7 @@ class TestInstructorDeclinedFromWorkshopReceiverIntegration(TestBase):
             "EMAIL_MODULE": [("boolean", True)],
         }
     )
-    def test_integration(
-        self,
-    ) -> None:
+    def test_integration(self) -> None:
         # Arrange
         self._setUpRoles()
         self._setUpTags()
@@ -269,7 +270,7 @@ class TestInstructorDeclinedFromWorkshopReceiverIntegration(TestBase):
 
         template = EmailTemplate.objects.create(
             name="Test Email Template",
-            signal=instructor_declined_from_workshop_signal.signal_name,
+            signal=INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
             from_header="workshops@carpentries.org",
             cc_header=["team@carpentries.org"],
             bcc_header=[],

--- a/amy/emails/tests/actions/test_instructor_declined_from_workshop_strategy.py
+++ b/amy/emails/tests/actions/test_instructor_declined_from_workshop_strategy.py
@@ -1,0 +1,290 @@
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from emails.actions.exceptions import EmailStrategyException
+from emails.actions.instructor_declined_from_workshop import (
+    instructor_declined_from_workshop_strategy,
+    run_instructor_declined_from_workshop_strategy,
+)
+from emails.models import EmailTemplate, ScheduledEmail, ScheduledEmailStatus
+from emails.signals import INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME
+from emails.types import StrategyEnum
+from recruitment.models import InstructorRecruitment, InstructorRecruitmentSignup
+from workshops.models import Event, Organization, Person, Role, Tag, Task
+
+
+class TestInstructorDeclinedFromWorkshopStrategy(TestCase):
+    def setUp(self) -> None:
+        host = Organization.objects.create(domain="test.com", fullname="Test")
+        self.event = Event.objects.create(
+            slug="test-event",
+            host=host,
+            administrator=host,
+            start=timezone.now().date() + timedelta(days=2),
+            end=timezone.now().date() + timedelta(days=3),
+        )
+        swc_tag = Tag.objects.create(name="SWC")
+        self.event.tags.set([swc_tag])
+        self.person = Person.objects.create(email="test@example.org")
+        instructor = Role.objects.create(name="instructor")
+        self.task = Task.objects.create(
+            role=instructor, person=self.person, event=self.event
+        )
+        self.recruitment = InstructorRecruitment.objects.create(
+            event=self.event, notes="Test notes"
+        )
+        self.signup = InstructorRecruitmentSignup.objects.create(
+            recruitment=self.recruitment, person=self.person, state="d"
+        )
+
+    def test_strategy_create(self) -> None:
+        # Arrange
+
+        # Act
+        result = instructor_declined_from_workshop_strategy(self.signup)
+
+        # Assert
+        self.assertEqual(result, StrategyEnum.CREATE)
+
+    def test_strategy_update(self) -> None:
+        # Arrange
+        template = EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ name }}",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+        ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+
+        # Act
+        result = instructor_declined_from_workshop_strategy(self.signup)
+
+        # Assert
+        self.assertEqual(result, StrategyEnum.UPDATE)
+
+    def test_strategy_cancel(self) -> None:
+        # Arrange
+        self.signup.state = "a"
+        self.signup.save()
+
+        template = EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ name }}",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+        ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+
+        # Act
+        result = instructor_declined_from_workshop_strategy(self.signup)
+
+        # Assert
+        self.assertEqual(result, StrategyEnum.CANCEL)
+
+
+class TestRunInstructorDeclinedFromWorkshopStrategy(TestCase):
+    def setUp(self) -> None:
+        host = Organization.objects.create(domain="test.com", fullname="Test")
+        self.event = Event.objects.create(
+            slug="test-event", host=host, start=date(2024, 8, 5), end=date(2024, 8, 5)
+        )
+        self.person = Person.objects.create(email="test@example.org")
+        instructor = Role.objects.create(name="instructor")
+        self.task = Task.objects.create(
+            role=instructor, person=self.person, event=self.event
+        )
+        self.recruitment = InstructorRecruitment.objects.create(
+            event=self.event, notes="Test notes"
+        )
+        self.signup = InstructorRecruitmentSignup.objects.create(
+            recruitment=self.recruitment, person=self.person
+        )
+
+    @patch(
+        "emails.actions.instructor_declined_from_workshop."
+        "instructor_declined_from_workshop_signal"
+    )
+    def test_strategy_calls_create_signal(
+        self,
+        mock_instructor_declined_from_workshop_signal,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.CREATE
+        request = RequestFactory().get("/")
+
+        # Act
+        run_instructor_declined_from_workshop_strategy(
+            strategy,
+            request,
+            signup=self.signup,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+        # Assert
+        mock_instructor_declined_from_workshop_signal.send.assert_called_once_with(
+            sender=self.signup,
+            request=request,
+            signup=self.signup,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+    @patch(
+        "emails.actions.instructor_declined_from_workshop."
+        "instructor_declined_from_workshop_update_signal"
+    )
+    def test_strategy_calls_update_signal(
+        self,
+        mock_update_signal,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.UPDATE
+        request = RequestFactory().get("/")
+
+        # Act
+        run_instructor_declined_from_workshop_strategy(
+            strategy,
+            request,
+            signup=self.signup,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+        # Assert
+        mock_update_signal.send.assert_called_once_with(
+            sender=self.signup,
+            request=request,
+            signup=self.signup,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+    @patch(
+        "emails.actions.instructor_declined_from_workshop."
+        "instructor_declined_from_workshop_cancel_signal"
+    )
+    def test_strategy_calls_cancel_signal(
+        self,
+        mock_cancel_signal,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.CANCEL
+        request = RequestFactory().get("/")
+
+        # Act
+        run_instructor_declined_from_workshop_strategy(
+            strategy,
+            request,
+            signup=self.signup,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+        # Assert
+        mock_cancel_signal.send.assert_called_once_with(
+            sender=self.signup,
+            request=request,
+            signup=self.signup,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+    @patch("emails.actions.base_strategy.logger")
+    @patch(
+        "emails.actions.instructor_declined_from_workshop."
+        "instructor_declined_from_workshop_signal"
+    )
+    @patch(
+        "emails.actions.instructor_declined_from_workshop."
+        "instructor_declined_from_workshop_update_signal"
+    )
+    @patch(
+        "emails.actions.instructor_declined_from_workshop."
+        "instructor_declined_from_workshop_cancel_signal"
+    )
+    def test_invalid_strategy_no_signal_called(
+        self,
+        mock_instructor_declined_from_workshop_cancel_signal,
+        mock_instructor_declined_from_workshop_update_signal,
+        mock_instructor_declined_from_workshop_signal,
+        mock_logger,
+    ) -> None:
+        # Arrange
+        strategy = StrategyEnum.NOOP
+        request = RequestFactory().get("/")
+
+        # Act
+        run_instructor_declined_from_workshop_strategy(
+            strategy,
+            request,
+            signup=self.signup,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+        # Assert
+        mock_instructor_declined_from_workshop_signal.send.assert_not_called()
+        mock_instructor_declined_from_workshop_update_signal.send.assert_not_called()
+        mock_instructor_declined_from_workshop_cancel_signal.send.assert_not_called()
+        mock_logger.debug.assert_called_once_with(
+            f"Strategy {strategy} for {self.signup} is a no-op"
+        )
+
+    def test_invalid_strategy(self) -> None:
+        # Arrange
+        strategy = MagicMock()
+        request = RequestFactory().get("/")
+
+        # Act & Assert
+        with self.assertRaises(
+            EmailStrategyException, msg=f"Unknown strategy {strategy}"
+        ):
+            run_instructor_declined_from_workshop_strategy(
+                strategy,
+                request,
+                signup=self.signup,
+                person_id=self.person.pk,
+                event_id=self.event.pk,
+                instructor_recruitment_id=self.recruitment.pk,
+                instructor_recruitment_signup_id=self.signup.pk,
+            )

--- a/amy/emails/tests/actions/test_instructor_declined_from_workshop_update_receiver.py
+++ b/amy/emails/tests/actions/test_instructor_declined_from_workshop_update_receiver.py
@@ -1,0 +1,385 @@
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import reverse
+
+from communityroles.models import CommunityRole, CommunityRoleConfig
+from emails.actions.instructor_declined_from_workshop import (
+    instructor_declined_from_workshop_strategy,
+    instructor_declined_from_workshop_update_receiver,
+    run_instructor_declined_from_workshop_strategy,
+)
+from emails.models import (
+    EmailTemplate,
+    ScheduledEmail,
+    ScheduledEmailLog,
+    ScheduledEmailStatus,
+)
+from emails.schemas import ContextModel, ToHeaderModel
+from emails.signals import (
+    INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+    instructor_declined_from_workshop_update_signal,
+)
+from emails.utils import api_model_url
+from recruitment.models import InstructorRecruitment, InstructorRecruitmentSignup
+from workshops.models import Event, Organization, Person, Role, Tag, Task
+from workshops.tests.base import TestBase
+
+
+class TestInstructorDeclinedFromWorkshopUpdateReceiver(TestCase):
+    def setUp(self) -> None:
+        host = Organization.objects.create(domain="test.com", fullname="Test")
+        self.event = Event.objects.create(
+            slug="test-event", host=host, start=date(2024, 8, 5), end=date(2024, 8, 5)
+        )
+        self.person = Person.objects.create(email="test@example.org")
+        instructor = Role.objects.create(name="instructor")
+        self.task = Task.objects.create(
+            role=instructor, person=self.person, event=self.event
+        )
+        self.recruitment = InstructorRecruitment.objects.create(
+            event=self.event, notes="Test notes"
+        )
+        self.signup = InstructorRecruitmentSignup.objects.create(
+            recruitment=self.recruitment, person=self.person
+        )
+
+    def setUpEmailTemplate(self) -> EmailTemplate:
+        return EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ name }}",
+            body="Hello, {{ name }}! Nice to meet **you**.",
+        )
+
+    @patch("emails.actions.base_action.logger")
+    def test_disabled_when_no_feature_flag(self, mock_logger) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        with self.settings(FLAGS={"EMAIL_MODULE": [("boolean", False)]}):
+            # Act
+            instructor_declined_from_workshop_update_receiver(None, request=request)
+            # Assert
+            mock_logger.debug.assert_called_once_with(
+                "EMAIL_MODULE feature flag not set, skipping "
+                "instructor_declined_from_workshop_update"
+            )
+
+    def test_receiver_connected_to_signal(self) -> None:
+        # Arrange
+        original_receivers = instructor_declined_from_workshop_update_signal.receivers[
+            :
+        ]
+
+        # Act
+        # attempt to connect the receiver
+        instructor_declined_from_workshop_update_signal.connect(
+            instructor_declined_from_workshop_update_receiver
+        )
+        new_receivers = instructor_declined_from_workshop_update_signal.receivers[:]
+
+        # Assert
+        # the same receiver list means this receiver has already been connected
+        self.assertEqual(original_receivers, new_receivers)
+
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    def test_action_triggered(self) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+
+        template = self.setUpEmailTemplate()
+        ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+
+        # Act
+        with patch(
+            "emails.actions.base_action.messages_action_updated"
+        ) as mock_messages_action_updated:
+            instructor_declined_from_workshop_update_signal.send(
+                sender=self.signup,
+                request=request,
+                person_id=self.person.pk,
+                event_id=self.event.pk,
+                instructor_recruitment_id=self.recruitment.pk,
+                instructor_recruitment_signup_id=self.signup.pk,
+            )
+
+        # Assert
+        scheduled_email = ScheduledEmail.objects.get(template=template)
+        mock_messages_action_updated.assert_called_once_with(
+            request,
+            INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+            scheduled_email,
+        )
+
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @patch("emails.actions.base_action.messages_action_updated")
+    @patch("emails.actions.instructor_declined_from_workshop.immediate_action")
+    def test_email_updated(
+        self,
+        mock_immediate_action: MagicMock,
+        mock_messages_action_updated: MagicMock,
+    ) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        template = self.setUpEmailTemplate()
+        scheduled_email = ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+        scheduled_at = datetime(2024, 12, 22, 12, 0, tzinfo=UTC)
+        mock_immediate_action.return_value = scheduled_at
+
+        # Act
+        with patch(
+            "emails.actions.base_action.EmailController.update_scheduled_email"
+        ) as mock_update_scheduled_email:
+            instructor_declined_from_workshop_update_signal.send(
+                sender=self.signup,
+                request=request,
+                person_id=self.person.pk,
+                event_id=self.event.pk,
+                instructor_recruitment_id=self.recruitment.pk,
+                instructor_recruitment_signup_id=self.signup.pk,
+            )
+
+        # Assert
+        mock_update_scheduled_email.assert_called_once_with(
+            scheduled_email=scheduled_email,
+            context_json=ContextModel(
+                {
+                    "person": api_model_url("person", self.person.pk),
+                    "event": api_model_url("event", self.event.pk),
+                    "instructor_recruitment_signup": api_model_url(
+                        "instructorrecruitmentsignup", self.signup.pk
+                    ),
+                }
+            ),
+            scheduled_at=scheduled_at,
+            to_header=[self.person.email],
+            to_header_context_json=ToHeaderModel(
+                [
+                    {
+                        "api_uri": api_model_url("person", self.person.pk),
+                        "property": "email",
+                    },  # type: ignore
+                ]
+            ),
+            generic_relation_obj=self.signup,
+            author=None,
+        )
+
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @patch("emails.actions.base_action.logger")
+    @patch("emails.actions.base_action.EmailController")
+    def test_previously_scheduled_email_not_existing(
+        self, mock_email_controller: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        signal = INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME
+
+        # Act
+        instructor_declined_from_workshop_update_signal.send(
+            sender=self.signup,
+            request=request,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+        # Assert
+        mock_email_controller.update_scheduled_email.assert_not_called()
+        signup = self.signup
+        mock_logger.warning.assert_called_once_with(
+            f"Scheduled email for signal {signal} and generic_relation_obj={signup!r} "
+            "does not exist."
+        )
+
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @patch("emails.actions.base_action.logger")
+    @patch("emails.actions.base_action.EmailController")
+    def test_multiple_previously_scheduled_emails(
+        self, mock_email_controller: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        signal = INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME
+        template = self.setUpEmailTemplate()
+        ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+        ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+
+        # Act
+        instructor_declined_from_workshop_update_signal.send(
+            sender=self.signup,
+            request=request,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+        # Assert
+        mock_email_controller.update_scheduled_email.assert_not_called()
+        mock_logger.warning.assert_called_once_with(
+            f"Too many scheduled emails for signal {signal} and "
+            f"generic_relation_obj={self.signup!r}. Can't update them."
+        )
+
+    @override_settings(FLAGS={"EMAIL_MODULE": [("boolean", True)]})
+    @patch("emails.actions.base_action.messages_missing_recipients")
+    def test_missing_recipients(
+        self, mock_messages_missing_recipients: MagicMock
+    ) -> None:
+        # Arrange
+        request = RequestFactory().get("/")
+        template = self.setUpEmailTemplate()
+        ScheduledEmail.objects.create(
+            template=template,
+            scheduled_at=datetime.now(UTC),
+            to_header=[],
+            cc_header=[],
+            bcc_header=[],
+            state=ScheduledEmailStatus.SCHEDULED,
+            generic_relation=self.signup,
+        )
+        signal = INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME
+        self.person.email = ""
+        self.person.save()
+
+        # Act
+        instructor_declined_from_workshop_update_signal.send(
+            sender=self.signup,
+            request=request,
+            person_id=self.person.pk,
+            event_id=self.event.pk,
+            instructor_recruitment_id=self.recruitment.pk,
+            instructor_recruitment_signup_id=self.signup.pk,
+        )
+
+        # Assert
+        mock_messages_missing_recipients.assert_called_once_with(request, signal)
+
+
+class TestInstructorDeclinedFromWorkshopUpdateIntegration(TestBase):
+    @override_settings(
+        FLAGS={
+            "INSTRUCTOR_RECRUITMENT": [("boolean", True)],
+            "EMAIL_MODULE": [("boolean", True)],
+        }
+    )
+    def test_integration(self) -> None:
+        # Arrange
+        self._setUpRoles()
+        self._setUpTags()
+        self._setUpAdministrators()
+        self._setUpUsersAndLogin()
+        host = Organization.objects.create(domain="test.com", fullname="Test")
+        person = Person.objects.create_user(  # type: ignore
+            username="test_test",
+            personal="Test",
+            family="User",
+            email="test@user.com",
+            password="test",
+        )
+        config = CommunityRoleConfig.objects.create(
+            name="instructor",
+            display_name="Instructor",
+            link_to_award=False,
+            link_to_membership=False,
+            additional_url=False,
+        )
+        CommunityRole.objects.create(
+            config=config,
+            person=person,
+        )
+        event = Event.objects.create(
+            slug="test-event",
+            host=host,
+            start=date.today() + timedelta(days=7),
+            end=date.today() + timedelta(days=8),
+            administrator=Organization.objects.get(domain="software-carpentry.org"),
+        )
+        event.tags.add(Tag.objects.get(name="SWC"))
+        recruitment = InstructorRecruitment.objects.create(status="o", event=event)
+        signup = InstructorRecruitmentSignup.objects.create(
+            recruitment=recruitment, person=person, state="d"
+        )
+
+        template = EmailTemplate.objects.create(
+            name="Test Email Template",
+            signal=INSTRUCTOR_DECLINED_FROM_WORKSHOP_SIGNAL_NAME,
+            from_header="workshops@carpentries.org",
+            cc_header=["team@carpentries.org"],
+            bcc_header=[],
+            subject="Greetings {{ person.personal }}",
+            body="Hello, {{ person.personal }}! Nice to meet **you**.",
+        )
+
+        request = RequestFactory().get("/")
+        with patch(
+            "emails.actions.base_action.messages_action_scheduled"
+        ) as mock_action_scheduled:
+            run_instructor_declined_from_workshop_strategy(
+                instructor_declined_from_workshop_strategy(signup),
+                request,
+                signup=signup,
+                person_id=person.pk,
+                event_id=event.pk,
+                instructor_recruitment_id=recruitment.pk,
+                instructor_recruitment_signup_id=signup.pk,
+            )
+        scheduled_email = ScheduledEmail.objects.get(template=template)
+
+        url = reverse("instructorrecruitmentsignup_changestate", args=[signup.pk])
+        payload = {"action": "decline"}
+
+        # Act
+        rv = self.client.post(url, payload)
+
+        # Assert
+        mock_action_scheduled.assert_called_once()
+        self.assertEqual(rv.status_code, 302)
+        scheduled_email.refresh_from_db()
+        self.assertEqual(scheduled_email.state, ScheduledEmailStatus.SCHEDULED)
+        # Ensure that last log is update (from 'scheduled' to 'scheduled')
+        last_log = (
+            ScheduledEmailLog.objects.filter(scheduled_email=scheduled_email)
+            .order_by("created_at")
+            .last()
+        )
+        assert last_log
+        self.assertEqual(last_log.state_before, last_log.state_after)


### PR DESCRIPTION
This fixes #2728 by implementing a complex strategy for instructor declined for workshop, and by changing how the strategies are run when instructor recruitment signup is accepted/declined.