### PR TITLE
fix(#2870): Improve social fields validation

### DIFF
--- a/src/emails/tests/actions/test_instructor_task_created_for_workshop_update_receiver.py
+++ b/src/emails/tests/actions/test_instructor_task_created_for_workshop_update_receiver.py
@@ -309,12 +309,12 @@ class TestInstructorTaskCreatedForWorkshopUpdateIntegration(TestBase):
             airport_iata="CDG",
             github="",
             twitter="",
-            bluesky="@purdykelsi.bsky.social",
-            mastodon="http://mastodon.com/@kelsipurdy",
+            bluesky="purdykelsi.bsky.social",
+            mastodon="kelsipurdy@mastodon.social",
             url="http://kelsipurdy.com/",
             affiliation="University of Arizona",
             occupation="TA at Biology Department",
-            orcid="0000-0001-2345-6789",
+            orcid="https://orcid.org/0000-0001-2345-6789",
             is_active=True,
         )
         instructor_role = Role.objects.get(name="instructor")

--- a/src/workshops/fields.py
+++ b/src/workshops/fields.py
@@ -3,7 +3,7 @@ from typing import Any, Protocol, cast
 
 import pytz
 from django import forms
-from django.core.validators import MaxLengthValidator, RegexValidator
+from django.core.validators import EmailValidator, MaxLengthValidator, RegexValidator
 from django.db import models
 from django.utils.safestring import SafeString, mark_safe
 from django_select2.forms import HeavySelect2Widget as DS2_HeavySelect2Widget
@@ -49,14 +49,14 @@ class NullableGithubUsernameField(models.CharField):  # type: ignore
 
 # ORCID IDs are 16 digits split into 4 groups of 4 by hyphens; the last
 # character may be "X" (ISO 7064 check digit).  The canonical form is the
-# full URI, but bare IDs are also accepted.
-# See https://support.orcid.org/hc/en-us/articles/360006897674
+# full URI.
+# See https://support.orcid.org/hc/en-us/articles/360006897674,
+# subsection "Storage of the ORCID iD in a database" which requires the full URI form.
 ORCID_REGEX_VALIDATOR = RegexValidator(
-    regex=r"^(https://orcid\.org/)?\d{4}-\d{4}-\d{4}-\d{3}[\dX]$",
+    regex=r"^https://orcid\.org/\d{4}-\d{4}-\d{4}-\d{3}[\dX]$",
     message=(
         "Enter a valid ORCID identifier, either as a bare ID "
-        "(e.g. 0000-0001-2345-6789) or as a full URI "
-        "(e.g. https://orcid.org/0000-0001-2345-6789)."
+        "as a full URI (e.g. https://orcid.org/0000-0001-2345-6789)."
     ),
 )
 
@@ -64,37 +64,42 @@ ORCID_REGEX_VALIDATOR = RegexValidator(
 class OrcidField(models.CharField):  # type: ignore
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("max_length", STR_LONG)
+        kwargs.setdefault(
+            "help_text", "Enter your ORCID identifier as a full URI (e.g. https://orcid.org/0000-0001-2345-6789)."
+        )
         super().__init__(**kwargs)
 
     default_validators = [ORCID_REGEX_VALIDATOR]
 
 
 # Bluesky handles follow the AT Protocol handle format: a dot-separated
-# domain name, optionally prefixed with "@".
+# domain name.
 # See https://atproto.com/specs/handle
 BLUESKY_HANDLE_VALIDATOR = RegexValidator(
-    regex=r"^@?([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$",
-    message=("Enter a valid Bluesky handle (e.g. alice.bsky.social or @alice.bsky.social)."),
+    regex=r"^([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$",
+    message=("Enter a valid Bluesky handle (e.g. alice.bsky.social)."),
 )
 
 
 class BlueSkyHandleField(models.CharField):  # type: ignore
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("max_length", STR_LONG)
+        kwargs.setdefault("help_text", "Enter your Bluesky handle (e.g. alice.bsky.social).")
         super().__init__(**kwargs)
 
     default_validators = [BLUESKY_HANDLE_VALIDATOR]
 
 
-# Mastodon profile URLs follow the pattern https://<instance>/@<username>.
-MASTODON_URL_VALIDATOR = RegexValidator(
-    regex=r"^https?://[^/]+/@[^/]+",
-    message=("Enter a valid Mastodon profile URL (e.g. https://mastodon.social/@alice)."),
-)
+# Mastodon usernames follow the email pattern,
+# see: https://docs.joinmastodon.org/user/signup/#address
+# URL is mentioned to be also accepted in the documentation, but the Mastodon website mostly uses email form.
+class MastodonHandleField(models.CharField):  # type: ignore
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("max_length", STR_LONG)
+        kwargs.setdefault("help_text", "Enter your Mastodon handle (e.g. alice@mastodon.social).")
+        super().__init__(**kwargs)
 
-
-class MastodonURLField(models.URLField):  # type: ignore
-    default_validators = [*models.URLField.default_validators, MASTODON_URL_VALIDATOR]
+    default_validators = [EmailValidator(message="Enter a valid Mastodon handle (e.g. alice@mastodon.social).")]
 
 
 # ------------------------------------------------------------

--- a/src/workshops/migrations/0289_validate_person_contact_fields.py
+++ b/src/workshops/migrations/0289_validate_person_contact_fields.py
@@ -33,8 +33,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="person",
             name="mastodon",
-            field=src.workshops.fields.MastodonURLField(
-                blank=True, null=True, unique=True, verbose_name="Mastodon URL"
+            field=src.workshops.fields.MastodonHandleField(
+                blank=True, null=True, unique=True, verbose_name="Mastodon username"
             ),
         ),
         migrations.AlterField(

--- a/src/workshops/models.py
+++ b/src/workshops/models.py
@@ -52,7 +52,7 @@ from src.workshops.consts import (
 )
 from src.workshops.fields import (
     BlueSkyHandleField,
-    MastodonURLField,
+    MastodonHandleField,
     NullableGithubUsernameField,
     OrcidField,
     choice_field_with_other,
@@ -812,12 +812,11 @@ class Person(
         blank=True,
         verbose_name="BlueSky username",
     )
-
-    mastodon = MastodonURLField(
+    mastodon = MastodonHandleField(
         unique=True,
         null=True,
         blank=True,
-        verbose_name="Mastodon URL",
+        verbose_name="Mastodon username",
     )
 
     url = models.CharField(

--- a/src/workshops/tests/base.py
+++ b/src/workshops/tests/base.py
@@ -172,7 +172,7 @@ class TestBase(SuperuserMixin, TestCase):
             airport_iata="CDG",
             github="herself",
             twitter="herself",
-            bluesky="@herself.bsky.social",
+            bluesky="herself.bsky.social",
             mastodon="",
             url="http://hermione.org",
             username="granger_hermione",

--- a/src/workshops/tests/test_fields.py
+++ b/src/workshops/tests/test_fields.py
@@ -4,7 +4,7 @@ from src.workshops.consts import COUNTRIES, IATA_AIRPORTS
 from src.workshops.fields import (
     AirportSelect2Widget,
     BlueSkyHandleField,
-    MastodonURLField,
+    MastodonHandleField,
     NullableGithubUsernameField,
     OrcidField,
     Select2TagWidget,
@@ -38,25 +38,26 @@ class TestNullableGHUsernameField(TestBase):
     def test_passing_usernames(self) -> None:
         """All correct usernames pass the field validation."""
         for username in self.passing:
-            self.field.run_validators(username)
+            with self.subTest(username=username):
+                self.field.run_validators(username)
 
     def test_failing_usernames(self) -> None:
         """All incorrect usernames don't pass the field validation."""
         for username in self.failing:
-            with self.assertRaises(ValidationError):
+            with self.subTest(username=username), self.assertRaises(ValidationError):
                 self.field.run_validators(username)
 
 
 class TestOrcidField(TestBase):
     def setUp(self) -> None:
         self.passing = [
-            "0000-0001-2345-6789",
-            "0000-0001-2345-678X",
             "https://orcid.org/0000-0001-2345-6789",
             "https://orcid.org/0000-0001-2345-678X",
             "",  # blank is allowed
         ]
         self.failing = [
+            "0000-0001-2345-6789",  # only URI form is accepted
+            "0000-0001-2345-678X",  # only URI form is accepted
             "0000-0001-2345-678",  # last group only 3 digits, no X
             "0000-0001-2345-6789X",  # extra character
             "000-0001-2345-6789",  # first group too short
@@ -64,18 +65,20 @@ class TestOrcidField(TestBase):
             "http://orcid.org/0000-0001-2345-6789",  # http not https
             "orcid.org/0000-0001-2345-6789",  # missing scheme
             "not-an-orcid",
+            "aaaa-bbbb-cccc-dddd",  # non-digit characters
         ]
         self.field = OrcidField()
 
     def test_passing_orcids(self) -> None:
         """Valid ORCID identifiers pass field validation."""
         for value in self.passing:
-            self.field.run_validators(value)
+            with self.subTest(value=value):
+                self.field.run_validators(value)
 
     def test_failing_orcids(self) -> None:
         """Invalid ORCID identifiers do not pass field validation."""
         for value in self.failing:
-            with self.assertRaises(ValidationError):
+            with self.subTest(value=value), self.assertRaises(ValidationError):
                 self.field.run_validators(value)
 
 
@@ -83,14 +86,14 @@ class TestBlueSkyHandleField(TestBase):
     def setUp(self) -> None:
         self.passing = [
             "alice.bsky.social",
-            "@alice.bsky.social",
             "alice.com",
-            "@alice.com",
             "my-handle.bsky.social",
             "user123.example.org",
             "",  # blank is allowed
         ]
         self.failing = [
+            "@alice.bsky.social",  # @ is not allowed
+            "@alice.com",
             "alice",  # no TLD
             "@alice",  # no TLD
             ".alice.bsky.social",  # leading dot
@@ -104,42 +107,44 @@ class TestBlueSkyHandleField(TestBase):
     def test_passing_handles(self) -> None:
         """Valid Bluesky handles pass field validation."""
         for value in self.passing:
-            self.field.run_validators(value)
+            with self.subTest(value=value):
+                self.field.run_validators(value)
 
     def test_failing_handles(self) -> None:
         """Invalid Bluesky handles do not pass field validation."""
         for value in self.failing:
-            with self.assertRaises(ValidationError):
+            with self.subTest(value=value), self.assertRaises(ValidationError):
                 self.field.run_validators(value)
 
 
-class TestMastodonURLField(TestBase):
+class TestMastodonHandleField(TestBase):
     def setUp(self) -> None:
         self.passing = [
-            "https://mastodon.social/@alice",
-            "https://fosstodon.org/@bob",
-            "http://mastodon.example.com/@carol",
-            "https://mastodon.social/@alice/extra/path",
+            "alice@mastodon.social",
             "",  # blank is allowed
         ]
         self.failing = [
-            "https://mastodon.social/alice",  # missing @ before username
-            "mastodon.social/@alice",  # missing scheme
-            "@alice@mastodon.social",  # handle format, not URL
-            "https://mastodon.social/",  # no username
-            "not-a-url",
+            "alice@",  # no domain
+            "alice@mastodon",  # missing TLD
+            "@mastodon.social",  # no username
+            "@alice@mastodon.social",  # leading @ not allowed
+            "https://mastodon.social/alice",  # URI
+            "https://mastodon.social/",  # URI
+            "mastodon.social/@alice",  # partial URI
+            "not-a-handle",
         ]
-        self.field = MastodonURLField()
+        self.field = MastodonHandleField()
 
-    def test_passing_urls(self) -> None:
-        """Valid Mastodon profile URLs pass field validation."""
+    def test_passing_handles(self) -> None:
+        """Valid Mastodon handles pass field validation."""
         for value in self.passing:
-            self.field.run_validators(value)
+            with self.subTest(value=value):
+                self.field.run_validators(value)
 
-    def test_failing_urls(self) -> None:
-        """Invalid Mastodon profile URLs do not pass field validation."""
+    def test_failing_handles(self) -> None:
+        """Invalid Mastodon handles do not pass field validation."""
         for value in self.failing:
-            with self.assertRaises(ValidationError):
+            with self.subTest(value=value), self.assertRaises(ValidationError):
                 self.field.run_validators(value)
 
 

--- a/src/workshops/tests/test_person.py
+++ b/src/workshops/tests/test_person.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import ValidationError
+from django.test import TestCase
 from django.urls import reverse
 from django_comments.models import Comment
 from reversion.models import Version
@@ -1637,7 +1638,7 @@ class TestArchivePerson(TestBase):
         self.assertFalse(self.admin.is_superuser)
 
 
-class TestPersonContactFieldValidation(TestBase):
+class TestPersonContactFieldValidation(TestCase):
     """Validate that Person contact fields enforce their format constraints."""
 
     # Exclude fields that are required by AbstractBaseUser but irrelevant here.
@@ -1673,14 +1674,14 @@ class TestPersonContactFieldValidation(TestBase):
     # orcid
     # ------------------------------------------------------------------
 
-    def test_orcid_bare_id_valid(self) -> None:
-        self._assert_valid(self._make_person(orcid="0000-0001-2345-6789"))
-
     def test_orcid_full_uri_valid(self) -> None:
         self._assert_valid(self._make_person(orcid="https://orcid.org/0000-0001-2345-678X"))
 
     def test_orcid_blank_valid(self) -> None:
         self._assert_valid(self._make_person(orcid=""))
+
+    def test_orcid_bare_id_invalid(self) -> None:
+        self._assert_field_invalid(self._make_person(orcid="0000-0001-2345-6789"), "orcid")
 
     def test_orcid_invalid(self) -> None:
         self._assert_field_invalid(self._make_person(orcid="not-an-orcid"), "orcid")
@@ -1696,11 +1697,14 @@ class TestPersonContactFieldValidation(TestBase):
     def test_bluesky_handle_valid(self) -> None:
         self._assert_valid(self._make_person(bluesky="alice.bsky.social"))
 
-    def test_bluesky_handle_with_at_valid(self) -> None:
-        self._assert_valid(self._make_person(bluesky="@alice.bsky.social"))
+    def test_bluesky_handle_blank_valid(self) -> None:
+        self._assert_valid(self._make_person(bluesky=""))
 
     def test_bluesky_null_allowed(self) -> None:
         self._assert_valid(self._make_person(bluesky=None))
+
+    def test_bluesky_handle_with_at_invalid(self) -> None:
+        self._assert_field_invalid(self._make_person(bluesky="@alice.bsky.social"), "bluesky")
 
     def test_bluesky_no_tld_invalid(self) -> None:
         self._assert_field_invalid(self._make_person(bluesky="alice"), "bluesky")
@@ -1709,15 +1713,17 @@ class TestPersonContactFieldValidation(TestBase):
     # mastodon
     # ------------------------------------------------------------------
 
-    def test_mastodon_url_valid(self) -> None:
-        self._assert_valid(self._make_person(mastodon="https://mastodon.social/@alice"))
+    def test_mastodon_valid(self) -> None:
+        self._assert_valid(self._make_person(mastodon="alice@mastodon.social"))
+
+    def test_mastodon_handle_blank_valid(self) -> None:
+        self._assert_valid(self._make_person(mastodon=""))
 
     def test_mastodon_null_allowed(self) -> None:
         self._assert_valid(self._make_person(mastodon=None))
 
-    def test_mastodon_missing_at_invalid(self) -> None:
-        """URL without /@username is not a valid Mastodon profile URL."""
-        self._assert_field_invalid(self._make_person(mastodon="https://mastodon.social/alice"), "mastodon")
+    def test_mastodon_url_invalid(self) -> None:
+        self._assert_field_invalid(self._make_person(mastodon="https://mastodon.social/@alice"), "mastodon")
 
     def test_mastodon_handle_format_invalid(self) -> None:
         """@user@instance handle format is not accepted (not a URL)."""


### PR DESCRIPTION
ORCID: expects URI with prefix `https://orcid.org/`
Bluesky: expects a handle without leading `@` character.
Mastodon: expects an email-like handle.

Since the format is quite precise now, especially for ORCID, help texts were added for user convenience.

This fixes #2870.