### PR TITLE
feat(#2877): Hide partnerships&community roles in indiv. account detail page

### DIFF
--- a/src/offering/templates/offering/account_details.html
+++ b/src/offering/templates/offering/account_details.html
@@ -50,6 +50,7 @@
   </tr>
 </table>
 
+{% if object.account_type != "individual" %}
 <h4>Partnerships:</h4>
 
 {% include "offering/includes/partnerships.html" with object_list=partnerships %}
@@ -59,6 +60,7 @@
 <a href="#" class="btn btn-success disabled">Add partnership</a>
 {% endif %}
 <p></p>
+{% endif %}
 
 <h4>Linked account benefits:</h4>
 
@@ -72,6 +74,7 @@
 
 <p></p>
 
+{% if object.account_type != "individual" %}
 <h4>Community roles related to partnerships linked to this account:</h4>
 
 <table class="table table-striped">
@@ -132,5 +135,6 @@
   </tr>
   {% endfor %}
 </table>
+{% endif %}
 
 {% endblock %}

--- a/src/offering/views.py
+++ b/src/offering/views.py
@@ -61,14 +61,15 @@ class AccountDetails(OnlyForAdminsMixin, FlaggedViewMixin, AMYDetailView[Account
         context["title"] = str(self.object)
         context["owners"] = AccountOwner.objects.filter(account=self.object).select_related("person")
         context["account_benefits"] = AccountBenefit.objects.filter(account=self.object).select_related("benefit")
-        context["partnerships"] = (
-            Partnership.objects.credits_usage_annotation()
-            .filter(account=self.object)
-            .select_related("tier", "partner_consortium", "partner_organisation", "account")
-        )
-        context["community_roles"] = CommunityRole.objects.filter(partnership__account=self.object).select_related(
-            "partnership", "person"
-        )
+        if self.object.account_type != "individual":
+            context["partnerships"] = (
+                Partnership.objects.credits_usage_annotation()
+                .filter(account=self.object)
+                .select_related("tier", "partner_consortium", "partner_organisation", "account")
+            )
+            context["community_roles"] = CommunityRole.objects.filter(partnership__account=self.object).select_related(
+                "partnership", "person"
+            )
         return context
 
 


### PR DESCRIPTION
This fixes #2877.