### PR TITLE
feat(#3005): Add confirmation modal for assigning trainees to different offerings

### DIFF
--- a/src/extrequests/forms.py
+++ b/src/extrequests/forms.py
@@ -15,6 +15,7 @@ from src.extrequests.models import (
     WorkshopInquiryRequest,
 )
 from src.extrequests.utils import any_member_code_valid, any_member_code_valid_training
+from src.extrequests.widgets import AccountBenefitSelect2Widget, BenefitSelect2Widget
 from src.offering.models import AccountBenefit, Benefit
 from src.workshops.fields import (
     AirportSelect2Widget,
@@ -132,7 +133,7 @@ class BulkMatchTrainingRequestForm(forms.Form):
         required=False,
         help_text="Use this for partnerships instead of memberships.",
         queryset=AccountBenefit.objects.filter(benefit__unit_type="seat"),
-        widget=ModelSelect2Widget(data_view="account-benefit-seats-lookup"),  # type: ignore[no-untyped-call]
+        widget=AccountBenefitSelect2Widget(data_view="account-benefit-seats-lookup"),  # type: ignore[no-untyped-call]
     )
 
     auto_assign = forms.BooleanField(
@@ -146,7 +147,7 @@ class BulkMatchTrainingRequestForm(forms.Form):
         label="Benefit for auto-match",
         required=False,
         queryset=Benefit.objects.filter(unit_type="seat"),
-        widget=ModelSelect2Widget(data_view="benefit-seats-lookup"),  # type: ignore[no-untyped-call]
+        widget=BenefitSelect2Widget(data_view="benefit-seats-lookup"),  # type: ignore[no-untyped-call]
     )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -163,6 +164,13 @@ class BulkMatchTrainingRequestForm(forms.Form):
             if self._show_allocated_benefit
             else "Assigned users will take instructor seats based on the registration code they entered."
         )
+        # `benefit_override` is only read when auto-matching, so it's greyed out until
+        # `auto_assign` is checked. Both directives need the `matchConfirmation` Alpine
+        # component from `requests/all_trainingrequests.html`, the form's only template.
+        # `.fill` seeds `autoAssign` from the checkbox, so a redisplayed form keeps its state.
+        self.fields["auto_assign"].widget.attrs["x-model.fill"] = "autoAssign"
+        self.fields["benefit_override"].widget.attrs[":disabled"] = "!autoAssign"
+
         self.helper = BootstrapHelper(add_submit_button=False, form_tag=False, add_cancel_button=False)
         self.helper.layout = Layout(
             "event",
@@ -211,7 +219,10 @@ class BulkMatchTrainingRequestForm(forms.Form):
                 "based on registration code at the same time."
             )
 
-        if self._show_allocated_benefit and not benefit_override:
+        # `benefit_override` only takes part in auto-matching, and the template disables it
+        # unless auto-matching is on - a disabled field isn't submitted, so it can only be
+        # required together with `auto_assign`.
+        if self._show_allocated_benefit and auto_assign and not benefit_override:
             errors["benefit_override"] = ValidationError("Must not be empty.")
 
         if errors:

--- a/src/extrequests/tests/test_forms.py
+++ b/src/extrequests/tests/test_forms.py
@@ -548,27 +548,41 @@ class TestBulkMatchTrainingRequestForm(TestCase):
         self.assertIn(msg, form2.errors["auto_assign"])
 
     def test_clean__benefit_override(self) -> None:
-        """Test that form is invalid when benefit override is empty and the feature flag indicates
-        that the field should be rendered."""
+        """Test that form is invalid when benefit override is empty while auto-assigning and the
+        feature flag indicates that the field should be rendered."""
         # Arrange
         person = Person.objects.create(username="test")
         training_request = create_training_request(state="p", person=person)
         organisation = Organization.objects.create(fullname="Test Org", domain="test.org")
         event = Event.objects.create(slug="test-event", host=organisation)
         event.tags.create(name="TTT")
-        membership = Membership.objects.create(
-            name="alpha-name",
-            variant="partner",
-            registration_code="test",
-            agreement_start=date.today(),
-            agreement_end=date.today() + timedelta(days=365),
-            contribution_type="financial",
-        )
-        Member.objects.create(
-            membership=membership,
-            organization=organisation,
-            role=MemberRole.objects.all()[0],
-        )
+
+        data = {
+            "requests": [training_request.pk],
+            "event": event.pk,
+            "auto_assign": True,
+            "benefit_override": "",
+        }
+
+        # Act
+        form = BulkMatchTrainingRequestForm(data, show_allocated_benefit=True)
+
+        # Assert
+        msg = "Must not be empty."
+
+        self.assertFalse(form.is_valid())
+        self.assertIn(msg, form.errors["benefit_override"])
+
+    def test_clean__benefit_override_not_required_without_auto_assign(self) -> None:
+        """Test that benefit override may be empty when not auto-assigning. The template disables
+        the field in that case, so the browser doesn't submit it at all."""
+        # Arrange
+        person = Person.objects.create(username="test")
+        training_request = create_training_request(state="p", person=person)
+        organisation = Organization.objects.create(fullname="Test Org", domain="test.org")
+        training_event_category = EventCategory.objects.create(name="training")
+        event = Event.objects.create(slug="test-event", host=organisation, event_category=training_event_category)
+        event.tags.create(name="TTT")
         account = Account.objects.create(
             account_type=Account.AccountTypeChoices.ORGANISATION,
             generic_relation=organisation,
@@ -590,17 +604,13 @@ class TestBulkMatchTrainingRequestForm(TestCase):
             "requests": [training_request.pk],
             "event": event.pk,
             "allocated_benefit": account_benefit.pk,
-            "benefit_override": "",
         }
 
         # Act
         form = BulkMatchTrainingRequestForm(data, show_allocated_benefit=True)
 
         # Assert
-        msg = "Must not be empty."
-
-        self.assertFalse(form.is_valid())
-        self.assertIn(msg, form.errors["benefit_override"])
+        self.assertTrue(form.is_valid(), form.errors)
 
     def test_auto_assign_label_help_text_based_on_feature_flag(self) -> None:
         """Test that auto-assign field label and help text change based on feature flag."""

--- a/src/extrequests/widgets.py
+++ b/src/extrequests/widgets.py
@@ -1,0 +1,45 @@
+from typing import Any, cast
+
+from src.offering.models import Benefit
+from src.workshops.fields import ModelSelect2Widget
+
+
+class BenefitSelect2Widget(ModelSelect2Widget):
+    """Select2 widget which exposes the `Benefit` behind every rendered option.
+
+    Options fetched over AJAX carry the same information (see `AccountBenefitsLookupView`
+    and `BenefitsLookupView` in `src.workshops.lookups`), so regardless of how an option
+    ended up in the widget, the client can tell which benefit it maps to. This is used by
+    the "Accept & match" confirmation modal in `requests/all_trainingrequests.html`.
+    """
+
+    def benefit_from_instance(self, instance: Any) -> Benefit:
+        return cast(Benefit, instance)
+
+    def create_option(
+        self,
+        name: str,
+        value: Any,
+        label: int | str,
+        selected: bool,
+        index: int,
+        subindex: int | None = None,
+        attrs: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        option = super().create_option(name, value, label, selected, index, subindex=subindex, attrs=attrs)
+
+        # `value` is a `ModelChoiceIteratorValue` for every non-empty option.
+        instance = getattr(value, "instance", None)
+        if instance is not None:
+            benefit = self.benefit_from_instance(instance)
+            option["attrs"]["data-benefit-id"] = str(benefit.pk)
+            option["attrs"]["data-benefit-name"] = benefit.name
+
+        return option
+
+
+class AccountBenefitSelect2Widget(BenefitSelect2Widget):
+    """`BenefitSelect2Widget` for a widget listing `AccountBenefit`s."""
+
+    def benefit_from_instance(self, instance: Any) -> Benefit:
+        return cast(Benefit, instance.benefit)

--- a/src/static/training_requests_match_confirmation.js
+++ b/src/static/training_requests_match_confirmation.js
@@ -1,0 +1,102 @@
+/* Confirmation modal for the "Accept & match" action on the training requests list.
+
+   Trainees state in their training request which offering (benefit) they signed up for.
+   The admin may match them to a different one, either by picking an "Allocated account
+   benefit" or, when auto-matching, a "Benefit for auto-match". When any of the selected
+   trainees asked for something else, we ask the admin to confirm first.
+
+   The `Benefit` behind an option is read from `data-benefit-id` / `data-benefit-name` for
+   options rendered by Django, and from `benefit_id` / `benefit_name` returned by the
+   lookup views for options fetched over AJAX by Select2. */
+
+/* Return {id, name} of the benefit behind currently selected option, or null. */
+function selectedBenefit(select) {
+  if (!select || !select.value) return null;
+
+  const option = select.selectedOptions[0];
+  // Select2 keeps the lookup response for options it created itself.
+  const data = ($(select).data("select2") && $(select).select2("data")[0]) || {};
+
+  const id = data.benefit_id || (option && option.dataset.benefitId);
+  if (!id) return null;
+
+  return {
+    id: id,
+    name: data.benefit_name || (option && option.dataset.benefitName) || "",
+  };
+}
+
+document.addEventListener("alpine:init", () => {
+  Alpine.data("matchConfirmation", () => ({
+    // Seeded from the "auto_assign" checkbox by `x-model.fill`; drives whether the
+    // "Benefit for auto-match" field is enabled (see BulkMatchTrainingRequestForm).
+    autoAssign: null,
+    open: false,
+    // Set once the admin confirms, so that the re-submit isn't intercepted again.
+    confirmed: false,
+    submitter: null,
+    benefitName: "",
+    mismatched: [],
+
+    /* Benefit that the selected trainees would be matched to, or null if the chosen
+       matching method doesn't use benefits (membership seats, or no seats at all). */
+    targetBenefit() {
+      const allocatedBenefit = this.$refs.form.querySelector("#id_allocated_benefit");
+      const autoAssign = this.$refs.form.querySelector("#id_auto_assign");
+      const benefitOverride = this.$refs.form.querySelector("#id_benefit_override");
+
+      if (allocatedBenefit && allocatedBenefit.value) return selectedBenefit(allocatedBenefit);
+      if (autoAssign && autoAssign.checked) return selectedBenefit(benefitOverride);
+      return null;
+    },
+
+    /* Selected requests asking for a benefit other than `benefit`. Requests which don't
+       specify a benefit are left out - there's nothing to disagree with. */
+    mismatchedRequests(benefit) {
+      const checkboxes = this.$refs.form.querySelectorAll('input[name="requests"]:checked');
+      return Array.from(checkboxes)
+        .filter((checkbox) => checkbox.dataset.benefitId && checkbox.dataset.benefitId !== benefit.id)
+        .map((checkbox) => ({
+          id: checkbox.value,
+          trainee: checkbox.dataset.trainee,
+          benefitName: checkbox.dataset.benefitName,
+        }));
+    },
+
+    onSubmit(event) {
+      if (this.confirmed) return;
+      // Other buttons in this form (accept, discard, unmatch) don't assign benefits.
+      if (!event.submitter || event.submitter.name !== "match") return;
+
+      const benefit = this.targetBenefit();
+      if (!benefit) return;
+
+      const mismatched = this.mismatchedRequests(benefit);
+      if (!mismatched.length) return;
+
+      event.preventDefault();
+      this.benefitName = benefit.name;
+      this.mismatched = mismatched;
+      this.submitter = event.submitter;
+      this.setOpen(true);
+    },
+
+    proceed() {
+      this.setOpen(false);
+      this.confirmed = true;
+      this.$refs.form.requestSubmit(this.submitter);
+    },
+
+    cancel() {
+      this.setOpen(false);
+      this.submitter = null;
+    },
+
+    /* `modal-open` stops the page underneath the backdrop from scrolling; normally
+       Bootstrap's own modal JS takes care of it, but this modal is driven by Alpine. */
+    setOpen(open) {
+      this.open = open;
+      document.body.classList.toggle("modal-open", open);
+    },
+  }));
+});

--- a/src/templates/requests/all_trainingrequests.html
+++ b/src/templates/requests/all_trainingrequests.html
@@ -8,7 +8,15 @@
 
 {% block content %}
   {% if requests %}
-    <form role="form" class="form-horizontal" method="post" action="{% url 'all_trainingrequests' %}?{{ request.GET.urlencode }}">
+    <div x-data="matchConfirmation">
+    <form
+      role="form"
+      class="form-horizontal"
+      method="post"
+      action="{% url 'all_trainingrequests' %}?{{ request.GET.urlencode }}"
+      x-ref="form"
+      @submit="onSubmit($event)"
+    >
     {% if form.errors.requests or match_form.errors.requests %}
       <div class="alert alert-danger" role="alert">You didn't select any requests.</div>
     {% elif form.errors or match_form.errors %}
@@ -56,7 +64,9 @@
           <td>
             <input type="checkbox" name="requests" value="{{ req.pk }}"
                    respond-to-select-all-checkbox
-                   email="{% if req.person %}{{ req.person.email }}{% elif req.email %}{{ req.email }}{% endif %}" />
+                   email="{% if req.person %}{{ req.person.email }}{% elif req.email %}{{ req.email }}{% endif %}"
+                   {% if req.benefit %}data-benefit-id="{{ req.benefit.pk }}" data-benefit-name="{{ req.benefit.name }}"{% endif %}
+                   data-trainee="{{ req.personal }}{% if req.middle %} {{ req.middle }}{% endif %} {{ req.family }} <{{ req.email }}>" />
           </td>
           <td>
             {{ req.personal }} {{ req.middle }} {{ req.family }}<br />
@@ -140,6 +150,46 @@
 
     {% crispy match_form %}
     </form>
+
+    {# Kept in a <template> so that neither the modal nor its backdrop show up before Alpine boots. #}
+    <template x-if="open">
+      <div @keydown.escape.window="cancel()">
+        <div class="modal d-block" tabindex="-1" role="dialog" aria-modal="true"
+             aria-labelledby="benefit_mismatch_modal_label">
+          <div class="modal-dialog modal-lg modal-dialog-scrollable" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="benefit_mismatch_modal_label">Different offering requested</h5>
+                <button type="button" class="btn-close" @click="cancel()" aria-label="Close"></button>
+              </div>
+              <div class="modal-body">
+                <p>
+                  You're about to match the selected trainees to
+                  <strong x-text="benefitName"></strong>, but
+                  <span x-text="mismatched.length"></span>
+                  of them signed up for a different offering:
+                </p>
+                <ul>
+                  <template x-for="request in mismatched" :key="request.id">
+                    <li>
+                      <span x-text="request.trainee"></span> &mdash;
+                      <strong x-text="request.benefitName"></strong>
+                    </li>
+                  </template>
+                </ul>
+                <p class="mb-0">Do you want to match them anyway?</p>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" x-init="$el.focus()" @click="cancel()">Cancel</button>
+                <button type="button" class="btn btn-primary" @click="proceed()">Accept &amp; match anyway</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-backdrop show"></div>
+      </div>
+    </template>
+    </div>
 {% else %}
     <p>No training requests.</p>
 {% endif %}
@@ -148,6 +198,7 @@
 
 {% block extrajs %}
 <script type="text/javascript" src="{% static 'checkboxes_sessionstorage.js' %}"></script>
+<script type="text/javascript" src="{% static 'training_requests_match_confirmation.js' %}"></script>
 <script type="text/javascript">
   $(function () {
     // datatables enabled for event tasks table

--- a/src/workshops/lookups.py
+++ b/src/workshops/lookups.py
@@ -640,7 +640,7 @@ class PartnershipTierLookupView(OnlyForAdminsNoRedirectMixin, PermissionRequired
         ]
 
 
-class AccountBenefitsLookupView(OnlyForAdminsNoRedirectMixin, PermissionRequiredMixin, AutoResponseView):
+class AccountBenefitsLookupView(OnlyForAdminsNoRedirectMixin, PermissionRequiredMixin, ExtensibleAutoResponseView):
     permission_required = ["offering.view_accountbenefit"]
     unit_type: str
 
@@ -649,7 +649,9 @@ class AccountBenefitsLookupView(OnlyForAdminsNoRedirectMixin, PermissionRequired
         self.unit_type = ""
 
     def get_queryset(self) -> QuerySet[AccountBenefit]:
-        results = AccountBenefit.objects.all()
+        results = AccountBenefit.objects.select_related("benefit", "partnership").order_by(
+            "partnership__name", "benefit__name"
+        )
 
         if self.unit_type in ("seat", "event"):
             results = results.filter(benefit__unit_type=self.unit_type)
@@ -667,6 +669,17 @@ class AccountBenefitsLookupView(OnlyForAdminsNoRedirectMixin, PermissionRequired
 
         return results
 
+    def parse_results(self, object_list: Sequence[AccountBenefit]) -> list[Any]:  # type: ignore[override]
+        return [
+            {
+                "id": str(obj.pk),
+                "text": str(obj),
+                "benefit_id": str(obj.benefit_id),
+                "benefit_name": obj.benefit.name,
+            }
+            for obj in object_list
+        ]
+
 
 class AccountBenefitSeatsLookupView(AccountBenefitsLookupView):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -680,7 +693,7 @@ class AccountBenefitEventsLookupView(AccountBenefitsLookupView):
         self.unit_type = "event"
 
 
-class BenefitsLookupView(OnlyForAdminsNoRedirectMixin, PermissionRequiredMixin, AutoResponseView):
+class BenefitsLookupView(OnlyForAdminsNoRedirectMixin, PermissionRequiredMixin, ExtensibleAutoResponseView):
     permission_required = ["offering.view_benefit"]
     unit_type: str
 
@@ -698,6 +711,19 @@ class BenefitsLookupView(OnlyForAdminsNoRedirectMixin, PermissionRequiredMixin, 
             results = results.filter(Q(name__icontains=self.term) | Q(description__icontains=self.term))
 
         return results
+
+    def parse_results(self, object_list: Sequence[Benefit]) -> list[Any]:  # type: ignore[override]
+        # `benefit_id` / `benefit_name` are named the same as in `AccountBenefitsLookupView`,
+        # so that the client can read the underlying benefit from either lookup.
+        return [
+            {
+                "id": str(obj.pk),
+                "text": str(obj),
+                "benefit_id": str(obj.pk),
+                "benefit_name": obj.name,
+            }
+            for obj in object_list
+        ]
 
 
 class BenefitSeatsLookupView(BenefitsLookupView):

--- a/src/workshops/tests/test_lookups.py
+++ b/src/workshops/tests/test_lookups.py
@@ -12,6 +12,7 @@ from src.offering.models import Account, AccountBenefit, Benefit
 from src.workshops.lookups import (
     AccountBenefitSeatsLookupView,
     AwardLookupView,
+    BenefitSeatsLookupView,
     EventLookupForAwardsView,
     EventLookupView,
     GenericObjectLookupView,
@@ -754,6 +755,8 @@ class TestAccountBenefitsLookupView(TestBase):
         )
 
     def setUpView(self, term: str = "", benefit: str = "") -> AccountBenefitSeatsLookupView:
+        """There are 2 AccountBenefit views: one for seat-type and one for event-type.
+        This test will use the seat-type view."""
         url = f"/?benefit={benefit}" if benefit else "/"
         request = RequestFactory().get(url)
         view = AccountBenefitSeatsLookupView(request=request, term=term)
@@ -785,3 +788,84 @@ class TestAccountBenefitsLookupView(TestBase):
         # Assert - unknown value is not in the whitelist, so no extra filtering
         self.assertIn(self.ab_it, queryset)
         self.assertIn(self.ab_other, queryset)
+
+    def test_parse_results(self) -> None:
+        # Arrange
+        view = self.setUpView()
+        queryset = view.get_queryset().order_by("registration_code")
+        # Act
+        results = view.parse_results(list(queryset))
+        # Assert
+        expected_results = [
+            {
+                "id": str(self.ab_it.pk),
+                "text": str(self.ab_it),
+                "benefit_id": str(self.benefit_it.pk),
+                "benefit_name": self.benefit_it.name,
+            },
+            {
+                "id": str(self.ab_other.pk),
+                "text": str(self.ab_other),
+                "benefit_id": str(self.benefit_other.pk),
+                "benefit_name": self.benefit_other.name,
+            },
+        ]
+        self.assertEqual(results, expected_results)
+
+
+class TestBenefitsLookupView(TestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.benefit_it, _ = Benefit.objects.get_or_create(
+            name="Instructor Training",
+            defaults=dict(
+                description="Instructor Training benefit",
+                unit_type="seat",
+                credits=10,
+            ),
+        )
+        self.benefit_other = Benefit.objects.create(
+            name="Other Benefit",
+            description="Other benefit",
+            unit_type="seat",
+            credits=5,
+        )
+
+    def setUpView(self, term: str = "") -> BenefitSeatsLookupView:
+        """There are 2 Benefit views: one for seat-type and one for event-type.
+        This test will use the seat-type view."""
+        request = RequestFactory().get("/")
+        view = BenefitSeatsLookupView(request=request, term=term)
+        return view
+
+    def test_get_queryset(self) -> None:
+        # Arrange
+        view = self.setUpView()
+        # Act
+        queryset = view.get_queryset()
+        # Assert
+        self.assertIn(self.benefit_it, queryset)
+        self.assertIn(self.benefit_other, queryset)
+
+    def test_parse_results(self) -> None:
+        # Arrange
+        view = self.setUpView()
+        queryset = view.get_queryset().order_by("name")
+        # Act
+        results = view.parse_results(list(queryset))
+        # Assert
+        expected_results = [
+            {
+                "id": str(self.benefit_it.pk),
+                "text": str(self.benefit_it),
+                "benefit_id": str(self.benefit_it.pk),
+                "benefit_name": self.benefit_it.name,
+            },
+            {
+                "id": str(self.benefit_other.pk),
+                "text": str(self.benefit_other),
+                "benefit_id": str(self.benefit_other.pk),
+                "benefit_name": self.benefit_other.name,
+            },
+        ]
+        self.assertEqual(results, expected_results)


### PR DESCRIPTION
This fixes #3005.