### PR TITLE
Testing out embedding Pretix in AMY

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -166,6 +166,8 @@ THIRD_PARTY_APPS = [
     "djangoformsetjs",
     "django_better_admin_arrayfield",
     "flags",
+    "corsheaders",
+    "sslserver",
 ]
 LOCAL_APPS = [
     "src.workshops.apps.WorkshopsConfig",
@@ -280,7 +282,9 @@ MIDDLEWARE = [
     "src.workshops.middleware.version_check.VersionCheckMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
     "reversion.middleware.RevisionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "django.middleware.common.CommonMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -671,3 +675,7 @@ CERTIFICATE_SIGNATURE = "SherAaron Hurt (Director of Workshops and Instruction)"
 
 # To silence the Django 6.0 warning about URLField assume_https default changing
 FORMS_URLFIELD_ASSUME_HTTPS = True
+
+SECURE_CROSS_ORIGIN_OPENER_POLICY = "unsafe-none"
+CORS_ALLOW_ALL_ORIGINS: True 
+

--- a/config/settings.py
+++ b/config/settings.py
@@ -166,8 +166,8 @@ THIRD_PARTY_APPS = [
     "djangoformsetjs",
     "django_better_admin_arrayfield",
     "flags",
-    "corsheaders",
-    "sslserver",
+    # "corsheaders",
+    # "sslserver",
 ]
 LOCAL_APPS = [
     "src.workshops.apps.WorkshopsConfig",
@@ -282,7 +282,7 @@ MIDDLEWARE = [
     "src.workshops.middleware.version_check.VersionCheckMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
     "reversion.middleware.RevisionMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
+    # "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.middleware.common.CommonMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",

--- a/config/settings.py
+++ b/config/settings.py
@@ -166,8 +166,6 @@ THIRD_PARTY_APPS = [
     "djangoformsetjs",
     "django_better_admin_arrayfield",
     "flags",
-    # "corsheaders",
-    # "sslserver",
 ]
 LOCAL_APPS = [
     "src.workshops.apps.WorkshopsConfig",
@@ -282,9 +280,7 @@ MIDDLEWARE = [
     "src.workshops.middleware.version_check.VersionCheckMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
     "reversion.middleware.RevisionMiddleware",
-    # "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    "django.middleware.common.CommonMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -379,6 +375,7 @@ TEMPLATES = [
                 # AMY version
                 "src.workshops.context_processors.version",
                 "src.workshops.context_processors.site_banner",
+                "src.workshops.context_processors.environments",
                 "src.workshops.context_processors.feature_flags_enabled",
                 # Consent enums
                 "src.consents.context_processors.terms",
@@ -618,6 +615,8 @@ if SITE_BANNER_STYLE not in ("local", "testing", "production"):
     raise ImproperlyConfigured("SITE_BANNER_STYLE accepts only one of 'local', 'testing', 'production'.")
 
 PROD_ENVIRONMENT = bool(SITE_BANNER_STYLE == "production")
+LOCAL_ENVIRONMENT = bool(SITE_BANNER_STYLE == "local")
+print(LOCAL_ENVIRONMENT)
 
 # Feature Flags
 # -----------------------------------------------------------------------------
@@ -675,7 +674,3 @@ CERTIFICATE_SIGNATURE = "SherAaron Hurt (Director of Workshops and Instruction)"
 
 # To silence the Django 6.0 warning about URLField assume_https default changing
 FORMS_URLFIELD_ASSUME_HTTPS = True
-
-SECURE_CROSS_ORIGIN_OPENER_POLICY = "unsafe-none"
-CORS_ALLOW_ALL_ORIGINS: True 
-

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -29,6 +29,10 @@
     <script src="{% static 'amy_utils.js' %}"></script>
     <script src="{% static 'prism.js' %}"></script>
 
+<link rel="stylesheet" type="text/css" href="https://pretix.carpentries.org/community-events/community-sessions/widget/v1.css" crossorigin>
+<script type="text/javascript" src="https://pretix.carpentries.org/widget/v1.en.js" async crossorigin></script>
+
+
     <title>AMY{% if title %}: {{ title }}{% endif %}</title>
   </head>
   <body>

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -29,8 +29,8 @@
     <script src="{% static 'amy_utils.js' %}"></script>
     <script src="{% static 'prism.js' %}"></script>
 
-<link rel="stylesheet" type="text/css" href="https://pretix.carpentries.org/community-events/community-sessions/widget/v1.css" crossorigin>
-<script type="text/javascript" src="https://pretix.carpentries.org/widget/v1.en.js" async crossorigin></script>
+<link rel="stylesheet" type="text/css" href="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/two-day-event/widget/v2.css" crossorigin>
+<script type="text/javascript" src="https://test-pretix.terrier-vibe.ts.net/widget/v2.en.js" async crossorigin></script>
 
 
     <title>AMY{% if title %}: {{ title }}{% endif %}</title>

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -29,10 +29,6 @@
     <script src="{% static 'amy_utils.js' %}"></script>
     <script src="{% static 'prism.js' %}"></script>
 
-<link rel="stylesheet" type="text/css" href="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/two-day-event/widget/v2.css" crossorigin>
-<script type="text/javascript" src="https://test-pretix.terrier-vibe.ts.net/widget/v2.en.js" async crossorigin></script>
-
-
     <title>AMY{% if title %}: {{ title }}{% endif %}</title>
   </head>
   <body>

--- a/src/templates/dashboard/instructor_dashboard.html
+++ b/src/templates/dashboard/instructor_dashboard.html
@@ -23,22 +23,21 @@
 Click on the button at the bottom of this page to update your profile information. <br>
 Your email address and GitHub id can not be updated here, as they are tied to your login id. Please contact us at <a href="mailto:team@carpentries.org">team@carpentries.org</a> if you would like to update this information.  <br>
 
-<pretix-widget event="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/series-test/"
+{% block extrastyle %}
+<link rel="stylesheet" type="text/css" href="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/series-test/widget/v2.css" crossorigin>
+{% endblock extrastyle %}
+{% block extrajs %}
+<script type="text/javascript" src="https://test-pretix.terrier-vibe.ts.net/widget/v2.en.js" async crossorigin></script>
+{% endblock extrajs %}
 
-   data-email = "{{ request.user.email }}"
-   data-attendee-name-given-name="{{ request.user.personal }}"
-   data-attendee-name-family-name="{{ request.user.family }}"
-  data-fix="true">
+<pretix-widget
+  event="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/series-test/"
+  data-email="{{ request.user.email }}"
+  data-attendee-name-given-name="{{ request.user.personal }}"
+  data-attendee-name-family-name="{{ request.user.family }}"
+  data-fix="true"
+>
 </pretix-widget>
-<noscript>
-   <div class="pretix-widget">
-        <div class="pretix-widget-info-message">
-            JavaScript is disabled in your browser. To access our ticket shop without JavaScript, please <a target="_blank" rel="noopener" href="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/two-day-event/">click here</a>.
-        </div>
-    </div>
-</noscript>
-
-</div>
 
   <table class="table table-striped">
     <tr><th width="40%">Personal name:</th><td>{{ user.personal|default:"—" }}</td></tr>

--- a/src/templates/dashboard/instructor_dashboard.html
+++ b/src/templates/dashboard/instructor_dashboard.html
@@ -36,6 +36,8 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
   data-attendee-name-given-name="{{ request.user.personal }}"
   data-attendee-name-family-name="{{ request.user.family }}"
   data-fix="true"
+  {# Only when running locally skip the SSL check - this way the modal opens up in localhost. #}
+  {% if LOCAL_ENVIRONMENT %}skip-ssl-check{% endif %}
 >
 </pretix-widget>
 
@@ -210,7 +212,5 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
   </div>
 
 </div>
-
-
 
 {% endblock %}

--- a/src/templates/dashboard/instructor_dashboard.html
+++ b/src/templates/dashboard/instructor_dashboard.html
@@ -23,23 +23,21 @@
 Click on the button at the bottom of this page to update your profile information. <br>
 Your email address and GitHub id can not be updated here, as they are tied to your login id. Please contact us at <a href="mailto:team@carpentries.org">team@carpentries.org</a> if you would like to update this information.  <br>
 
-
-<div>
- <h2>TESTING Check out events on pretix here.</h2>
-<pretix-widget
-  event="https://pretix.carpentries.org/community-events/community-sessions/" 
+<pretix-widget 
+  event="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/two-day-event/">
   data-email="{{ request.user.email }}"
   data-attendee-name="{{ request.user.personal }}" + "{{ request.user.family }}"
   data-fix="true"
+  skip-ssl-check
 </pretix-widget>
-
 <noscript>
    <div class="pretix-widget">
         <div class="pretix-widget-info-message">
-            JavaScript is disabled in your browser. To access our ticket shop without JavaScript, please <a target="_blank" rel="noopener" href="https://pretix.carpentries.org/community-events/community-sessions/">click here</a>.
+            JavaScript is disabled in your browser. To access our ticket shop without JavaScript, please <a target="_blank" rel="noopener" href="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/two-day-event/">click here</a>.
         </div>
     </div>
 </noscript>
+
 </div>
 
   <table class="table table-striped">

--- a/src/templates/dashboard/instructor_dashboard.html
+++ b/src/templates/dashboard/instructor_dashboard.html
@@ -23,6 +23,25 @@
 Click on the button at the bottom of this page to update your profile information. <br>
 Your email address and GitHub id can not be updated here, as they are tied to your login id. Please contact us at <a href="mailto:team@carpentries.org">team@carpentries.org</a> if you would like to update this information.  <br>
 
+
+<div>
+ <h2>TESTING Check out events on pretix here.</h2>
+<pretix-widget
+  event="https://pretix.carpentries.org/community-events/community-sessions/" 
+  data-email="{{ request.user.email }}"
+  data-attendee-name="{{ request.user.personal }}" + "{{ request.user.family }}"
+  data-fix="true"
+</pretix-widget>
+
+<noscript>
+   <div class="pretix-widget">
+        <div class="pretix-widget-info-message">
+            JavaScript is disabled in your browser. To access our ticket shop without JavaScript, please <a target="_blank" rel="noopener" href="https://pretix.carpentries.org/community-events/community-sessions/">click here</a>.
+        </div>
+    </div>
+</noscript>
+</div>
+
   <table class="table table-striped">
     <tr><th width="40%">Personal name:</th><td>{{ user.personal|default:"—" }}</td></tr>
     <tr><th>Middle name:</th><td>{{ user.middle|default:"—" }}</td></tr>
@@ -194,5 +213,7 @@ Your email address and GitHub id can not be updated here, as they are tied to yo
   </div>
 
 </div>
+
+
 
 {% endblock %}

--- a/src/templates/dashboard/instructor_dashboard.html
+++ b/src/templates/dashboard/instructor_dashboard.html
@@ -23,12 +23,12 @@
 Click on the button at the bottom of this page to update your profile information. <br>
 Your email address and GitHub id can not be updated here, as they are tied to your login id. Please contact us at <a href="mailto:team@carpentries.org">team@carpentries.org</a> if you would like to update this information.  <br>
 
-<pretix-widget 
-  event="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/two-day-event/">
-  data-email="{{ request.user.email }}"
-  data-attendee-name="{{ request.user.personal }}" + "{{ request.user.family }}"
-  data-fix="true"
-  skip-ssl-check
+<pretix-widget event="https://test-pretix.terrier-vibe.ts.net/carp-inst-train/series-test/"
+
+   data-email = "{{ request.user.email }}"
+   data-attendee-name-given-name="{{ request.user.personal }}"
+   data-attendee-name-family-name="{{ request.user.family }}"
+  data-fix="true">
 </pretix-widget>
 <noscript>
    <div class="pretix-widget">

--- a/src/workshops/context_processors.py
+++ b/src/workshops/context_processors.py
@@ -23,6 +23,14 @@ def site_banner(request: HttpRequest) -> dict[str, str]:
     return data
 
 
+def environments(request: HttpRequest) -> dict[str, bool]:
+    data = {
+        "LOCAL_ENVIRONMENT": settings.LOCAL_ENVIRONMENT,
+        "PROD_ENVIRONMENT": settings.PROD_ENVIRONMENT,
+    }
+    return data
+
+
 def feature_flags_enabled(request: HttpRequest) -> dict[str, Any]:
     flags = get_flags(request=request)
     data = {"FEATURE_FLAGS_ENABLED": [flag for flag in flags.values() if flag.check_state(request=request) is True]}


### PR DESCRIPTION
@pbanaszkiewicz As discussed, this PR begins to try to embed Pretix in AMY.  I will share credentials with you tomorrow.  

For now, you can run AMY locally with this PR and log in as an active user and go to `/dashboard`. You will see the embedded widget at the top of the page with a list of dates. Select any date and use the voucher `abcde`. This now takes you to an external page to continue registration. The email and attendee name are automatically filled in from the AMY profile. This is the step we'd like to keep within AMY. This will help integrate the profile creation form questions with event registration questions and integrate event registration with AMY event tasks.  

You can see some cors headers settings I tried changing with @froggleston.  I commented those back out because they weren't working but I wanted you to see them.  

