### PR TITLE
admin-dashboard -> dashboard

### DIFF
--- a/src/templates/navigation.html
+++ b/src/templates/navigation.html
@@ -4,7 +4,7 @@
 
 {% block navbar %}
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top shadow {% if SITE_BANNER_STYLE != 'production' %}navbar-banner-displacement{% endif %}">
-      <a class="navbar-brand" href="{% url 'dashboard' %}">AMY</a>
+      <a class="navbar-brand" href="{% url 'dispatch' %}">AMY</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/src/templates/navigation.html
+++ b/src/templates/navigation.html
@@ -4,7 +4,7 @@
 
 {% block navbar %}
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top shadow {% if SITE_BANNER_STYLE != 'production' %}navbar-banner-displacement{% endif %}">
-      <a class="navbar-brand" href="{% url 'admin-dashboard' %}">AMY</a>
+      <a class="navbar-brand" href="{% url 'dashboard' %}">AMY</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
An attempt to fix #2930. This should make the logo at the top of the page link to /dashboard which all logged in can view rather than /dashboard/admin