### PR TITLE
feat(#2771): Update API serializer for inline Attachments

### DIFF
--- a/amy/api/v2/serializers.py
+++ b/amy/api/v2/serializers.py
@@ -267,6 +267,8 @@ class InlineAttachmentSerializer(serializers.ModelSerializer[Attachment]):
             "filename",
             "s3_path",
             "s3_bucket",
+            "presigned_url",
+            "presigned_url_expiration",
         )
 
 

--- a/amy/workshops/tests/runner.py
+++ b/amy/workshops/tests/runner.py
@@ -12,7 +12,6 @@ class SilenceLogsRunner(DiscoverRunner):
 
     def __init__(self, **kwargs: Any) -> None:
         self.log_output = kwargs.pop("log_output", False)
-        print(self.log_output)
         super().__init__(**kwargs)
 
     @classmethod


### PR DESCRIPTION
This fixes #2771 - a problem in REST API serializer definition that causes issue in the email worker.