### PR TITLE
Sort tiers and use real tier names during testing

### DIFF
--- a/src/workshops/lookups.py
+++ b/src/workshops/lookups.py
@@ -567,7 +567,7 @@ class PartnershipLookupView(OnlyForAdminsNoRedirectMixin, ExtensibleAutoResponse
 
 class PartnershipTierLookupView(OnlyForAdminsNoRedirectMixin, ExtensibleAutoResponseView):
     def get_queryset(self) -> QuerySet[PartnershipTier]:
-        q = PartnershipTier.objects.order_by("name")
+        q = PartnershipTier.objects.order_by("credits", "name")
         if self.term:
             q = q.filter(name__icontains=self.term)
         return q

--- a/src/workshops/management/commands/fake_database.py
+++ b/src/workshops/management/commands/fake_database.py
@@ -902,7 +902,7 @@ class Command(BaseCommand):
     def fake_partnership_tiers(self) -> None:
         self.stdout.write("Generating 4 fake partnership tiers...")
 
-        for name, credits in [("bronze", 16), ("silver", 32), ("gold", 64), ("platinum", 128)]:
+        for name, credits in [("Launch", 16), ("Expand", 48), ("Scale", 80), ("Transform", 128)]:
             PartnershipTier.objects.create(name=name, credits=credits)
 
     def fake_consortiums(self) -> None:


### PR DESCRIPTION
This PR does the following:

* Sorts partnership tiers by credits rather than by name
* Uses actual tier names/credit values for consistency during local testing