### PR TITLE
fix(#2984): Change TrainingRequest.benefit to only include active, seat benefits

### DIFF
--- a/src/workshops/migrations/0295_trainingrequest_benefit.py
+++ b/src/workshops/migrations/0295_trainingrequest_benefit.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 blank=False,
                 default=None,
-                limit_choices_to=models.Q(("active", True)),
+                limit_choices_to=models.Q(("active", True), ("unit_type", "seat")),
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 to="offering.benefit",

--- a/src/workshops/models.py
+++ b/src/workshops/models.py
@@ -2148,7 +2148,7 @@ class TrainingRequest(
         blank=False,
         default=None,
         verbose_name="What Carpentries offering are you signing up for?",
-        limit_choices_to=Q(active=True),
+        limit_choices_to=Q(active=True, unit_type="seat"),
     )
 
     person = models.ForeignKey(


### PR DESCRIPTION
This fix is provided for #2984.