### PR TITLE
fix(emails): Invalid context name for account benefits

### DIFF
--- a/src/emails/actions/new_partnership_onboarding.py
+++ b/src/emails/actions/new_partnership_onboarding.py
@@ -113,7 +113,7 @@ def get_context_json(context: NewPartnershipOnboardingContext) -> ContextModel:
         {
             "partnership": api_model_url("partnership", context["partnership"].pk),
             "account_benefits": [
-                api_model_url("account_benefit", benefit.pk) for benefit in context["account_benefits"]
+                api_model_url("accountbenefit", benefit.pk) for benefit in context["account_benefits"]
             ],
             "benefits": [api_model_url("benefit", benefit.pk) for benefit in context["benefits"]],
         },

--- a/src/emails/utils.py
+++ b/src/emails/utils.py
@@ -18,6 +18,7 @@ from jinja2 import Environment
 from rest_framework.serializers import ModelSerializer
 
 from src.api.v2.serializers import (
+    AccountBenefitSerializer,
     AwardSerializer,
     BenefitSerializer,
     ConsortiumSerializer,
@@ -36,7 +37,7 @@ from src.emails.models import ScheduledEmail
 from src.emails.signals import Signal
 from src.extrequests.models import SelfOrganisedSubmission
 from src.fiscal.models import Consortium, Partnership
-from src.offering.models import Benefit
+from src.offering.models import AccountBenefit, Benefit
 from src.recruitment.models import InstructorRecruitmentSignup
 from src.workshops.models import (
     Award,
@@ -273,6 +274,7 @@ def map_single_api_uri_to_serialized_model(uri: str) -> dict[str, Any]:
         TrainingRequirement: TrainingRequirementSerializer,
         SelfOrganisedSubmission: SelfOrganisedSubmissionSerializer,
         Benefit: BenefitSerializer,
+        AccountBenefit: AccountBenefitSerializer,
     }
 
     match urlparse(uri):


### PR DESCRIPTION
This fixes invalid context name for 'account benefit' objects, and adds their serializer to the mapping.