### PR TITLE
fix(#2826): Show "missing airport information" only for logged-in users

### DIFF
--- a/amy/templates/base.html
+++ b/amy/templates/base.html
@@ -52,7 +52,7 @@
       <div class="row">
         {% block leftcolumn %}{% endblock leftcolumn %}
         <div class="{% block maincolumn %}col-sm-12 col-md-12{% endblock maincolumn %} main pb-5">
-        {% if not user.airport_iata %}
+        {% if user.is_authenticated and not user.airport_iata %}
         <div class="alert alert-warning" role="alert">
           <strong>Warning:</strong>
           Your profile is missing airport information. <a href="{% url 'autoupdate_profile' %}">Click here to complete your profile.</a>


### PR DESCRIPTION
This fixes #2826.