### PR TITLE
fix(#2795): Make autoemails removal migration depending on workshops.0277 migration

### DIFF
--- a/amy/autoemails/migrations/0020_remove_rqjob_trigger_remove_trigger_template_and_more.py
+++ b/amy/autoemails/migrations/0020_remove_rqjob_trigger_remove_trigger_template_and_more.py
@@ -7,6 +7,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("autoemails", "0019_alter_trigger_action"),
+        ("workshops", "0277_merge_20250206_0536"),
     ]
 
     operations = [


### PR DESCRIPTION
This enforces order: 0277 is removing relationships to RQJobs, then 0020 is removing RQJobs.

Fixes #2795.